### PR TITLE
🐛 Update provider components if (and only if) its spec has been changed

### DIFF
--- a/internal/controller/genericprovider_controller_test.go
+++ b/internal/controller/genericprovider_controller_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -459,6 +460,181 @@ func TestNewGenericProviderList(t *testing.T) {
 				g.Expect(genericProviderList.GetObject()).ToNot(BeIdenticalTo(tc.providerList))
 			}
 		})
+	}
+}
+
+func TestProviderSpecChanges(t *testing.T) {
+	testCases := []struct {
+		name        string
+		spec        operatorv1.ProviderSpec
+		updatedSpec operatorv1.ProviderSpec
+		expectError bool
+	}{
+		{
+			name: "same spec, hash annotation doesn't change",
+			spec: operatorv1.ProviderSpec{
+				Version: testCurrentVersion,
+				FetchConfig: &operatorv1.FetchConfiguration{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "dummy-config",
+						},
+					},
+				},
+			},
+			updatedSpec: operatorv1.ProviderSpec{
+				Version: testCurrentVersion,
+				FetchConfig: &operatorv1.FetchConfiguration{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "dummy-config",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "add more replicas, hash annotation is updated",
+			spec: operatorv1.ProviderSpec{
+				Version: testCurrentVersion,
+				FetchConfig: &operatorv1.FetchConfiguration{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "dummy-config",
+						},
+					},
+				},
+			},
+			updatedSpec: operatorv1.ProviderSpec{
+				Version: testCurrentVersion,
+				Deployment: &operatorv1.DeploymentSpec{
+					Replicas: pointer.Int(2),
+				},
+				FetchConfig: &operatorv1.FetchConfiguration{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "dummy-config",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "upgrade to a non-existent version, hash annotation is empty",
+			expectError: true,
+			spec: operatorv1.ProviderSpec{
+				Version: testCurrentVersion,
+				FetchConfig: &operatorv1.FetchConfiguration{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "dummy-config",
+						},
+					},
+				},
+			},
+			updatedSpec: operatorv1.ProviderSpec{
+				Version: "10000.0.0-NONEXISTENT",
+				Deployment: &operatorv1.DeploymentSpec{
+					Replicas: pointer.Int(2),
+				},
+				FetchConfig: &operatorv1.FetchConfiguration{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "dummy-config",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			specHash, err := calculateHash(tc.spec)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			updatedSpecHash, err := calculateHash(tc.spec)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			provider := &genericprovider.CoreProviderWrapper{
+				CoreProvider: &operatorv1.CoreProvider{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-api",
+					},
+					Spec: operatorv1.CoreProviderSpec{
+						ProviderSpec: tc.spec,
+					},
+				},
+			}
+
+			namespace := "test-provider-spec-changes"
+
+			t.Log("Ensure namespace exists", namespace)
+			g.Expect(env.EnsureNamespaceExists(ctx, namespace)).To(Succeed())
+
+			g.Expect(env.CreateAndWait(ctx, dummyConfigMap(namespace, testCurrentVersion))).To(Succeed())
+
+			provider.SetNamespace(namespace)
+			t.Log("creating test provider", provider.GetName())
+			g.Expect(env.CreateAndWait(ctx, provider.GetObject())).To(Succeed())
+
+			g.Eventually(generateExpectedResultChecker(provider, specHash, corev1.ConditionTrue), timeout).Should(BeEquivalentTo(true))
+
+			// Change provider spec
+			provider.SetSpec(tc.updatedSpec)
+
+			// Set a label to ensure that provider was changed
+			labels := provider.GetLabels()
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			labels["my-label"] = "some-value"
+			provider.SetLabels(labels)
+
+			g.Expect(env.Client.Update(ctx, provider.GetObject())).To(Succeed())
+
+			if !tc.expectError {
+				g.Eventually(generateExpectedResultChecker(provider, updatedSpecHash, corev1.ConditionTrue), timeout).Should(BeEquivalentTo(true))
+			} else {
+				g.Eventually(generateExpectedResultChecker(provider, "", corev1.ConditionFalse), timeout).Should(BeEquivalentTo(true))
+			}
+
+			// Clean up
+			objs := []client.Object{provider.GetObject()}
+			objs = append(objs, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testCurrentVersion,
+					Namespace: namespace,
+				},
+			})
+
+			g.Expect(env.CleanupAndWait(ctx, objs...)).To(Succeed())
+		})
+	}
+}
+
+func generateExpectedResultChecker(provider *genericprovider.CoreProviderWrapper, specHash string, condStatus corev1.ConditionStatus) func() bool {
+	return func() bool {
+		if err := env.Get(ctx, client.ObjectKeyFromObject(provider.GetObject()), provider.GetObject()); err != nil {
+			return false
+		}
+
+		// In case of error we don't want the spec annotation to be updated
+		if provider.GetAnnotations()[appliedSpecHashAnnotation] != specHash {
+			return false
+		}
+
+		for _, cond := range provider.GetStatus().Conditions {
+			if cond.Type == operatorv1.ProviderInstalledCondition {
+				if cond.Status == condStatus {
+					return true
+				}
+			}
+		}
+
+		return false
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Now we update provider components only if it's version has changed, but there are other cases where we need to do the same. For instance, when we update its DeploymentSpec or ManagementSpec.

Also we should reconcile providers if their spec is the same as for the last applied version. 

To fix it we calculate last applied spec hash and store it in a provider annotation. For next reconciliations we calculate the hash again. If it's the same as in the annotation, we skip further steps and stop immediately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #156 
