### PR TITLE
🐛 Fix imagePullSecrets bug

### DIFF
--- a/hack/charts/cluster-api-operator/templates/deployment.yaml
+++ b/hack/charts/cluster-api-operator/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
       securityContext:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         {{- if .Values.logLevel }}
@@ -80,10 +84,6 @@ spec:
         image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
         {{- end }}
         imagePullPolicy: {{ .Values.image.manager.pullPolicy }}
-        {{- with .Values.imagePullSecrets.manager }}
-        imagePullSecrets:
-        {{- toYaml . | nindent 12 }}
-        {{- end }}
         name: manager
         ports:
         - containerPort: 9443
@@ -112,10 +112,6 @@ spec:
         image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
         {{- end }}
         imagePullPolicy: {{ .Values.image.kubeRBACProxy.pullPolicy }}
-        {{- with .Values.imagePullSecrets.kubeRBACProxy }}
-        imagePullSecrets:
-        {{- toYaml . | nindent 12 }}
-        {{- end }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -32,9 +32,7 @@ image:
     pullPolicy: IfNotPresent
 healthAddr: ":8081"
 metricsBindAddr: "127.0.0.1:8080"
-imagePullSecrets:
-  manager: {}
-  kubeRBACProxy: {}
+imagePullSecrets: {}
 resources:
   manager:
     limits:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Based on https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers `imagePullSecrets` is part of the PodSpec, not ContainerSpec

This PR fix this bug by moving the `imagePullSecrets` to the right indentation, and also adjusts the values files accordingly.

Without this fix, the helm chart is not usable 😞 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Maybe a tool like https://github.com/yannh/kubeconform ran as a CI step might help in catching similar issues in the future
