### PR TITLE
⚠️ Use v1alpha2 manifests in the helm chart

### DIFF
--- a/hack/charts/cluster-api-operator/templates/bootstrap-conditions.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap-conditions.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: capi-system
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -18,12 +18,13 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if .Values.secretName }}
+{{- with .Values.configSecret }}
 spec:
-  secretName: {{ .Values.secretName }}
-{{- if .Values.secretNamespace }}
-  secretNamespace: {{ .Values.secretNamespace }}
-{{- end }}
+  configSecret:
+    name: {{ .name }}
+    {{- if .namespace }}
+    namespace: {{ .namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -30,7 +30,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: {{ $bootstrapNamespace }}
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: {{ $bootstrapName }}
@@ -38,17 +38,18 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if or $bootstrapVersion $.Values.secretName }}
+{{- if or $bootstrapVersion $.Values.configSecret.name }}
 spec:
 {{- end}}
 {{- if $bootstrapVersion }}
   version: {{ $bootstrapVersion }}
 {{- end }}
-{{- if $.Values.secretName }}
-  secretName: {{ $.Values.secretName }}
-{{- end }}
-{{- if $.Values.secretNamespace }}
-  secretNamespace: {{ $.Values.secretNamespace }}
+{{- if $.Values.configSecret.name }}
+  configSecret:
+    name: {{ $.Values.configSecret.name }}
+    {{- if $.Values.configSecret.namespace }}
+    namespace: {{ $.Values.configSecret.namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/control-plane-conditions.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane-conditions.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: capi-system
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -18,12 +18,13 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if .Values.secretName }}
+{{- with .Values.configSecret }}
 spec:
-  secretName: {{ .Values.secretName }}
-{{- if .Values.secretNamespace }}
-  secretNamespace: {{ .Values.secretNamespace }}
-{{- end }}
+  configSecret:
+    name: {{ .name }}
+    {{- if .namespace }}
+    namespace: {{ .namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -30,7 +30,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: {{ $controlPlaneNamespace }}
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: {{ $controlPlaneName }}
@@ -38,17 +38,18 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if or $controlPlaneVersion $.Values.secretName }}
+{{- if or $controlPlaneVersion $.Values.configSecret.name }}
 spec:
 {{- end}}
 {{- if $controlPlaneVersion }}
   version: {{ $controlPlaneVersion }}
 {{- end }}
-{{- if $.Values.secretName }}
-  secretName: {{ $.Values.secretName }}
-{{- end }}
-{{- if $.Values.secretNamespace }}
-  secretNamespace: {{ $.Values.secretNamespace }}
+{{- if $.Values.configSecret.name }}
+  configSecret:
+    name: {{ $.Values.configSecret.name }}
+    {{- if $.Values.configSecret.namespace }}
+    namespace: {{ $.Values.configSecret.namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -29,7 +29,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: {{ $coreNamespace }}
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: {{ $coreName }}
@@ -37,16 +37,17 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if or $coreVersion .Values.secretName }}
+{{- if or $coreVersion $.Values.configSecret.name }}
 spec:
 {{- end}}
 {{- if $coreVersion }}
   version: {{ $coreVersion }}
 {{- end }}
-{{- if .Values.secretName }}
-  secretName: {{ .Values.secretName }}
-{{- end }}
-{{- if .Values.secretNamespace }}
-  secretNamespace: {{ .Values.secretNamespace }}
+{{- if $.Values.configSecret.name }}
+  configSecret:
+    name: {{ $.Values.configSecret.name }}
+    {{- if $.Values.configSecret.namespace }}
+    namespace: {{ $.Values.configSecret.namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.infrastructure }}
+
 # Deploy core, bootstrap, and infrastructure components if not specified
 {{- if not .Values.core }}
 ---
@@ -10,7 +11,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: capi-system
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -18,14 +19,16 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if .Values.secretName }}
+{{- with .Values.configSecret }}
 spec:
-  secretName: {{ .Values.secretName }}
-{{- if .Values.secretNamespace }}
-  secretNamespace: {{ .Values.secretNamespace }}
+  configSecret:
+    name: {{ .name }}
+    {{- if .namespace }}
+    namespace: {{ .namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}
+
 {{- if not .Values.bootstrap }}
 ---
 apiVersion: v1
@@ -36,7 +39,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: capi-kubeadm-bootstrap-system
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -44,14 +47,16 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if .Values.secretName }}
+{{- with .Values.configSecret }}
 spec:
