### PR TITLE
🌱 Add a preflight check to validate core provider name

### DIFF
--- a/api/v1alpha1/conditions_consts.go
+++ b/api/v1alpha1/conditions_consts.go
@@ -29,6 +29,9 @@ const (
 	// IncorrectVersionFormatReason documents that the provider version is in the incorrect format.
 	IncorrectVersionFormatReason = "IncorrectVersionFormat"
 
+	// IncorrectCoreProviderNameReason documents that the provider name is incorrect.
+	IncorrectCoreProviderNameReason = "IncorrectCoreProviderNameReason"
+
 	// EmptyVersionReason documents that the provider version is in the incorrect format.
 	EmptyVersionReason = "EmptyVersionReason"
 

--- a/internal/controller/preflight_checks_test.go
+++ b/internal/controller/preflight_checks_test.go
@@ -75,6 +75,42 @@ func TestPreflightChecks(t *testing.T) {
 			},
 		},
 		{
+			name:          "core provider with incorrect name, preflight check failed",
+			expectedError: true,
+			providers: []genericprovider.GenericProvider{
+				&genericprovider.CoreProviderWrapper{
+					CoreProvider: &operatorv1.CoreProvider{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "my-fancy-cluster-api",
+							Namespace: namespaceName1,
+						},
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "CoreProvider",
+							APIVersion: "operator.cluster.x-k8s.io/v1alpha1",
+						},
+						Spec: operatorv1.CoreProviderSpec{
+							ProviderSpec: operatorv1.ProviderSpec{
+								Version: "v1.0.0",
+								FetchConfig: &operatorv1.FetchConfiguration{
+									URL: "https://example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCondition: clusterv1.Condition{
+				Type:     operatorv1.PreflightCheckCondition,
+				Reason:   operatorv1.IncorrectCoreProviderNameReason,
+				Severity: clusterv1.ConditionSeverityError,
+				Message:  "Incorrect CoreProvider name: my-fancy-cluster-api. It should be cluster-api",
+				Status:   corev1.ConditionFalse,
+			},
+			providerList: &genericprovider.CoreProviderListWrapper{
+				CoreProviderList: &operatorv1.CoreProviderList{},
+			},
+		},
+		{
 			name:          "two core providers were created, preflight check failed",
 			expectedError: true,
 			providers: []genericprovider.GenericProvider{
@@ -562,20 +598,20 @@ func TestPreflightChecks(t *testing.T) {
 			},
 		},
 		{
-			name:          "custom Core Provider without fetch config, preflight check failed",
+			name:          "custom Infrastructure Provider without fetch config, preflight check failed",
 			expectedError: true,
 			providers: []genericprovider.GenericProvider{
-				&genericprovider.CoreProviderWrapper{
-					CoreProvider: &operatorv1.CoreProvider{
+				&genericprovider.InfrastructureProviderWrapper{
+					InfrastructureProvider: &operatorv1.InfrastructureProvider{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "my-custom-cluster-api",
+							Name:      "my-custom-aws",
 							Namespace: namespaceName1,
 						},
 						TypeMeta: metav1.TypeMeta{
-							Kind:       "CoreProvider",
+							Kind:       "InfrastructureProvider",
 							APIVersion: "operator.cluster.x-k8s.io/v1alpha1",
 						},
-						Spec: operatorv1.CoreProviderSpec{
+						Spec: operatorv1.InfrastructureProviderSpec{
 							ProviderSpec: operatorv1.ProviderSpec{
 								Version: "v1.0.0",
 							},
@@ -595,20 +631,20 @@ func TestPreflightChecks(t *testing.T) {
 			},
 		},
 		{
-			name:          "custom Core Provider with fetch config with empty values, preflight check failed",
+			name:          "custom Infrastructure Provider with fetch config with empty values, preflight check failed",
 			expectedError: true,
 			providers: []genericprovider.GenericProvider{
-				&genericprovider.CoreProviderWrapper{
-					CoreProvider: &operatorv1.CoreProvider{
+				&genericprovider.InfrastructureProviderWrapper{
+					InfrastructureProvider: &operatorv1.InfrastructureProvider{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "my-custom-cluster-api",
+							Name:      "my-custom-aws",
 							Namespace: namespaceName1,
 						},
 						TypeMeta: metav1.TypeMeta{
-							Kind:       "CoreProvider",
+							Kind:       "InfrastructureProvider",
 							APIVersion: "operator.cluster.x-k8s.io/v1alpha1",
 						},
-						Spec: operatorv1.CoreProviderSpec{
+						Spec: operatorv1.InfrastructureProviderSpec{
 							ProviderSpec: operatorv1.ProviderSpec{
 								Version: "v1.0.0",
 								FetchConfig: &operatorv1.FetchConfiguration{


### PR DESCRIPTION
When you try to install a Core Provider with a name different from "cluster-api", clusterctl validation [fails](https://github.com/kubernetes-sigs/cluster-api/blob/main/cmd/clusterctl/client/config/providers_client.go#L414-L416).
After that CAPI operator puts a vague error description in the logs and doesn't add anything meaningful to the provider status.

This PR adds a pre-flight check to compare the Core Provider name with the expected name, allowing for earlier failure and an informative update to the provider status.

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
