### PR TITLE
🌱 Add go.work/go.sum to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ cmd/clusterctl/clusterctl
 bin
 hack/tools/bin
 
+# go.work files
+go.work
+go.work.sum
+
 # Test binary, build with `go test -c`
 *.test
 


### PR DESCRIPTION
Signed-off by: Furkat Gofurov <furkat.gofurov@suse.com>

**What this PR does / why we need it**:
VSCode doesn't support nested modules and locally I am seeing few issues with it, i.e it will not give autocomplete or linting suggestions. Adding a go.work/go.sum files allows VSCode to recognize the nested modules.