### PR TITLE
🌱 Relocate version change validation to preflight check 

### DIFF
--- a/internal/controller/consts.go
+++ b/internal/controller/consts.go
@@ -16,13 +16,7 @@ limitations under the License.
 
 package controller
 
-import "time"
-
 const (
-	// preflightFailedRequeueAfter is how long to wait before trying to reconcile
-	// if some preflight check has failed.
-	preflightFailedRequeueAfter = 30 * time.Second
-
 	httpsScheme             = "https"
 	githubDomain            = "github.com"
 	gitlabHostPrefix        = "gitlab."

--- a/internal/controller/genericprovider_controller.go
+++ b/internal/controller/genericprovider_controller.go
@@ -108,10 +108,15 @@ func (r *GenericProviderReconciler) Reconcile(ctx context.Context, req reconcile
 	}
 
 	// Run preflight checks to ensure that we can proceed with given specification
-	res, err := preflightchecks.PreflightChecks(ctx, r.Client, typedProvider, typedProviderList)
+	res, halt, err := preflightchecks.PreflightChecks(ctx, r.Client, typedProvider, typedProviderList)
 	if !res.IsZero() || err != nil {
-		// the steps are sequential, so we must be complete before progressing.
 		return res, err
+	}
+
+	if halt {
+		log.Info("No changes detected, skipping further steps")
+
+		return res, nil
 	}
 
 	return r.reconcile(ctx, typedProvider, typedProviderList)

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -45,7 +45,6 @@ import (
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
-	"sigs.k8s.io/cluster-api-operator/internal/controller/preflightchecks"
 	"sigs.k8s.io/cluster-api-operator/util"
 )
 
@@ -105,11 +104,6 @@ func newPhaseReconciler(r GenericProviderReconciler, provider genericprovider.Ge
 		provider:           provider,
 		providerList:       providerList,
 	}
-}
-
-// preflightChecks a wrapper around the preflight checks.
-func (p *phaseReconciler) preflightChecks(ctx context.Context) (reconcile.Result, error) {
-	return preflightchecks.PreflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
 }
 
 // initializePhaseReconciler initializes phase reconciler.

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -32,9 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
-	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
-	"sigs.k8s.io/cluster-api-operator/util"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
@@ -45,6 +42,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
+	"sigs.k8s.io/cluster-api-operator/internal/controller/preflightchecks"
+	"sigs.k8s.io/cluster-api-operator/util"
 )
 
 const metadataFile = "metadata.yaml"
@@ -107,7 +109,7 @@ func newPhaseReconciler(r GenericProviderReconciler, provider genericprovider.Ge
 
 // preflightChecks a wrapper around the preflight checks.
 func (p *phaseReconciler) preflightChecks(ctx context.Context) (reconcile.Result, error) {
-	return preflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
+	return preflightchecks.PreflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
 }
 
 // initializePhaseReconciler initializes phase reconciler.

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -345,58 +345,14 @@ func (p *phaseReconciler) fetch(ctx context.Context) (reconcile.Result, error) {
 func (p *phaseReconciler) preInstall(ctx context.Context) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	needPreDelete, err := p.versionChanged()
-	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, "failed getting clusterctl Provider version")
-	}
-
-	// we need to delete existing components only if their version changes and something has already been installed.
-	if !needPreDelete || p.provider.GetStatus().InstalledVersion == nil {
-		return reconcile.Result{}, nil
-	}
-
 	log.Info("Upgrade detected, deleting existing components")
 
 	return p.delete(ctx)
 }
 
-// versionChanged try to get installed version from provider status and decide if it has changed.
-func (p *phaseReconciler) versionChanged() (bool, error) {
-	installedVersion := p.provider.GetStatus().InstalledVersion
-	if installedVersion == nil {
-		return true, nil
-	}
-
-	currentVersion, err := versionutil.ParseSemantic(*installedVersion)
-	if err != nil {
-		return false, err
-	}
-
-	res, err := currentVersion.Compare(p.components.Version())
-	if err != nil {
-		return false, err
-	}
-
-	// we need to delete installed components if versions are different
-	versionChanged := res != 0
-
-	return versionChanged, nil
-}
-
 // install installs the provider components using clusterctl library.
 func (p *phaseReconciler) install(ctx context.Context) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-
