### PR TITLE
:bug: Fix leader elect helm chart args

### DIFF
--- a/hack/charts/cluster-api-operator/templates/deployment.yaml
+++ b/hack/charts/cluster-api-operator/templates/deployment.yaml
@@ -69,13 +69,13 @@ spec:
         {{- with .Values.leaderElection }}
         - --leader-elect={{ .enabled }}
         {{- if .leaseDuration }}
-        - --leader-election-lease-duration={{ .leaseDuration }}
+        - --leader-elect-lease-duration={{ .leaseDuration }}
         {{- end }}
         {{- if .renewDeadline }}
-        - --leader-election-renew-deadline={{ .renewDeadline }}
+        - --leader-elect-renew-deadline={{ .renewDeadline }}
         {{- end }}
         {{- if .retryPeriod }}
-        - --leader-election-retry-period={{ .retryPeriod }}
+        - --leader-elect-retry-period={{ .retryPeriod }}
         {{- end }}
         {{- end }}
         command:


### PR DESCRIPTION

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fix small typo in helm chart for leader election
related arguments

Related logs:
```
unknown flag: --leader-election-lease-duration
Usage of /manager:
      ...
      --leader-elect-lease-duration duration   Interval at which non-leader candidates will wait to force acquire leadership (duration string) (default 15s)
      --leader-elect-renew-deadline duration   Duration that the leading controller manager will retry refreshing leadership before giving up (duration string) (default 10s)
      --leader-elect-retry-period duration     Duration the LeaderElector clients should wait between tries of actions (duration string) (default 2s)
      ...
```


Would be nice if we can get a new helm chart version released after it is merged (although not critical to have)