### PR TITLE
🐛 delete all provider resources 

### DIFF
--- a/internal/controller/client_proxy.go
+++ b/internal/controller/client_proxy.go
@@ -76,6 +76,8 @@ func (k *controllerProxy) ListResources(labels map[string]string, namespaces ...
 				{Kind: "Secret", Namespaced: true},
 				{Kind: "ConfigMap", Namespaced: true},
 				{Kind: "Service", Namespaced: true},
+				{Kind: "ServiceAccount", Namespaced: true},
+				{Kind: "Namespace"},
 			},
 		},
 		{
@@ -88,8 +90,30 @@ func (k *controllerProxy) ListResources(labels map[string]string, namespaces ...
 		{
 			GroupVersion: "admissionregistration.k8s.io/v1",
 			APIResources: []metav1.APIResource{
-				{Kind: "ValidatingWebhookConfiguration", Namespaced: true},
-				{Kind: "MutatingWebhookConfiguration", Namespaced: true},
+				{Kind: "ValidatingWebhookConfiguration"},
+				{Kind: "MutatingWebhookConfiguration"},
+			},
+		},
+		{
+			GroupVersion: "apiextensions.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Kind: "CustomResourceDefinition"},
+			},
+		},
+		{
+			GroupVersion: "cert-manager.io/v1",
+			APIResources: []metav1.APIResource{
+				{Kind: "Certificate", Namespaced: true},
+				{Kind: "Issuer", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "rbac.authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Kind: "Role", Namespaced: true},
+				{Kind: "RoleBinding", Namespaced: true},
+				{Kind: "ClusterRole"},
+				{Kind: "ClusterRoleBinding"},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Client proxy defines among which types we will search for objects we need to delete. Currently this list is not full and we skip some types, like ClusterRole or ClusterRole bindings. It leads to the fact that objects of these types stay in the system when their provider is deleted.

This PR updates the list of resource types we need to scan.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