-	versionChanged, err := p.versionChanged()
-	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, "failed getting clusterctl Provider version")
-	}
-
-	// skip installation if the version hasn't changed.
-	if !versionChanged {
-		log.Info("Provider already installed")
-		return reconcile.Result{}, nil
-	}
 
 	clusterClient := p.newClusterClient()
 

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -300,10 +300,6 @@ func (p *phaseReconciler) validateRepoCAPIVersion() error {
 		return fmt.Errorf("invalid provider metadata: version %s for the provider %s does not match any release series", p.options.Version, name)
 	}
 
-	if releaseSeries.Contract != "v1alpha4" && releaseSeries.Contract != "v1beta1" {
-		return fmt.Errorf(capiVersionIncompatibilityMessage, clusterv1.GroupVersion.Version, releaseSeries.Contract, name)
-	}
-
 	p.contract = releaseSeries.Contract
 
 	return nil

--- a/internal/controller/preflightchecks/preflight_checks.go
+++ b/internal/controller/preflightchecks/preflight_checks.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package preflightchecks
 
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/go-github/v52/github"
 	"golang.org/x/oauth2"
@@ -38,19 +39,22 @@ import (
 
 const (
 	coreProvider = "CoreProvider"
+
+	// preflightFailedRequeueAfter is how long to wait before trying to reconcile
+	// if some preflight check has failed.
+	preflightFailedRequeueAfter = 30 * time.Second
 )
 
 var (
 	moreThanOneCoreProviderInstanceExistsMessage = "CoreProvider already exists in the cluster. Only one is allowed."
 	moreThanOneProviderInstanceExistsMessage     = "There is already a %s with name %s in the cluster. Only one is allowed."
-	capiVersionIncompatibilityMessage            = "CAPI operator is only compatible with %s providers, detected %s for provider %s."
 	invalidGithubTokenMessage                    = "Invalid github token, please check your github token value and it's permissions" //nolint:gosec
 	waitingForCoreProviderReadyMessage           = "Waiting for the core provider to be installed."
 	emptyVersionMessage                          = "Version cannot be empty"
 )
 
-// preflightChecks performs preflight checks before installing provider.
-func preflightChecks(ctx context.Context, c client.Client, provider genericprovider.GenericProvider, providerList genericprovider.GenericProviderList) (ctrl.Result, error) {
+// PreflightChecks performs preflight checks before installing provider.
+func PreflightChecks(ctx context.Context, c client.Client, provider genericprovider.GenericProvider, providerList genericprovider.GenericProviderList) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	log.Info("Performing preflight checks")

--- a/internal/controller/preflightchecks/preflight_checks_test.go
+++ b/internal/controller/preflightchecks/preflight_checks_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package preflightchecks
 
 import (
 	"context"
@@ -29,11 +29,16 @@ import (
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
+	"sigs.k8s.io/cluster-api-operator/internal/envtest"
 )
+
+var env *envtest.Environment
 
 func TestPreflightChecks(t *testing.T) {
 	namespaceName1 := "provider-test-ns-1"
 	namespaceName2 := "provider-test-ns-2"
+
+	env = envtest.New()
 
 	testCases := []struct {
 		name              string
@@ -640,10 +645,10 @@ func TestPreflightChecks(t *testing.T) {
 			fakeclient := fake.NewClientBuilder().WithObjects().Build()
 
 			for _, c := range tc.providers {
-				gs.Expect(fakeclient.Create(ctx, c.GetObject())).To(Succeed())
+				gs.Expect(fakeclient.Create(context.Background(), c.GetObject())).To(Succeed())
 			}
 
-			_, err := preflightChecks(context.Background(), fakeclient, tc.providers[0], tc.providerList)
+			_, err := PreflightChecks(context.Background(), fakeclient, tc.providers[0], tc.providerList)
 			if tc.expectedError {
 				gs.Expect(err).To(HaveOccurred())
 			} else {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Previously, the check was executed at the end of reconciliation and in multiple instances. By moving it to the beginning, the process is halted when installed and desired versions match, streamlining the reconciliation workflow.

