### PR TITLE
🌱 Add Fedosin to OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,3 +16,4 @@ aliases:
   cluster-api-operator-admins:
   - alexander-demichev
   - JoelSpeed
+  - Fedosin


### PR DESCRIPTION
**What this PR does / why we need it:**

In order to participate productively in the project, user Fedosin is required to be on the list of owners.