### PR TITLE
🌱 Update references from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ENVSUBST := $(abspath $(TOOLS_BIN_DIR)/envsubst)
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
-PROD_REGISTRY ?= k8s.gcr.io/cluster-api
+PROD_REGISTRY ?= registry.k8s.io/cluster-api
 
 STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api
 STAGING_BUCKET ?= artifacts.k8s-staging-cluster-api.appspot.com

--- a/internal/controllers/component_customizer_test.go
+++ b/internal/controllers/component_customizer_test.go
@@ -49,7 +49,7 @@ func TestCustomizeDeployment(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "manager",
-						Image: "k8s.gcr.io/a-manager:1.6.2",
+						Image: "registry.k8s.io/a-manager:1.6.2",
 						Env: []corev1.EnvVar{
 							{
 								Name:  "test1",
@@ -451,7 +451,7 @@ func TestCustomizeDeployment(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name:  "manager",
-									Image: "k8s.gcr.io/a-manager:1.6.2",
+									Image: "registry.k8s.io/a-manager:1.6.2",
 									Env: []corev1.EnvVar{
 										{
 											Name:  "test1",


### PR DESCRIPTION
With the [change to defaulting](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) to registry.k8s.io as our image registry and the [planned freeze in April](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), projects within the Kubernetes orgs should update their image references to point to the new address.

**NOTE:** We can ignore references to staging-k8s.gcr.io, but any other references to k8s.gcr.io should be updated to registry.k8s.io

[k8s.gcr.io search results](https://cs.k8s.io/?q=k8s.gcr.io&i=nope&files=&excludeFiles=vendor%2F&repos=kubernetes-sigs/cluster-api-operator) 

ref: [[Umbrella Issue] Migrate K8s projects from k8s.gcr.io -> registry.k8s.io](https://github.com/kubernetes/k8s.io/issues/4738)

/kind cleanup
/priority important-soon

