### PR TITLE
🐛 Fix CI for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,13 @@ jobs:
           - ""
     steps:
       - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/setup-go@v2
         with:
-          version: v1.43.0
-          working-directory: ${{matrix.working-directory}}
-          args: --timeout 3m0s
+          ## golang v1.18 breaks golangci-lint <= v1.45
+          ## ref: https://github.com/golangci/golangci-lint/issues/2374#issuecomment-1069029422
+          go-version: '1.17'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.44.0
+          args: --timeout 15m 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces required changes to fix cluster-api-operator CI.