### PR TITLE
🌱 Stop using github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.25.3
 	k8s.io/apiextensions-apiserver v0.25.3
@@ -87,6 +86,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/internal/controllers/client_proxy.go
+++ b/internal/controllers/client_proxy.go
@@ -18,9 +18,10 @@ package controllers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -130,7 +131,7 @@ func listObjByGVK(c client.Client, groupVersion, kind string, options []client.L
 
 	if err := c.List(ctx, objList, options...); err != nil {
 		if !errors.Is(err, &meta.NoKindMatchError{}) {
-			return nil, errors.Wrapf(err, "failed to list objects for the %q GroupVersionKind", objList.GroupVersionKind())
+			return nil, fmt.Errorf("failed to list objects for the %q GroupVersionKind: %w", objList.GroupVersionKind(), err)
 		}
 	}
 

--- a/internal/controllers/preflight_checks.go
+++ b/internal/controllers/preflight_checks.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
@@ -92,7 +91,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 	}
 
 	if err := c.List(ctx, providerList.GetObject()); err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to list providers")
+		return ctrl.Result{}, fmt.Errorf("failed to list providers: %w", err)
 	}
 
 	// Check that no more than one instance of the provider is installed.
@@ -132,7 +131,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 	if !util.IsCoreProvider(provider) {
 		ready, err := coreProviderIsReady(ctx, c)
 		if err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "failed to get coreProvider ready condition")
+			return ctrl.Result{}, fmt.Errorf("failed to get coreProvider ready condition: %w", err)
 		}
 
 		if !ready {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This project is deprecated and not maintained anymore: https://github.com/pkg/errors

We can use standard golang primitives for that.

