### PR TITLE
🌱 compile capi operator binary only once in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,19 +38,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Copy the sources
 COPY ./ ./
 
-# Cache the go build into the the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
-RUN --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/go/pkg/mod \
-  go build cmd/main.go
-
 # Build
 ARG path=cmd/main.go
 ARG ARCH
 ARG ldflags
 
-# Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
-RUN --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/go/pkg/mod \
+# Do not force rebuild of up-to-date packages (do not use -a)
+RUN --mount=type=cache,target=/go/pkg/mod \
   CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
   go build -ldflags "${ldflags} -extldflags '-static'" \
   -o manager ${path}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Now we compile it twice, which seems unnecessary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
