### PR TITLE
🐛 Compress components manifests if they don't fit in the configmap 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
+	github.com/docker/go-units v0.5.0 // indirect
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/docker/docker v20.10.24+incompatible h1:Ugvxm7a8+Gz6vqQYQQ2W7GYq5EUPa
 github.com/docker/docker v20.10.24+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
-github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
-github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
+github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 h1:7QPwrLT79GlD5sizHf27aoY2RTvw62mO6x7mxkScNk0=
 github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46/go.mod h1:esf2rsHFNlZlxsqsZDojNBcnNs5REqIvRrWRHqX0vEU=

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -194,7 +194,7 @@ metadata:
 					},
 				},
 			},
-			wantErr: "ConfigMap ns1/v1.2.3 has no components",
+			wantErr: "ConfigMap ns1/v1.2.3 Data has no components",
 		},
 		{
 			name: "configmap with invalid version in the name",

--- a/test/e2e/compressed_manifests_test.go
+++ b/test/e2e/compressed_manifests_test.go
@@ -1,0 +1,210 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ociInfrastructureProviderName           = "oci"
+	ociInfrastructureProviderVersion        = "v0.12.0"
+	ociInfrastructureProviderDeploymentName = "capoci-controller-manager"
+	compressedAnnotation                    = "provider.cluster.x-k8s.io/compressed"
+	componentsConfigMapKey                  = "components"
+)
+
+var _ = Describe("Create and delete a provider with manifests that don't fit the configmap", func() {
+	It("should successfully create a CoreProvider", func() {
+		k8sclient := bootstrapClusterProxy.GetClient()
+		coreProvider := &operatorv1.CoreProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      coreProviderName,
+				Namespace: operatorNamespace,
+			},
+			Spec: operatorv1.CoreProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{},
+			},
+		}
+
+		Expect(k8sclient.Create(ctx, coreProvider)).To(Succeed())
+
+		By("Waiting for the core provider deployment to be ready")
+		Eventually(func() bool {
+			isReady, err := waitForDeployment(k8sclient, ctx, coreProviderDeploymentName)
+			if err != nil {
+				return false
+			}
+			return isReady
+		}, timeout).Should(Equal(true))
+
+		By("Waiting for core provider to be ready")
+		Eventually(func() bool {
+			coreProvider := &operatorv1.CoreProvider{}
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: coreProviderName}
+			if err := k8sclient.Get(ctx, key, coreProvider); err != nil {
+				return false
+			}
+
+			for _, c := range coreProvider.Status.Conditions {
+				if c.Type == operatorv1.ProviderInstalledCondition && c.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}, timeout).Should(Equal(true))
+
+		By("Waiting for status.IntalledVersion to be set")
+		Eventually(func() bool {
+			coreProvider := &operatorv1.CoreProvider{}
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: coreProviderName}
+			if err := k8sclient.Get(ctx, key, coreProvider); err != nil {
+				return false
+			}
+
+			if coreProvider.Status.InstalledVersion != nil && *coreProvider.Status.InstalledVersion == coreProvider.Spec.Version {
+				return true
+			}
+			return false
+		}, timeout).Should(Equal(true))
+	})
+
+	It("should successfully create and delete an InfrastructureProvider for OCI", func() {
+		k8sclient := bootstrapClusterProxy.GetClient()
+		infraProvider := &operatorv1.InfrastructureProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ociInfrastructureProviderName,
+				Namespace: operatorNamespace,
+			},
+			Spec: operatorv1.InfrastructureProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{
+					Version: ociInfrastructureProviderVersion,
+				},
+			},
+		}
+
+		Expect(k8sclient.Create(ctx, infraProvider)).To(Succeed())
+
+		By("Waiting for the infrastructure provider to be ready")
+		Eventually(func() bool {
+			infraProvider := &operatorv1.InfrastructureProvider{}
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: ociInfrastructureProviderName}
+			if err := k8sclient.Get(ctx, key, infraProvider); err != nil {
+				return false
+			}
+
+			for _, c := range infraProvider.Status.Conditions {
+				if c.Type == operatorv1.ProviderInstalledCondition && c.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}, timeout).Should(Equal(true))
+
+		By("Waiting for status.IntalledVersion to be set")
+		Eventually(func() bool {
+			infraProvider := &operatorv1.InfrastructureProvider{}
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: ociInfrastructureProviderName}
+			if err := k8sclient.Get(ctx, key, infraProvider); err != nil {
+				return false
+			}
+
+			if infraProvider.Status.InstalledVersion != nil && *infraProvider.Status.InstalledVersion == infraProvider.Spec.Version {
+				return true
+			}
+			return false
+		}, timeout).Should(Equal(true))
+
+		By("Ensure that the created config map has correct annotation")
+		cm := &corev1.ConfigMap{}
+		cmName := fmt.Sprintf("infrastructure-%s-%s", ociInfrastructureProviderName, ociInfrastructureProviderVersion)
+		key := client.ObjectKey{Namespace: operatorNamespace, Name: cmName}
+		Expect(k8sclient.Get(ctx, key, cm)).To(Succeed())
+
+		Expect(cm.GetAnnotations()[compressedAnnotation]).To(Equal("true"))
+
+		Expect(cm.BinaryData[componentsConfigMapKey]).ToNot(BeEmpty())
+
+		Expect(k8sclient.Delete(ctx, infraProvider)).To(Succeed())
+
+		By("Waiting for the infrastructure provider deployment to be created")
+		Eventually(func() bool {
+			deployment := &appsv1.Deployment{}
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: ociInfrastructureProviderDeploymentName}
+
+			return k8sclient.Get(ctx, key, deployment) == nil
+		}, timeout).Should(Equal(true))
+
+		By("Waiting for the infrastructure provider deployment to be deleted")
+		Eventually(func() bool {
+			deployment := &appsv1.Deployment{}
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: ociInfrastructureProviderDeploymentName}
+			isInfraProviderDeleted, err := waitForObjectToBeDeleted(k8sclient, ctx, key, deployment)
+			if err != nil {
+				return false
+			}
+			return isInfraProviderDeleted
+		}, timeout).Should(Equal(true))
+	})
+
+	It("should successfully delete a CoreProvider", func() {
+		k8sclient := bootstrapClusterProxy.GetClient()
+		coreProvider := &operatorv1.CoreProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      coreProviderName,
+				Namespace: operatorNamespace,
+			},
+			Spec: operatorv1.CoreProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{},
+			},
+		}
+
+		Expect(k8sclient.Delete(ctx, coreProvider)).To(Succeed())
+
+		By("Waiting for the core provider deployment to be deleted")
+		Eventually(func() bool {
+			deployment := &appsv1.Deployment{}
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: coreProviderDeploymentName}
+			isReady, err := waitForObjectToBeDeleted(k8sclient, ctx, key, deployment)
+			if err != nil {
+				return false
+			}
+			return isReady
+		}, timeout).Should(Equal(true))
+
+		By("Waiting for the core provider object to be deleted")
+		Eventually(func() bool {
+			key := client.ObjectKey{Namespace: operatorNamespace, Name: coreProviderName}
+			isReady, err := waitForObjectToBeDeleted(k8sclient, ctx, key, coreProvider)
+			if err != nil {
+				return false
+			}
+			return isReady
+		}, timeout).Should(Equal(true))
+	})
+})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
By default we download capi provider manifests from the provided URL and store it in a confimap to reuse later. Currently there is a limit on the configmap size, which is 1mb. If we the manifests size is bigger then the installation process fails.

To avoid it we will compress manifests if they can't be stored in the configmap directly.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #20
