### PR TITLE
🌱 allow to halt reconciliation

### DIFF
--- a/internal/controller/manifests_downloader_test.go
+++ b/internal/controller/manifests_downloader_test.go
@@ -54,10 +54,10 @@ func TestManifestsDownloader(t *testing.T) {
 		},
 	}
 
-	_, err := p.initializePhaseReconciler(ctx)
+	_, _, err := p.initializePhaseReconciler(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = p.downloadManifests(ctx)
+	_, _, err = p.downloadManifests(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Ensure that config map was created

--- a/internal/controller/preflight_checks_test.go
+++ b/internal/controller/preflight_checks_test.go
@@ -643,7 +643,7 @@ func TestPreflightChecks(t *testing.T) {
 				gs.Expect(fakeclient.Create(ctx, c.GetObject())).To(Succeed())
 			}
 
-			_, err := preflightChecks(context.Background(), fakeclient, tc.providers[0], tc.providerList)
+			_, _, err := preflightChecks(context.Background(), fakeclient, tc.providers[0], tc.providerList)
 			if tc.expectedError {
 				gs.Expect(err).To(HaveOccurred())
 			} else {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Previously, the operator would always proceed to the next phase after a successful execution of the previous one, with the only way to stop reconciliation being an error returned from a phase function. This could be problematic when halting reconciliation is needed without any errors, such as when a provider's version hasn't changed.

This commit introduces a new "halt" flag as a return value for phase functions. When a function sets this flag to true, the operator will halt reconciliation for the provider immediately.
