### PR TITLE
🐛 fix: ensure that all required env variables are set before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ E2E_CONF_FILE ?= $(ROOT)/test/e2e/config/operator-dev.yaml
 E2E_CONF_FILE_ENVSUBST ?= $(ROOT)/test/e2e/config/operator-dev-envsubst.yaml
 SKIP_CLEANUP ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= false
+E2E_CERT_MANAGER_VERSION ?= v1.7.1
+E2E_OPERATOR_IMAGE ?= $(CONTROLLER_IMG):$(TAG)
 
 # Relase
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
@@ -353,7 +355,7 @@ docker-push-%:
 
 .PHONY: docker-build-e2e
 docker-build-e2e:
-	$(MAKE) CONTROLLER_IMG_TAG="gcr.io/k8s-staging-capi-operator/cluster-api-operator:dev" docker-build
+	$(MAKE) CONTROLLER_IMG_TAG="$(E2E_OPERATOR_IMAGE)" docker-build
 
 .PHONY: set-manifest-pull-policy
 set-manifest-pull-policy:
@@ -464,7 +466,7 @@ test-e2e: $(KUSTOMIZE)
 
 .PHONY: test-e2e-run
 test-e2e-run: $(GINKGO) $(ENVSUBST) ## Run e2e tests
-	$(ENVSUBST) < $(E2E_CONF_FILE) > $(E2E_CONF_FILE_ENVSUBST) && \
+	E2E_OPERATOR_IMAGE=$(E2E_OPERATOR_IMAGE) E2E_CERT_MANAGER_VERSION=$(E2E_CERT_MANAGER_VERSION) $(ENVSUBST) < $(E2E_CONF_FILE) > $(E2E_CONF_FILE_ENVSUBST) && \
 	$(GINKGO) -v -trace -tags=e2e --junit-report=junit_cluster_api_operator_e2e.xml --output-dir="${JUNIT_REPORT_DIR}" --no-color=$(GINKGO_NOCOLOR) $(GINKGO_ARGS) ./test/e2e -- \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)"  -e2e.components=$(ROOT)/$(RELEASE_DIR)/operator-components.yaml \

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -27,9 +27,6 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 source "${REPO_ROOT}/hack/ensure-kind.sh"
 
 # Build operator images
-export CERT_MANAGER_VERSION=v1.7.1
-export OPERATOR_IMAGE=gcr.io/k8s-staging-capi-operator/cluster-api-operator:dev
-
 echo "+ Building CAPI operator image"
 make docker-build-e2e
 

--- a/test/e2e/config/operator-dev.yaml
+++ b/test/e2e/config/operator-dev.yaml
@@ -2,11 +2,11 @@ managementClusterName: capi-operator-e2e
 
 images:
 # Use local dev images built source tree;
-- name: ${OPERATOR_IMAGE} # This should be substituted with operator image
+- name: ${E2E_OPERATOR_IMAGE} # This should be substituted with operator image
   loadBehavior: tryLoad
 
 intervals:
   default/wait-controllers: ["3m", "10s"]
 
 variables:
-  CERTMANAGER_URL: https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+  CERTMANAGER_URL: https://github.com/cert-manager/cert-manager/releases/download/${E2E_CERT_MANAGER_VERSION}/cert-manager.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we don't set defaults for 2 mandatory env variables: CERT_MANAGER_VERSION and OPERATOR_IMAGE. If user doesn't define them manually before running tests, the execution will fail with some vague error messages.

This commit ensures that the env variables always have default values.
