### PR TITLE
🐛Make version field required on API scheme level

### DIFF
--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -32,7 +32,7 @@ const (
 // ProviderSpec is the desired state of the Provider.
 type ProviderSpec struct {
 	// Version indicates the provider version.
-	Version string `json:"version,omitempty"`
+	Version string `json:"version"`
 
 	// Manager defines the properties that can be enabled on the controller manager for the provider.
 	// +optional

--- a/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
@@ -1402,6 +1402,8 @@ spec:
               version:
                 description: Version indicates the provider version.
                 type: string
+            required:
+            - version
             type: object
           status:
             description: BootstrapProviderStatus defines the observed state of BootstrapProvider.

--- a/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
@@ -1403,6 +1403,8 @@ spec:
               version:
                 description: Version indicates the provider version.
                 type: string
+            required:
+            - version
             type: object
           status:
             description: ControlPlaneProviderStatus defines the observed state of

--- a/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
@@ -1402,6 +1402,8 @@ spec:
               version:
                 description: Version indicates the provider version.
                 type: string
+            required:
+            - version
             type: object
           status:
             description: CoreProviderStatus defines the observed state of CoreProvider.

--- a/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
@@ -1403,6 +1403,8 @@ spec:
               version:
                 description: Version indicates the provider version.
                 type: string
+            required:
+            - version
             type: object
           status:
             description: InfrastructureProviderStatus defines the observed state of


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Make version field required on API scheme level

this pr should go after https://github.com/kubernetes-sigs/cluster-api-operator/pull/29
/hold 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
