### PR TITLE
✨Bump go version to v1.20.4

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: Generate release artifacts
         run: |
           make release

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.19"
+  go: "1.20"
   skip-files:
     - "zz_generated.*\\.go$"
   allow-parallel-runners: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.20.4 as builder
+# Run this with docker build --build-arg builder_image=<golang:x.y.z>
+ARG builder_image
+
+FROM ${builder_image} as builder
 WORKDIR /workspace
 
 # Run this with docker build --build-arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.19.0 as builder
+FROM golang:1.20.4 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build-arg goproxy=$(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
 	docker pull docker.io/docker/dockerfile:1.4
-	docker pull docker.io/library/golang:1.19.0
+	docker pull docker.io/library/golang:1.20.4
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: docker-build

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ ROOT:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .DEFAULT_GOAL:=help
 
+GO_VERSION ?= 1.20.4
+GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
+
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)
@@ -318,12 +321,12 @@ modules: ## Runs go mod to ensure modules are up to date.
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
 	docker pull docker.io/docker/dockerfile:1.4
-	docker pull docker.io/library/golang:1.20.4
+	docker pull $(GO_CONTAINER_IMAGE)
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg LDFLAGS="$(LDFLAGS)" . -t $(CONTROLLER_IMG_TAG)
+	docker build --build-arg builder_image=$(GO_CONTAINER_IMAGE) --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) --build-arg LDFLAGS="$(LDFLAGS)" . -t $(CONTROLLER_IMG_TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"time"
@@ -113,8 +112,6 @@ func InitFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	InitFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-operator
 
-go 1.19
+go 1.20
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.4.3
 

--- a/hack/chart-update/go.mod
+++ b/hack/chart-update/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-operator/hack/chart-update
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-github/v50 v50.1.0

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.19.0
+  minimum_go_version=go1.20.4
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-operator/hack/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46

--- a/scripts/ci-verify.sh
+++ b/scripts/ci-verify.sh
@@ -21,5 +21,5 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
 
-echo "*** Verifying Cluster API ***"
+echo "*** Verifying Cluster API Operator ***"
 make verify


### PR DESCRIPTION
**What this PR does / why we need it**:
Few CI jobs are failing in main branch ([e2e-main](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-cluster-api-operator-e2e-main/1679273348166586368), [test-main](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-operator/186/pull-cluster-api-operator-test-main/1679273348103671808)) and PRs like #186  due to go version incompatibility with k8s:

```
Activated service account credentials for: [prow-build@k8s-infra-prow-build.iam.gserviceaccount.com]
+ WRAPPED_COMMAND_PID=[2](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-operator/186/pull-cluster-api-operator-test-main/1679273348103671808#1:build-log.txt%3A2)7
+ wait 27
+ ./scripts/ci-test.sh
Detected go version: go version go1.19.10 linux/amd6[4](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-operator/186/pull-cluster-api-operator-test-main/1679273348103671808#1:build-log.txt%3A4).
Kubernetes requires go1.20.0 or greater.
Please install go1.20.0 or later.
+ EXIT_VALUE=2
+ set +o xtrace
```

This PR bumps go version (1st commit), fixes lint issue (2nd commit) and also allows users to override the builder image (3rd commit)
