### PR TITLE
✨ Add serviceAccountName to DeploymentSpec

### DIFF
--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -115,6 +115,10 @@ type DeploymentSpec struct {
 	// +optional
 	Containers []ContainerSpec `json:"containers"`
 
+	// If specified, the pod's service account
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
 	// List of image pull secrets specified in the Deployment
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`

--- a/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
@@ -1154,6 +1154,9 @@ spec:
                       between explicit zero and not specified. Defaults to 1.
                     minimum: 0
                     type: integer
+                  serviceAccountName:
+                    description: If specified, the pod's service account
+                    type: string
                   tolerations:
                     description: If specified, the pod's tolerations.
                     items:

--- a/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
@@ -1155,6 +1155,9 @@ spec:
                       between explicit zero and not specified. Defaults to 1.
                     minimum: 0
                     type: integer
+                  serviceAccountName:
+                    description: If specified, the pod's service account
+                    type: string
                   tolerations:
                     description: If specified, the pod's tolerations.
                     items:

--- a/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
@@ -1154,6 +1154,9 @@ spec:
                       between explicit zero and not specified. Defaults to 1.
                     minimum: 0
                     type: integer
+                  serviceAccountName:
+                    description: If specified, the pod's service account
+                    type: string
                   tolerations:
                     description: If specified, the pod's tolerations.
                     items:

--- a/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
@@ -1155,6 +1155,9 @@ spec:
                       between explicit zero and not specified. Defaults to 1.
                     minimum: 0
                     type: integer
+                  serviceAccountName:
+                    description: If specified, the pod's service account
+                    type: string
                   tolerations:
                     description: If specified, the pod's tolerations.
                     items:

--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -108,6 +108,10 @@ func customizeDeployment(pSpec operatorv1.ProviderSpec, d *appsv1.Deployment) {
 			d.Spec.Template.Spec.Tolerations = dSpec.Tolerations
 		}
 
+		if dSpec.ServiceAccountName != "" {
+			d.Spec.Template.Spec.ServiceAccountName = dSpec.ServiceAccountName
+		}
+
 		if dSpec.ImagePullSecrets != nil {
 			d.Spec.Template.Spec.ImagePullSecrets = dSpec.ImagePullSecrets
 		}

--- a/internal/controller/component_customizer_test.go
+++ b/internal/controller/component_customizer_test.go
@@ -203,6 +203,23 @@ func TestCustomizeDeployment(t *testing.T) {
 			},
 		},
 		{
+			name: "only serviceAccountName modified",
+			inputDeploymentSpec: &operatorv1.DeploymentSpec{
+				ServiceAccountName: "foo-service-account",
+			},
+			expectedDeploymentSpec: func(inputDS *appsv1.DeploymentSpec) (*appsv1.DeploymentSpec, bool) {
+				expectedDS := &appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							ServiceAccountName: "foo-service-account",
+						},
+					},
+				}
+
+				return expectedDS, reflect.DeepEqual(inputDS.Template.Spec.ServiceAccountName, expectedDS.Template.Spec.ServiceAccountName)
+			},
+		},
+		{
 			name: "only image pull secrets modified",
 			inputDeploymentSpec: &operatorv1.DeploymentSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Today, it's difficult to override the service account with an IRSA configured value. I would like the ability override the serviceAccountName for the deployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
