### PR TITLE
✨Add more e2e tests

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -29,7 +29,11 @@ source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 # shellcheck source=./hack/ensure-kind.sh
 source "${REPO_ROOT}/hack/ensure-kind.sh"
 
-  
+if [ -z $GITHUB_TOKEN ]
+then
+    echo "GITHUB_TOKEN variable is required"
+fi
+
 # Build operator images
 ARCH="$(go env GOARCH)"
 export REGISTRY=gcr.io/k8s-staging-cluster-api

--- a/test/e2e/config/operator-dev.yaml
+++ b/test/e2e/config/operator-dev.yaml
@@ -10,3 +10,4 @@ intervals:
 
 variables:
   CERTMANAGER_URL: https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+  GITHUB_TOKEN: ${GITHUB_TOKEN}

--- a/test/e2e/coreprovider.go
+++ b/test/e2e/coreprovider.go
@@ -1,0 +1,91 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var _ = Describe("CoreProvider creation", func() {
+	It("should set expected condition when more than one CoreProvider is created", func() {
+		k8sClient := bootstrapClusterProxy.GetClient()
+
+		coreProvider1, err := newGenericProvider(&operatorv1.CoreProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      coreProviderName,
+				Namespace: operatorNamespace,
+			},
+			Spec: operatorv1.CoreProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{
+					Version:    coreProviderVersion,
+					SecretName: providerSecretName,
+				},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		newNamespaceName := "test-namespace"
+		newNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: newNamespaceName,
+			},
+		}
+
+		coreProvider2, err := newGenericProvider(&operatorv1.CoreProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      coreProviderName,
+				Namespace: newNamespaceName,
+			},
+			Spec: operatorv1.CoreProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{
+					Version:    coreProviderVersion,
+					SecretName: providerSecretName,
+				},
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Creating two core providers")
+		Expect(k8sClient.Create(ctx, newNamespace)).To(Succeed())
+		Expect(k8sClient.Create(ctx, coreProvider1.GetObject())).To(Succeed())
+		Expect(k8sClient.Create(ctx, coreProvider2.GetObject())).To(Succeed())
+
+		By("Waiting for condition to be set")
+		waitForProviderCondition(coreProvider1,
+			clusterv1.Condition{
+				Type:   operatorv1.PreflightCheckCondition,
+				Status: corev1.ConditionFalse,
+				Reason: operatorv1.MoreThanOneProviderInstanceExistsReason,
+			},
+			k8sClient)
+
+		By("Deleting core providers")
+		Expect(cleanupAndWait(ctx, k8sClient, coreProvider1.GetObject(), coreProvider2.GetObject())).To(Succeed())
+
+		waitForDeploymentDeleted(operatorNamespace, coreProviderDeploymentName, k8sClient)
+		waitForDeploymentDeleted(newNamespaceName, coreProviderDeploymentName, k8sClient)
+	})
+})

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -21,7 +21,21 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-operator/controllers/genericprovider"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -29,8 +43,161 @@ var (
 )
 
 const (
-	timeout                    = 5 * time.Minute
-	operatorNamespace          = "capi-operator-system"
+	timeout            = 10 * time.Minute
+	operatorNamespace  = "capi-operator-system"
+	providerSecretName = "provider-secret"
+
 	coreProviderName           = "cluster-api"
 	coreProviderDeploymentName = "capi-controller-manager"
+	coreProviderVersion        = "v1.1.1"
+
+	infrastructureProviderName           = "aws"
+	infrastructureProviderDeploymentName = "capa-controller-manager"
+	infraProviderVersion                 = "v1.4.0"
+
+	boostrapProviderName           = "kubeadm"
+	boostrapProviderDeploymentName = "capi-kubeadm-bootstrap-controller-manager"
+
+	controlPlaneProviderName           = "kubeadm"
+	controlPlaneProviderDeploymentName = "capi-kubeadm-control-plane-controller-manager"
 )
