### PR TITLE
🌱 Add furkatgofurov7 to cluster-api-operator-admins list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,6 +18,7 @@ aliases:
   - Fedosin
   - alexander-demicev
   - damdo
+  - furkatgofurov7
 
   # non-admin folks who have write-access and can approve any PRs in the repo
   cluster-api-operator-maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding myself to the admins list mainly because I noticed this list will be used for kpromo image promotion PRs when releasing and tagging owners automatically in the [PR](https://github.com/kubernetes/k8s.io/pull/6081#issue-1994907757)

