### PR TITLE
🐛 Don't requeue provider if its spec is invalid

### DIFF
--- a/internal/controller/preflight_checks.go
+++ b/internal/controller/preflight_checks.go
@@ -61,7 +61,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 			emptyVersionMessage,
 		))
 
-		return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}, fmt.Errorf("version can't be empty for provider %s", provider.GetName())
+		return ctrl.Result{}, fmt.Errorf("version can't be empty for provider %s", provider.GetName())
 	}
 
 	// Check that provider version contains a valid value.
@@ -74,7 +74,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 			err.Error(),
 		))
 
-		return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}, fmt.Errorf("version contains invalid value for provider %s", provider.GetName())
+		return ctrl.Result{}, fmt.Errorf("version contains invalid value for provider %s", provider.GetName())
 	}
 
 	if spec.FetchConfig != nil && spec.FetchConfig.Selector != nil && spec.FetchConfig.URL != "" {
@@ -86,8 +86,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 			"Only one of Selector and URL must be provided, not both",
 		))
 
-		return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter},
-			fmt.Errorf("only one of Selector and URL must be provided for provider %s", provider.GetName())
+		return ctrl.Result{}, fmt.Errorf("only one of Selector and URL must be provided for provider %s", provider.GetName())
 	}
 
 	if err := c.List(ctx, providerList.GetObject()); err != nil {
@@ -114,7 +113,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 			preflightFalseCondition.Message = moreThanOneCoreProviderInstanceExistsMessage
 			conditions.Set(provider, preflightFalseCondition)
 
-			return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}, fmt.Errorf("only one instance of CoreProvider is allowed")
+			return ctrl.Result{}, fmt.Errorf("only one instance of CoreProvider is allowed")
 		}
 
 		// For any other provider we should check that instances with similar name exist in any namespace
@@ -123,7 +122,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 			log.Info(preflightFalseCondition.Message)
 			conditions.Set(provider, preflightFalseCondition)
 
-			return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}, fmt.Errorf("only one %s provider is allowed in the cluster", p.GetName())
+			return ctrl.Result{}, fmt.Errorf("only one %s provider is allowed in the cluster", p.GetName())
 		}
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Currently if provider fails spec validation during preflight checks, we requeue it again with a 30 seconds interval. It doesn't make sense, because the spec still will be invalid and validation will fail again and again.

This PR identifies all places where we don't need to requeue providers and updates them accordingly.
