### PR TITLE
🐛 Use absolute path to refer to operator installation from quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,9 +40,9 @@ Deploy Cluster API components with docker provider using a single command during
 helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure=docker --set cert-manager.enabled=true --set configSecret.name=${CREDENTIALS_SECRET_NAME} --set configSecret.namespace=${CREDENTIALS_SECRET_NAMESPACE}  --wait --timeout 90s
 ```
 
-Docker provider can be replaced by any provider supported by [clusterctl](https://cluster-api.sigs.k8s.io/reference/providers.html?highlight=hetz#infrastructure).
+Docker provider can be replaced by any provider supported by [clusterctl](https://cluster-api.sigs.k8s.io/reference/providers.html#infrastructure).
 
-Other options for installing Cluster API Operator are described in [full documentation](README.md#installation).
+Other options for installing Cluster API Operator are described in [full documentation](https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/docs/README.md#installation).
  
 # Example API Usage
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use absolute path to refer to operator installation from quickstart to be able to properly render it when referred to from the [CAPI book](https://main.cluster-api.sigs.k8s.io/user/quick-start-operator).

Also, removes highlighting of Hetzner provider in the reference link (I would assume it was typo and not intentional)

Note: currently link to "full documentation" in CAPI book refers to the doc in operator repo which can't be accessed and throws [not found error](https://main.cluster-api.sigs.k8s.io/user/README.html#installation), and we are replacing that with absolute path to make it possible to render it properly


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
