### PR TITLE
🐛 prevent false lint error

### DIFF
--- a/internal/controller/preflight_checks.go
+++ b/internal/controller/preflight_checks.go
@@ -44,7 +44,7 @@ var (
 	moreThanOneCoreProviderInstanceExistsMessage = "CoreProvider already exists in the cluster. Only one is allowed."
 	moreThanOneProviderInstanceExistsMessage     = "There is already a %s with name %s in the cluster. Only one is allowed."
 	capiVersionIncompatibilityMessage            = "CAPI operator is only compatible with %s providers, detected %s for provider %s."
-	invalidGithubTokenMessage                    = "Invalid github token, please check your github token value and it's permissions"
+	invalidGithubTokenMessage                    = "Invalid github token, please check your github token value and it's permissions" //nolint:gosec
 	waitingForCoreProviderReadyMessage           = "Waiting for the core provider to be installed."
 	emptyVersionMessage                          = "Version cannot be empty"
 )


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Gosec linter reports a false error `G101: Potential hardcoded credentials (gosec)`. To prevent it we disable the linter in that place.

