### PR TITLE
🌱 Increase cloudbuild timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Image builds are failing with a timeout https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cluster-api-operator-push-images/1628085636898492416, I can see that other projects a bigger timeout value https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/cloudbuild.yaml#L2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
