### PR TITLE
✨ add local-development support using Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,31 @@
+# -*- mode: Python -*-
+
+load('ext://cert_manager', 'deploy_cert_manager')
+
+def build_image():
+    docker_build(
+      "gcr.io/k8s-staging-cluster-api/cluster-api-operator-amd64",
+      ".",
+      ignore=[
+        ".git",
+        ".github",
+        "docs",
+        "test",
+        "scripts",
+        "*.md",
+        "LICENSE",
+        "OWNERS",
+        "OWNERS_ALIASES",
+        "PROJECT",
+        "SECURITY_CONTACTS"
+        ]
+    )
+
+def deploy():
+    k8s_yaml(
+        kustomize('./config/default')
+    )
+
+build_image()
+deploy_cert_manager()
+deploy()

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,16 @@
+# Local Development
+Tilt is favoured by most Cluster API projects for local development, it offers a simple way of creating a local development environment.
+
+## Create a kind cluster
+We'll need to create a kind cluster to deploy the operator to. This cluster will be used to deploy `cluster-api-operator` to, along with all dependencies such as `cert-manager`
+```bash
+kind create cluster
+```
+
+## Run Tilt
+Once the cluster is live and you've confirmed you're using the correct context, you can simply run:
+```bash
+tilt up
+```
+
+That's it! Tilt will automatically reload the deployment to your local cluster every time you make a code change.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Tilt and documentation for setting up a local development environment. 
