### PR TITLE
🐛 Support installing providers with custom names in air-gapped environments

### DIFF
--- a/internal/controller/manifests_downloader.go
+++ b/internal/controller/manifests_downloader.go
@@ -50,8 +50,6 @@ const (
 func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	log.Info("Downloading provider manifests")
-
 	// Return immediately if a custom config map is used instead of a url.
 	if p.provider.GetSpec().FetchConfig != nil && p.provider.GetSpec().FetchConfig.Selector != nil {
 		log.V(5).Info("Custom config map is used, skip downloading provider manifests")
@@ -74,6 +72,8 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 
 		return reconcile.Result{}, nil
 	}
+
+	log.Info("Downloading provider manifests")
 
 	repo, err := repositoryFactory(p.providerConfig, p.configClient.Variables())
 	if err != nil {

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -218,9 +218,23 @@ func (p *phaseReconciler) secretReader(ctx context.Context) (configclient.Reader
 	}
 
 	// If provided store fetch config url in memory reader.
-	if p.provider.GetSpec().FetchConfig != nil && p.provider.GetSpec().FetchConfig.URL != "" {
-		log.Info("Custom fetch configuration url was provided")
-		return mr.AddProvider(p.provider.GetName(), util.ClusterctlProviderType(p.provider), p.provider.GetSpec().FetchConfig.URL)
+	if p.provider.GetSpec().FetchConfig != nil {
+		if p.provider.GetSpec().FetchConfig.URL != "" {
+			log.Info("Custom fetch configuration url was provided")
+			return mr.AddProvider(p.provider.GetName(), util.ClusterctlProviderType(p.provider), p.provider.GetSpec().FetchConfig.URL)
+		}
+
+		if p.provider.GetSpec().FetchConfig.Selector != nil {
+			log.Info("Custom fetch configuration config map was provided")
+
+			// To register a new provider from the config map, we need to specify a URL with a valid
+			// format. However, since we're using data from a local config map, URLs are not needed.
+			// As a workaround, we add a fake but well-formatted URL.
+
+			fakeURL := "https://example.com/my-provider"
+
+			return mr.AddProvider(p.provider.GetName(), util.ClusterctlProviderType(p.provider), fakeURL)
+		}
 	}
 
 	return mr, nil


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently we do not support installation of providers with custom names for air-gapped environments. It happens because we inject new names in the list of known providers only for those with URL specified, ignoring config maps.
This PR fixes it, so we support both URL and ConfigMap installations with custom names.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
