### PR TITLE
🌱 Configure importas linter and fix import issues 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,9 @@
-
+run:
+  timeout: 5m
+  go: "1.19"
+  skip-files:
+    - "zz_generated.*\\.go$"
+  allow-parallel-runners: true
 
 linters:
   disable-all: true
@@ -95,6 +100,37 @@ linters-settings:
     checks: ["all", "-ST1000"]
     dot-import-whitelist:
       - "github.com/onsi/gomega"
+  importas:
+    no-unaliased: true
+    alias:
+      # Kubernetes
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+        alias: apiextensionsv1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: apierrors
+      - pkg: k8s.io/apimachinery/pkg/util/errors
+        alias: kerrors
+      - pkg: k8s.io/apimachinery/pkg/util/runtime
+        alias: utilruntime
+      # Controller Runtime
+      - pkg: sigs.k8s.io/controller-runtime
+        alias: ctrl
+      # CAPI
+      - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+        alias: clusterv1
+      - pkg: sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3
+        alias: clusterctlv1
+      - pkg: sigs.k8s.io/cluster-api/cmd/clusterctl/client/config
+        alias: configclient
+      # CAPI Operator
+      - pkg: sigs.k8s.io/cluster-api-operator/api/v1alpha1
+        alias: operatorv1
+      - pkg: sigs.k8s.io/cluster-api-operator/internal/controller
+        alias: providercontroller
 issues:
   exclude:
     # Not all platforms are supported by this operator, those which aren't

--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -18,7 +18,7 @@ package controllers
 
 import (
 	"k8s.io/client-go/rest"
-	internalcontrollers "sigs.k8s.io/cluster-api-operator/internal/controller"
+	providercontroller "sigs.k8s.io/cluster-api-operator/internal/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -32,7 +32,7 @@ type GenericProviderReconciler struct {
 }
 
 func (r *GenericProviderReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
-	return (&internalcontrollers.GenericProviderReconciler{
+	return (&providercontroller.GenericProviderReconciler{
 		Provider:     r.Provider,
 		ProviderList: r.ProviderList,
 		Client:       r.Client,

--- a/internal/controller/component_customizer_test.go
+++ b/internal/controller/component_customizer_test.go
@@ -30,7 +30,7 @@ import (
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
-	configv1 "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	ctrlconfigv1 "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 )
 
 func TestCustomizeDeployment(t *testing.T) {
@@ -423,17 +423,17 @@ func TestCustomizeDeployment(t *testing.T) {
 				FeatureGates:    map[string]bool{"TEST": true, "ANOTHER": false},
 				ProfilerAddress: "localhost:1234",
 				Verbosity:       5,
-				ControllerManagerConfigurationSpec: configv1.ControllerManagerConfigurationSpec{
+				ControllerManagerConfigurationSpec: ctrlconfigv1.ControllerManagerConfigurationSpec{
 					CacheNamespace: "testNS",
 					SyncPeriod:     &metav1.Duration{Duration: sevenHours},
-					Controller:     &configv1.ControllerConfigurationSpec{GroupKindConcurrency: map[string]int{"machine": 3}},
-					Metrics:        configv1.ControllerMetrics{BindAddress: ":4567"},
-					Health: configv1.ControllerHealth{
+					Controller:     &ctrlconfigv1.ControllerConfigurationSpec{GroupKindConcurrency: map[string]int{"machine": 3}},
+					Metrics:        ctrlconfigv1.ControllerMetrics{BindAddress: ":4567"},
+					Health: ctrlconfigv1.ControllerHealth{
 						HealthProbeBindAddress: ":6789",
 						ReadinessEndpointName:  "readyish",
 						LivenessEndpointName:   "mostly",
 					},
-					Webhook: configv1.ControllerWebhook{
+					Webhook: ctrlconfigv1.ControllerWebhook{
 						Port:    pointer.Int(3579),
 						CertDir: "/tmp/certs",
 					},

--- a/internal/webhook/bootstrapprovider_webhook.go
+++ b/internal/webhook/bootstrapprovider_webhook.go
@@ -23,7 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
 )
 
 type BootstrapProviderWebhook struct {
@@ -31,7 +31,7 @@ type BootstrapProviderWebhook struct {
 
 func (r *BootstrapProviderWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&v1alpha1.BootstrapProvider{}).
+		For(&operatorv1.BootstrapProvider{}).
 		WithValidator(r).
 		Complete()
 }

--- a/internal/webhook/controlplaneprovider_webhook.go
+++ b/internal/webhook/controlplaneprovider_webhook.go
@@ -23,7 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
 )
 
 type ControlPlaneProviderWebhook struct {
@@ -31,7 +31,7 @@ type ControlPlaneProviderWebhook struct {
 
 func (r *ControlPlaneProviderWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&v1alpha1.ControlPlaneProvider{}).
+		For(&operatorv1.ControlPlaneProvider{}).
 		WithValidator(r).
 		Complete()
 }

--- a/internal/webhook/coreprovider_webhook.go
+++ b/internal/webhook/coreprovider_webhook.go
@@ -23,7 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
 )
 
 type CoreProviderWebhook struct {
@@ -32,7 +32,7 @@ type CoreProviderWebhook struct {
 func (r *CoreProviderWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		WithValidator(r).
-		For(&v1alpha1.CoreProvider{}).
+		For(&operatorv1.CoreProvider{}).
 		Complete()
 }
 

--- a/internal/webhook/infrastructureprovider_webhook.go
+++ b/internal/webhook/infrastructureprovider_webhook.go
@@ -23,7 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
 )
 
 type InfrastructureProviderWebhook struct {
@@ -32,7 +32,7 @@ type InfrastructureProviderWebhook struct {
 func (r *InfrastructureProviderWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		WithValidator(r).
-		For(&v1alpha1.InfrastructureProvider{}).
+		For(&operatorv1.InfrastructureProvider{}).
 		Complete()
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds aliases for most common (k8s.io/*) and operator specific packages to make broader use of `importas` linter from the .golangci.yaml. Also, due to mandating of the imports, fixes some imports to pass the CI