### PR TITLE
:bug: Fix url fetch from gitlab repository

### DIFF
--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -548,7 +548,7 @@ func repositoryFactory(providerConfig configclient.Provider, configVariablesClie
 	}
 
 	// if the url is a GitLab repository
-	if strings.HasPrefix(rURL.Host, gitlabHostPrefix) && strings.HasPrefix(rURL.RawPath, gitlabPackagesAPIPrefix) {
+	if strings.HasPrefix(rURL.Host, gitlabHostPrefix) && strings.HasPrefix(rURL.Path, gitlabPackagesAPIPrefix) {
 		repo, err := repository.NewGitLabRepository(providerConfig, configVariablesClient)
 		if err != nil {
 			return nil, fmt.Errorf("error creating the GitLab repository client: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bug with gitlab fetching.

url.RawPath is optional, and fulfilled only if provider 'fetchUrl' contains urlencoded characters.  It's better to use Url.Path
