### PR TITLE
🌱 Add dependabot groups. Allow additional patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,17 +16,30 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      ## group all dependencies with a k8s.io prefix into a single PR.
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
+      ## group all dependencies with a github.com/onsi prefix into a single PR.
+      ginkgo:
+        patterns: [ "github.com/onsi/*" ]
     ignore:
       # Ignore Cluster-API as its upgraded manually.
       - dependency-name: "sigs.k8s.io/cluster-api"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "sigs.k8s.io/cluster-api/test"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "go.etcd.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "google.golang.org/grpc"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     commit-message:
       prefix: ":seedling:"
     labels:
@@ -37,17 +50,27 @@ updates:
     directory: "/test"
     schedule:
       interval: "weekly"
+    ## group all dependencies with a k8s.io prefix into a single PR.
+    groups:
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
     ignore:
       # Ignore Cluster-API as its upgraded manually.
       - dependency-name: "sigs.k8s.io/cluster-api"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "sigs.k8s.io/cluster-api/test"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "go.etcd.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "google.golang.org/grpc"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     commit-message:
       prefix: ":seedling:"
     labels:
@@ -58,17 +81,27 @@ updates:
     directory: "/hack/tools"
     schedule:
       interval: "weekly"
+    ## group all dependencies with a k8s.io prefix into a single PR.
+    groups:
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
     ignore:
       # Ignore Cluster-API as its upgraded manually.
       - dependency-name: "sigs.k8s.io/cluster-api"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "sigs.k8s.io/cluster-api/test"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "go.etcd.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "google.golang.org/grpc"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     commit-message:
       prefix: ":seedling:"
     labels:
@@ -79,17 +112,27 @@ updates:
     directory: "/hack/chart-update"
     schedule:
       interval: "weekly"
+    ## group all dependencies with a k8s.io prefix into a single PR.
+    groups:
+      kubernetes:
+        patterns: [ "k8s.io/*" ]
     ignore:
       # Ignore Cluster-API as its upgraded manually.
       - dependency-name: "sigs.k8s.io/cluster-api"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "sigs.k8s.io/cluster-api/test"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore controller-runtime as its upgraded manually.
       - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "go.etcd.io/*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: "google.golang.org/grpc"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     commit-message:
       prefix: ":seedling:"
     labels:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Allow patch updates for the ignored dependencies in our dependabot config and group the k8s.io dependencies to reduce the number of individual PRs.

Inspired by: https://github.com/kubernetes-sigs/cluster-api/pull/9263

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
