### PR TITLE
✨ support provider downgrades

### DIFF
--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -351,17 +351,20 @@ func (s *phaseReconciler) updateRequiresPreDeletion() (bool, error) {
 		return false, nil
 	}
 
-	nextVersion, err := versionutil.ParseSemantic(s.components.Version())
-	if err != nil {
-		return false, err
-	}
-
 	currentVersion, err := versionutil.ParseSemantic(*installedVersion)
 	if err != nil {
 		return false, err
 	}
 
-	return currentVersion.LessThan(nextVersion), nil
+	res, err := currentVersion.Compare(s.components.Version())
+	if err != nil {
+		return false, err
+	}
+
+	// we need to delete installed components if versions are different
+	needPreDelete := res != 0
+
+	return needPreDelete, nil
 }
 
 // install installs the provider components using clusterctl library.

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -293,6 +293,33 @@ func (e *Environment) CreateNamespace(ctx context.Context, generateName string) 
 	return ns, nil
 }
 
+func (e *Environment) EnsureNamespaceExists(ctx context.Context, namespace string) error {
+	// Check if the namespace exists
+	ns := &corev1.Namespace{}
+
+	err := e.Client.Get(ctx, client.ObjectKey{Name: namespace}, ns)
+	if err == nil {
+		return nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("unexpected error during namespace checking: %w", err)
+	}
+
+	// Create the namespace if it doesn't exist
+	newNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	if err := e.Client.Create(ctx, newNamespace); err != nil {
+		return fmt.Errorf("unable to create namespace %s: %w", namespace, err)
+	}
+
+	return nil
+}
+
 func getFilePathToClusterctlCRDs(root string) string {
 	if clusterctlCRDPath := os.Getenv("CLUSTERCTL_CRD_PATH"); clusterctlCRDPath != "" {
 		return clusterctlCRDPath


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Previously, the operator allowed only installation of new provider versions. Downgrading to a previous version would result in operator failure.

This PR introduces support for seamless provider downgrades in addition to upgrades.