+
+func newGenericProvider(obj client.Object) (genericprovider.GenericProvider, error) {
+	switch obj := obj.(type) {
+	case *operatorv1.CoreProvider:
+		return &genericprovider.CoreProviderWrapper{CoreProvider: obj}, nil
+	case *operatorv1.BootstrapProvider:
+		return &genericprovider.BootstrapProviderWrapper{BootstrapProvider: obj}, nil
+	case *operatorv1.ControlPlaneProvider:
+		return &genericprovider.ControlPlaneProviderWrapper{ControlPlaneProvider: obj}, nil
+	case *operatorv1.InfrastructureProvider:
+		return &genericprovider.InfrastructureProviderWrapper{InfrastructureProvider: obj}, nil
+	default:
+		providerKind := reflect.Indirect(reflect.ValueOf(obj)).Type().Name()
+		failedToCastInterfaceErr := fmt.Errorf("failed to cast interface for type: %s", providerKind)
+		return nil, failedToCastInterfaceErr
+	}
+}
+
+func waitForProviderCondition(provider genericprovider.GenericProvider, condition clusterv1.Condition, k8sClient client.Client) {
+	Eventually(func() bool {
+		key := client.ObjectKey{Namespace: provider.GetObject().GetNamespace(), Name: provider.GetObject().GetName()}
+		if err := k8sClient.Get(ctx, key, provider.GetObject()); err != nil {
+			return false
+		}
+
+		for _, c := range provider.GetStatus().Conditions {
+			if c.Type == condition.Type && c.Status == condition.Status && c.Reason == condition.Reason {
+				return true
+			}
+		}
+		return false
+	}, timeout).Should(Equal(true))
+}
+
+func waitForDeploymentReady(namespace, name string, k8sClient client.Client) {
+	Eventually(func() bool {
+		deployment := &appsv1.Deployment{}
+		key := client.ObjectKey{Namespace: namespace, Name: name}
+		if err := k8sClient.Get(ctx, key, deployment); err != nil {
+			return false
+		}
+
+		for _, c := range deployment.Status.Conditions {
+			if c.Type == appsv1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+
+		return false
+
+	}, timeout).Should(Equal(true))
+}
+
+func waitForDeploymentDeleted(namespace, name string, k8sClient client.Client) {
+	Eventually(func() bool {
+		deployment := &appsv1.Deployment{}
+		key := client.ObjectKey{Namespace: namespace, Name: name}
+		if err := k8sClient.Get(ctx, key, deployment); err != nil {
+			return apierrors.IsNotFound(err)
+		}
+
+		return false
+	}, timeout).Should(Equal(true))
+}
+
+func waitForInstalledVersionSet(provider genericprovider.GenericProvider, version string, k8sClient client.Client) {
+	Eventually(func() bool {
+		key := client.ObjectKey{Namespace: operatorNamespace, Name: provider.GetName()}
+		if err := k8sClient.Get(ctx, key, provider.GetObject()); err != nil {
+			return false
+		}
+
+		if provider.GetStatus().InstalledVersion != nil && *provider.GetStatus().InstalledVersion == version {
+			return true
+		}
+		return false
+	}, timeout).Should(Equal(true))
+}
+
+func cleanupAndWait(ctx context.Context, cl client.Client, objs ...client.Object) error {
+	if err := cleanup(ctx, cl, objs...); err != nil {
+		return err
+	}
+	// Makes sure the cache is updated with the deleted object
+	errs := []error{}
+	for _, o := range objs {
+		oCopy := o.DeepCopyObject().(client.Object)
+		key := client.ObjectKeyFromObject(o)
+		err := wait.ExponentialBackoff(
+			wait.Backoff{
+				Duration: 150 * time.Millisecond,
+				Factor:   1.5,
+				Steps:    8,
+				Jitter:   0.4,
+			},
+			func() (done bool, err error) {
+				if err := cl.Get(ctx, key, oCopy); err != nil {
+					if apierrors.IsNotFound(err) {
+						return true, nil
+					}
+					return false, err
+				}
+				return false, nil
+			})
+		errs = append(errs, errors.Wrapf(err, "key %s, %s is not being deleted from the client cache", o.GetObjectKind().GroupVersionKind().String(), key))
+	}
+	return kerrors.NewAggregate(errs)
+}
+
+func cleanup(ctx context.Context, cl client.Client, objs ...client.Object) error {
+	errs := []error{}
+	for _, o := range objs {
+		oCopy := o.DeepCopyObject().(client.Object)
+		key := client.ObjectKeyFromObject(oCopy)
+
+		err := cl.Get(ctx, key, oCopy)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		errs = append(errs, err)
+
+		// Remove finalizers from the object
+		if oCopy.GetFinalizers() != nil {
+			oCopy.SetFinalizers(nil)
+		}
+
+		err = cl.Update(ctx, oCopy)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		errs = append(errs, err)
+
+		err = cl.Delete(ctx, oCopy)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		errs = append(errs, err)
+	}
+	return kerrors.NewAggregate(errs)
+}

--- a/test/e2e/version.go
+++ b/test/e2e/version.go
@@ -1,0 +1,65 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var _ = Describe("Provider version conditions", func() {
+	It("should set appropriate condition when provider version doesn't exist", func() {
+		k8sClient := bootstrapClusterProxy.GetClient()
+
+		provider, err := newGenericProvider(&operatorv1.CoreProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      coreProviderName,
+				Namespace: operatorNamespace,
+			},
+			Spec: operatorv1.CoreProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{
+					Version:    "v99.99.99",
+					SecretName: providerSecretName,
+				},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Creating core provider")
+		Expect(k8sClient.Create(ctx, provider.GetObject()))
+
+		By("Waiting for condition to be set")
+		waitForProviderCondition(provider,
+			clusterv1.Condition{
+				Type:   operatorv1.PreflightCheckCondition,
+				Status: corev1.ConditionFalse,
+				Reason: operatorv1.CAPIVersionIncompatibilityReason,
+			},
+			k8sClient)
+
+		By("Deleting core provider")
+		Expect(cleanupAndWait(ctx, k8sClient, provider.GetObject())).To(Succeed())
+		waitForDeploymentDeleted(operatorNamespace, coreProviderDeploymentName, k8sClient)
+	})
+})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- use a github token in e2e to avoid API request limits
- add a bunch of e2e tests: provider creation/deletion, duplicate providers, test for a wrong provider version 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-operator/issues/31
Fixes https://github.com/kubernetes-sigs/cluster-api-operator/issues/32
Fixes https://github.com/kubernetes-sigs/cluster-api-operator/issues/34
Fixes https://github.com/kubernetes-sigs/cluster-api-operator/issues/37