-  secretName: {{ .Values.secretName }}
-{{- if .Values.secretNamespace }}
-  secretNamespace: {{ .Values.secretNamespace }}
+  configSecret:
+    name: {{ .name }}
+    {{- if .namespace }}
+    namespace: {{ .namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}
+
 {{- if not .Values.controlPlane }}
 ---
 apiVersion: v1
@@ -62,7 +67,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: capi-kubeadm-control-plane-system
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -70,12 +75,14 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if .Values.secretName }}
+{{- with .Values.configSecret }}
 spec:
-  secretName: {{ .Values.secretName }}
-{{- if .Values.secretNamespace }}
-  secretNamespace: {{ .Values.secretNamespace }}
+  configSecret:
+    name: {{ .name }}
+    {{- if .namespace }}
+    namespace: {{ .namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}
+
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -30,7 +30,7 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: {{ $infrastructureNamespace }}
 ---
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: {{ $infrastructureName }}
@@ -38,17 +38,18 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
-{{- if or $infrastructureVersion $.Values.secretName }}
+{{- if or $infrastructureVersion $.Values.configSecret.name }}
 spec:
 {{- end }}
 {{- if $infrastructureVersion }}
   version: {{ $infrastructureVersion }}
 {{- end }}
-{{- if $.Values.secretName }}
-  secretName: {{ $.Values.secretName }}
-{{- end }}
-{{- if $.Values.secretNamespace }}
-  secretNamespace: {{ $.Values.secretNamespace }}
+{{- if $.Values.configSecret.name }}
+  configSecret:
+    name: {{ $.Values.configSecret.name }}
+    {{- if $.Values.configSecret.namespace }}
+    namespace: {{ $.Values.configSecret.namespace }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -13,8 +13,7 @@ controlPlane: ""
 infrastructure: ""
 # ---
 # Common configuration secret options
-secretName: ""
-secretNamespace: ""
+configSecret: {}
 # ---
 # CAPI operator deployment options
 logLevel: 2

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -53,12 +53,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy all providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"core":            "capi-custom-ns:cluster-api:v1.4.2",
-			"controlPlane":    "kubeadm-control-plane-custom-ns:kubeadm:v1.4.2",
-			"bootstrap":       "kubeadm-bootstrap-custom-ns:kubeadm:v1.4.2",
-			"infrastructure":  "capd-custom-ns:docker:v1.4.2",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"core":                   "capi-custom-ns:cluster-api:v1.4.2",
+			"controlPlane":           "kubeadm-control-plane-custom-ns:kubeadm:v1.4.2",
+			"bootstrap":              "kubeadm-bootstrap-custom-ns:kubeadm:v1.4.2",
+			"infrastructure":         "capd-custom-ns:docker:v1.4.2",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -69,12 +69,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy all providers with custom versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"core":            "cluster-api:v1.4.2",
-			"controlPlane":    "kubeadm:v1.4.2",
-			"bootstrap":       "kubeadm:v1.4.2",
-			"infrastructure":  "docker:v1.4.2",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"core":                   "cluster-api:v1.4.2",
+			"controlPlane":           "kubeadm:v1.4.2",
+			"bootstrap":              "kubeadm:v1.4.2",
+			"infrastructure":         "docker:v1.4.2",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -85,12 +85,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy all providers with latest version", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"core":            "cluster-api",
-			"controlPlane":    "kubeadm",
-			"bootstrap":       "kubeadm",
-			"infrastructure":  "docker",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"core":                   "cluster-api",
+			"controlPlane":           "kubeadm",
+			"bootstrap":              "kubeadm",
+			"infrastructure":         "docker",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -101,9 +101,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core, bootstrap, control plane when only infra is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"infrastructure":  "docker",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"infrastructure":         "docker",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -114,9 +114,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core when only bootstrap is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"bootstrap":       "kubeadm",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"bootstrap":              "kubeadm",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -127,9 +127,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core when only control plane is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"controlPlane":    "kubeadm",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"controlPlane":           "kubeadm",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -140,9 +140,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy multiple infra providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"infrastructure":  "capd-custom-ns:docker:v1.4.2;capz-custom-ns:azure:v1.10.0",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"infrastructure":         "capd-custom-ns:docker:v1.4.2;capz-custom-ns:azure:v1.10.0",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -153,9 +153,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy multiple control plane providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"controlPlane":    "kubeadm-control-plane-custom-ns:kubeadm:v1.4.2;rke2-control-plane-custom-ns:rke2:v0.3.0",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"controlPlane":           "kubeadm-control-plane-custom-ns:kubeadm:v1.4.2;rke2-control-plane-custom-ns:rke2:v0.3.0",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -166,9 +166,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy multiple bootstrap providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"secretName":      "test-secret-name",
-			"secretNamespace": "test-secret-namespace",
-			"bootstrap":       "kubeadm-bootstrap-custom-ns:kubeadm:v1.4.2;rke2-bootstrap-custom-ns:rke2:v0.3.0",
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"bootstrap":              "kubeadm-bootstrap-custom-ns:kubeadm:v1.4.2;rke2-bootstrap-custom-ns:rke2:v0.3.0",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())

--- a/test/e2e/resources/all-providers-custom-ns-versions.yaml
+++ b/test/e2e/resources/all-providers-custom-ns-versions.yaml
@@ -36,7 +36,7 @@ metadata:
   name: capd-custom-ns
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -46,11 +46,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -60,11 +61,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/core.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -74,11 +76,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: docker
@@ -88,5 +91,6 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/all-providers-custom-versions.yaml
+++ b/test/e2e/resources/all-providers-custom-versions.yaml
@@ -36,7 +36,7 @@ metadata:
   name: docker-infrastructure-system
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -46,11 +46,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -60,11 +61,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/core.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -74,11 +76,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: docker
@@ -88,5 +91,6 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/all-providers-latest-versions.yaml
+++ b/test/e2e/resources/all-providers-latest-versions.yaml
@@ -36,7 +36,7 @@ metadata:
   name: docker-infrastructure-system
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -45,11 +45,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -58,11 +59,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/core.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -71,11 +73,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: docker
@@ -84,5 +87,6 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/multiple-bootstrap-custom-ns-versions.yaml
+++ b/test/e2e/resources/multiple-bootstrap-custom-ns-versions.yaml
@@ -27,7 +27,7 @@ metadata:
   name: rke2-bootstrap-custom-ns
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -37,11 +37,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: rke2
@@ -51,11 +52,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v0.3.0
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/bootstrap-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -64,5 +66,6 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/multiple-control-plane-custom-ns-versions.yaml
+++ b/test/e2e/resources/multiple-control-plane-custom-ns-versions.yaml
@@ -27,7 +27,7 @@ metadata:
   name: rke2-control-plane-custom-ns
 ---
 # Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -37,11 +37,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: rke2
@@ -51,11 +52,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v0.3.0
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/control-plane-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -64,5 +66,6 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/multiple-infra-custom-ns-versions.yaml
+++ b/test/e2e/resources/multiple-infra-custom-ns-versions.yaml
@@ -45,7 +45,7 @@ metadata:
   name: capz-custom-ns
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -54,11 +54,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -67,11 +68,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -80,11 +82,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: docker
@@ -94,11 +97,12 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.4.2
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: azure
@@ -108,5 +112,6 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   version: v1.10.0
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/only-bootstrap.yaml
+++ b/test/e2e/resources/only-bootstrap.yaml
@@ -18,7 +18,7 @@ metadata:
   name: kubeadm-bootstrap-system
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -27,11 +27,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/bootstrap-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -40,5 +41,6 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/only-control-plane.yaml
+++ b/test/e2e/resources/only-control-plane.yaml
@@ -18,7 +18,7 @@ metadata:
   name: kubeadm-control-plane-system
 ---
 # Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -27,11 +27,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/control-plane-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -40,5 +41,6 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/only-infra.yaml
+++ b/test/e2e/resources/only-infra.yaml
@@ -36,7 +36,7 @@ metadata:
   name: docker-infrastructure-system
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
@@ -45,11 +45,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
@@ -58,11 +59,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
@@ -71,11 +73,12 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha1
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: docker
@@ -84,5 +87,6 @@ metadata:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "2"
 spec:
-  secretName: test-secret-name
-  secretNamespace: test-secret-namespace
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

We introduced v1alpha2 API in https://github.com/kubernetes-sigs/cluster-api-operator/pull/190. In this PR we update manifests in the helm chart to the new version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
