### PR TITLE
🐛 Avoid failures on unchanged provider version

### DIFF
--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -350,8 +350,8 @@ func (p *phaseReconciler) preInstall(ctx context.Context) (reconcile.Result, err
 }
 
 // versionChanged try to get installed version from provider status and decide if it has changed.
-func (s *phaseReconciler) versionChanged() (bool, error) {
-	installedVersion := s.provider.GetStatus().InstalledVersion
+func (p *phaseReconciler) versionChanged() (bool, error) {
+	installedVersion := p.provider.GetStatus().InstalledVersion
 	if installedVersion == nil {
 		return true, nil
 	}
@@ -361,7 +361,7 @@ func (s *phaseReconciler) versionChanged() (bool, error) {
 		return false, err
 	}
 
-	res, err := currentVersion.Compare(s.components.Version())
+	res, err := currentVersion.Compare(p.components.Version())
 	if err != nil {
 		return false, err
 	}
@@ -453,9 +453,9 @@ func clusterctlProviderName(provider genericprovider.GenericProvider) client.Obj
 }
 
 // newClusterClient returns a clusterctl client for interacting with management cluster.
-func (s *phaseReconciler) newClusterClient() cluster.Client {
-	return cluster.New(cluster.Kubeconfig{}, s.configClient, cluster.InjectProxy(&controllerProxy{
-		ctrlClient: s.ctrlClient,
-		ctrlConfig: s.ctrlConfig,
+func (p *phaseReconciler) newClusterClient() cluster.Client {
+	return cluster.New(cluster.Kubeconfig{}, p.configClient, cluster.InjectProxy(&controllerProxy{
+		ctrlClient: p.ctrlClient,
+		ctrlConfig: p.ctrlConfig,
 	}))
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In the current implementation, when a provider version remains the same during subsequent reconciliations, the operator encounters an error with the message "failed getting clusterctl Provider version," leading to a degraded status.

This PR addresses this issue by adding a check to determine whether the provider version has changed or not.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
