### PR TITLE
🐛 Always call customizeDeployment function

### DIFF
--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -73,9 +73,7 @@ func customizeObjectsFn(provider genericprovider.GenericProvider) func(objs []un
 					return nil, err
 				}
 
-				if provider.GetSpec().Deployment != nil {
-					customizeDeployment(provider.GetSpec(), d)
-				}
+				customizeDeployment(provider.GetSpec(), d)
 
 				if err := scheme.Scheme.Convert(d, &o, nil); err != nil {
 					return nil, err


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: 
Now we call it only if Deployment spec is not empty. Then, inside the function, we customize both Deployment and Manager if related specs are not empty. It causes an error when we don't update Manager if Deployment spec is empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #172 
