### PR TITLE
Update owners and aliases

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,6 @@
-# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS docs at https://go.k8s.io/owners for information on OWNERS files.
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/cluster-api/blob/main/OWNERS_ALIASES for a list of members for each alias.
 
 approvers:
-  - alexander-demichev
-  - fabriziopandini
-  - JoelSpeed
+  - sig-cluster-lifecycle-leads
+  - cluster-api-operator-admins

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,18 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  sig-cluster-lifecycle-leads:
+  - fabriziopandini
+  - justinsb
+  - neolit123
+  - timothysc
+
+  # -----------------------------------------------------------
+  # OWNER_ALIASES for Cluster API Operator
+  # -----------------------------------------------------------
+
+  # active folks who can be contacted to perform admin-related
+  # tasks on the repo, or otherwise approve any PRS.
+  cluster-api-operator-admins:
+  - alexander-demichev
+  - JoelSpeed


### PR DESCRIPTION
I added `cluster-api-operator-admins` alias and `sig-cluster-lifecycle-leads` to approvers, also removed @fabriziopandini see - https://github.com/kubernetes/org/issues/3119#issuecomment-985859765