### PR TITLE
✨  Add ability to specify a namespace for provider secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests for the operator e.g
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		paths=./internal/controller/... \
+		paths=./internal/webhook/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \
 		output:crd:dir=./config/crd/bases \

--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -51,6 +51,10 @@ type ProviderSpec struct {
 	// +optional
 	SecretName string `json:"secretName,omitempty"`
 
+	// SecretNamespace is the namespace of the Secret providing the configuration variables. If not specified,
+	// the namespace of the provider will be used.
+	SecretNamespace string `json:"secretNamespace,omitempty"`
+
 	// FetchConfig determines how the operator will fetch the components and metadata for the provider.
 	// If nil, the operator will try to fetch components according to default
 	// embedded fetch configuration for the given kind and `ObjectMeta.Name`.

--- a/config/chart/webhookcainjection_patch.yaml
+++ b/config/chart/webhookcainjection_patch.yaml
@@ -1,6 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
@@ -1447,6 +1447,11 @@ spec:
                   name should be updated. The contents should be in the form of key:value.
                   This secret must be in the same namespace as the provider.
                 type: string
+              secretNamespace:
+                description: SecretNamespace is the namespace of the Secret providing
+                  the configuration variables. If not specified, the namespace of
+                  the provider will be used.
+                type: string
               version:
                 description: Version indicates the provider version.
                 type: string

--- a/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
@@ -1448,6 +1448,11 @@ spec:
                   name should be updated. The contents should be in the form of key:value.
                   This secret must be in the same namespace as the provider.
                 type: string
+              secretNamespace:
+                description: SecretNamespace is the namespace of the Secret providing
+                  the configuration variables. If not specified, the namespace of
+                  the provider will be used.
+                type: string
               version:
                 description: Version indicates the provider version.
                 type: string

--- a/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
@@ -1447,6 +1447,11 @@ spec:
                   name should be updated. The contents should be in the form of key:value.
                   This secret must be in the same namespace as the provider.
                 type: string
+              secretNamespace:
+                description: SecretNamespace is the namespace of the Secret providing
+                  the configuration variables. If not specified, the namespace of
+                  the provider will be used.
+                type: string
               version:
                 description: Version indicates the provider version.
                 type: string

--- a/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
@@ -1448,6 +1448,11 @@ spec:
                   name should be updated. The contents should be in the form of key:value.
                   This secret must be in the same namespace as the provider.
                 type: string
+              secretNamespace:
+                description: SecretNamespace is the namespace of the Secret providing
+                  the configuration variables. If not specified, the namespace of
+                  the provider will be used.
+                type: string
               version:
                 description: Version indicates the provider version.
                 type: string

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,6 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,18 +1,19 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
+kind: MutatingWebhookConfiguration
 metadata:
-  name: validating-webhook-configuration
+  name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1alpha1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-operator-cluster-x-k8s-io-v1alpha1-bootstrapprovider
+      path: /mutate-operator-cluster-x-k8s-io-v1alpha1-bootstrapprovider
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: vbootstrapprovider.kb.io
   rules:
   - apiGroups:
@@ -27,13 +28,14 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1alpha1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-operator-cluster-x-k8s-io-v1alpha1-controlplaneprovider
+      path: /mutate-operator-cluster-x-k8s-io-v1alpha1-controlplaneprovider
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: vcontrolplaneprovider.kb.io
   rules:
   - apiGroups:
@@ -48,13 +50,14 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1alpha1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-operator-cluster-x-k8s-io-v1alpha1-coreprovider
+      path: /mutate-operator-cluster-x-k8s-io-v1alpha1-coreprovider
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: vcoreprovider.kb.io
   rules:
   - apiGroups:
@@ -69,13 +72,108 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1alpha1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-operator-cluster-x-k8s-io-v1alpha1-infrastructureprovider
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vinfrastructureprovider.kb.io
+  rules:
+  - apiGroups:
+    - operator.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - infrastructureproviders
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-operator-cluster-x-k8s-io-v1alpha1-bootstrapprovider
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vbootstrapprovider.kb.io
+  rules:
+  - apiGroups:
+    - operator.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bootstrapproviders
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-operator-cluster-x-k8s-io-v1alpha1-controlplaneprovider
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vcontrolplaneprovider.kb.io
+  rules:
+  - apiGroups:
+    - operator.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - controlplaneproviders
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-operator-cluster-x-k8s-io-v1alpha1-coreprovider
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vcoreprovider.kb.io
+  rules:
+  - apiGroups:
+    - operator.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - coreproviders
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
       path: /validate-operator-cluster-x-k8s-io-v1alpha1-infrastructureprovider
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: vinfrastructureprovider.kb.io
   rules:
   - apiGroups:

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -195,7 +195,7 @@ func (p *phaseReconciler) secretReader(ctx context.Context) (configclient.Reader
 	// Fetch configuration variables from the secret. See API field docs for more info.
 	if p.provider.GetSpec().SecretName != "" {
 		secret := &corev1.Secret{}
-		key := types.NamespacedName{Namespace: p.provider.GetNamespace(), Name: p.provider.GetSpec().SecretName}
+		key := types.NamespacedName{Namespace: p.provider.GetSpec().SecretNamespace, Name: p.provider.GetSpec().SecretName}
 
 		if err := p.ctrlClient.Get(ctx, key, secret); err != nil {
 			return nil, err

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -38,6 +38,7 @@ func TestSecretReader(t *testing.T) {
 	fakeclient := fake.NewClientBuilder().WithObjects().Build()
 
 	secretName := "test-secret"
+	secretNamespace := "test-secret-namespace"
 	namespace := "test-namespace"
 
 	p := &phaseReconciler{
@@ -54,7 +55,8 @@ func TestSecretReader(t *testing.T) {
 				},
 				Spec: operatorv1.CoreProviderSpec{
 					ProviderSpec: operatorv1.ProviderSpec{
-						SecretName: secretName,
+						SecretName:      secretName,
+						SecretNamespace: secretNamespace,
 						FetchConfig: &operatorv1.FetchConfiguration{
 							URL: "https://example.com",
 						},
@@ -72,7 +74,7 @@ func TestSecretReader(t *testing.T) {
 	g.Expect(fakeclient.Create(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
-			Namespace: namespace,
+			Namespace: secretNamespace,
 		},
 		Data: map[string][]byte{
 			testKey1: []byte(testValue1),

--- a/internal/controller/preflight_checks.go
+++ b/internal/controller/preflight_checks.go
@@ -117,7 +117,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 	// Validate that provided github token works and has repository access.
 	if spec.SecretName != "" {
 		secret := &corev1.Secret{}
-		key := types.NamespacedName{Namespace: provider.GetNamespace(), Name: provider.GetSpec().SecretName}
+		key := types.NamespacedName{Namespace: provider.GetSpec().SecretNamespace, Name: provider.GetSpec().SecretName}
 
 		if err := c.Get(ctx, key, secret); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get providers secret: %w", err)

--- a/internal/webhook/provider_webhook.go
+++ b/internal/webhook/provider_webhook.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+)
+
+// setDefaultProviderSpec sets the default values for the provider spec.
+func setDefaultProviderSpec(providerSpec *operatorv1.ProviderSpec, providerNamespace string) {
+	if providerSpec.SecretName != "" && providerSpec.SecretNamespace == "" {
+		providerSpec.SecretNamespace = providerNamespace
+	}
+}

--- a/internal/webhook/provider_webhook_test.go
+++ b/internal/webhook/provider_webhook_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"reflect"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+)
+
+func TestSetDefaultProviderSpec(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		providerSpec         *operatorv1.ProviderSpec
+		namespace            string
+		expectedProviderSpec *operatorv1.ProviderSpec
+	}{
+		{
+			name: "shoud default secret namespace if not specified",
+			providerSpec: &operatorv1.ProviderSpec{
+				SecretName: "test-secret",
+			},
+			namespace: "test-namespace",
+			expectedProviderSpec: &operatorv1.ProviderSpec{
+				SecretName:      "test-secret",
+				SecretNamespace: "test-namespace",
+			},
+		},
+		{
+			name: "shoud not default secret namespace if specified",
+			providerSpec: &operatorv1.ProviderSpec{
+				SecretName:      "test-secret",
+				SecretNamespace: "test-namespace-1",
+			},
+			namespace: "test-namespace-2",
+			expectedProviderSpec: &operatorv1.ProviderSpec{
+				SecretName:      "test-secret",
+				SecretNamespace: "test-namespace-1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gs := NewWithT(t)
+			setDefaultProviderSpec(tc.providerSpec, tc.namespace)
+			gs.Expect(reflect.DeepEqual(tc.providerSpec, tc.expectedProviderSpec)).To(BeTrue())
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Add the ability to specify a namespace for provider secret, this allows users to share a secret between providers. This way we can provide a better ux.

In the next version of API we can change the field to `corev1.ObjectReference`, I wanted to avoid a breaking change.

cc @damdo @Fedosin @furkatgofurov7 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
