### PR TITLE
🐛 Fix incorrect fieldSpecs paths

### DIFF
--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -5,12 +5,12 @@ nameReference:
   fieldSpecs:
   - kind: CustomResourceDefinition
     group: apiextensions.k8s.io
-    path: spec/conversion/webhookClientConfig/service/name
+    path: spec/conversion/webhook/clientConfig/service/name
 
 namespace:
 - kind: CustomResourceDefinition
   group: apiextensions.k8s.io
-  path: spec/conversion/webhookClientConfig/service/namespace
+  path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
 
 varReference:

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -16,7 +16,7 @@ spec:
       clientConfig:
         caBundle: Cg==
         service:
-          name: webhook-service
+          name: capi-operator-webhook-service
           namespace: 'capi-operator-system'
           path: /convert
       conversionReviewVersions:
@@ -1577,7 +1577,7 @@ spec:
       clientConfig:
         caBundle: Cg==
         service:
-          name: webhook-service
+          name: capi-operator-webhook-service
           namespace: 'capi-operator-system'
           path: /convert
       conversionReviewVersions:
@@ -3140,7 +3140,7 @@ spec:
       clientConfig:
         caBundle: Cg==
         service:
-          name: webhook-service
+          name: capi-operator-webhook-service
           namespace: 'capi-operator-system'
           path: /convert
       conversionReviewVersions:
@@ -4701,7 +4701,7 @@ spec:
       clientConfig:
         caBundle: Cg==
         service:
-          name: webhook-service
+          name: capi-operator-webhook-service
           namespace: 'capi-operator-system'
           path: /convert
       conversionReviewVersions:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Several paths for name references are not correct and therefore kustomize doesn't substitute right values there.

This PR fixes it and makes kustomize works correctly.

Reference patch: https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/config/crd/patches/webhook_in_coreproviders.yaml#L18

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
