### PR TITLE
🌱 Bump dockerfile image to v1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1-experimental
+# syntax=docker/dockerfile:1.4
 
 # Copyright 2018 The Kubernetes Authors.
 #

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
-	docker pull docker.io/docker/dockerfile:1.1-experimental
+	docker pull docker.io/docker/dockerfile:1.4
 	docker pull docker.io/library/golang:1.19.0
 	docker pull gcr.io/distroless/static:latest
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Current version 1.1 is outdated and not compatible with OCI:

```
docker pull docker.io/docker/dockerfile:1.1-experimental
Trying to pull docker.io/docker/dockerfile:1.1-experimental...
Error: copying system image from manifest list: initializing image from source docker://docker/dockerfile:1.1-experimental: unsupported docker v2s2 media type: "application/vnd.oci.image.layer.v1.tar+gzip"
```

To comply with cluster-api repo, we update it to v1.4.

