### PR TITLE
🐛 Delete provider's CRDs and namespace along with the provider custom resource

### DIFF
--- a/internal/controller/client_proxy.go
+++ b/internal/controller/client_proxy.go
@@ -76,6 +76,8 @@ func (k *controllerProxy) ListResources(labels map[string]string, namespaces ...
 				{Kind: "Secret", Namespaced: true},
 				{Kind: "ConfigMap", Namespaced: true},
 				{Kind: "Service", Namespaced: true},
+				{Kind: "ServiceAccount", Namespaced: true},
+				{Kind: "Namespace"},
 			},
 		},
 		{
@@ -88,8 +90,30 @@ func (k *controllerProxy) ListResources(labels map[string]string, namespaces ...
 		{
 			GroupVersion: "admissionregistration.k8s.io/v1",
 			APIResources: []metav1.APIResource{
-				{Kind: "ValidatingWebhookConfiguration", Namespaced: true},
-				{Kind: "MutatingWebhookConfiguration", Namespaced: true},
+				{Kind: "ValidatingWebhookConfiguration"},
+				{Kind: "MutatingWebhookConfiguration"},
+			},
+		},
+		{
+			GroupVersion: "apiextensions.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Kind: "CustomResourceDefinition"},
+			},
+		},
+		{
+			GroupVersion: "cert-manager.io/v1",
+			APIResources: []metav1.APIResource{
+				{Kind: "Certificate", Namespaced: true},
+				{Kind: "Issuer", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "rbac.authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Kind: "Role", Namespaced: true},
+				{Kind: "RoleBinding", Namespaced: true},
+				{Kind: "ClusterRole"},
+				{Kind: "ClusterRoleBinding"},
 			},
 		},
 	}

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -365,7 +365,7 @@ func (p *phaseReconciler) preInstall(ctx context.Context) (reconcile.Result, err
 
 	log.Info("Upgrade detected, deleting existing components")
 
-	return p.delete(ctx)
+	return p.delete(ctx, false, false)
 }
 
 // versionChanged try to get installed version from provider status and decide if it has changed.
@@ -432,7 +432,7 @@ func (p *phaseReconciler) install(ctx context.Context) (reconcile.Result, error)
 }
 
 // delete deletes the provider components using clusterctl library.
-func (p *phaseReconciler) delete(ctx context.Context) (reconcile.Result, error) {
+func (p *phaseReconciler) delete(ctx context.Context, includeNamespace, includeCRDs bool) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Deleting provider")
 
@@ -451,8 +451,8 @@ func (p *phaseReconciler) delete(ctx context.Context) (reconcile.Result, error) 
 
 	err := clusterClient.ProviderComponents().Delete(cluster.DeleteOptions{
 		Provider:         *p.clusterctlProvider,
-		IncludeNamespace: false,
-		IncludeCRDs:      false,
+		IncludeNamespace: includeNamespace,
+		IncludeCRDs:      includeCRDs,
 	})
 
 	return reconcile.Result{}, wrapPhaseError(err, operatorv1.OldComponentsDeletionErrorReason)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Now we keep provider's namespace and CRDs after we delete the provider, which pollutes the system. System administrators have to manually delete stalled objects after that. After this PR operator will delete all providers components completely.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #120 
