### PR TITLE
✨ Allow clusterctl plugn to be installed with krew

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,14 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.20'
-      - name: Generate release artifacts
-        run: |
-          make release
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --timeout 60m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create draft GH release
         uses: softprops/action-gh-release@v1
         with:
@@ -33,4 +38,5 @@ jobs:
           files: |
             out/operator-components.yaml
             out/package/*
+            dist/*.tar.gz
           body: "TODO: Add release notes here."

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,21 @@
+before:
+  hooks:
+    - make release
+
+builds:
+- id: "clusterctl-operator"
+  main: ./cmd/plugin
+  binary: bin/clusterctl-operator
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm64
+archives:
+- id: clusterctl-operator
+  builds:
+  - clusterctl-operator
+  name_template: "clusterctl-operator_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
+  wrap_in_directory: false

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,42 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: operator
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/kubernetes-sigs/cluster-api-operator
+  shortDescription: Use this clusterctl plugin to bootstrap a management cluster for Cluster API with the Cluster API Operator.
+  description: |
+    Use this clusterctl plugin to bootstrap a management cluster for Cluster API with the Cluster API Operator.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: clusterctl-operator
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: clusterctl-operator
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: clusterctl-operator
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: clusterctl-operator
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
+    bin: clusterctl-operator.exe
+

--- a/Makefile
+++ b/Makefile
@@ -494,8 +494,9 @@ release-alias-tag: # Adds the tag to the last build tag.
 upload-staging-artifacts: ## Upload release artifacts to the staging bucket
 	gsutil cp $(RELEASE_DIR)/* gs://$(STAGING_BUCKET)/components/$(RELEASE_ALIAS_TAG)/
 
-.PHONY: update-helm-repo
-update-helm-repo:
+.PHONY: update-helm-plugin-repo
+update-helm-plugin-repo:
+	./hack/update-plugin-yaml.sh $(RELEASE_TAG)
 	./hack/update-helm-repo.sh $(RELEASE_TAG)
 
 .PHONY: promote-images

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,11 +45,11 @@ docker pull registry.k8s.io/capi-operator/cluster-api-operator:${RELEASE_TAG}
 
 4. Publish the release on Github.
 
-5. After release was published, switch back to main branch and update index.yaml. It's the source for operator helm chart repository.
+5. After release was published, switch back to main branch and update index.yaml and clusterctl-operator.yaml. It's the source for operator helm chart repository and local krew plugin manifest index.
 
 ```bash
 git checkout main
-make update-helm-repo
+make update-helm-plugin-repo
 ```
 
 6. Create a PR with the changes.

--- a/hack/update-plugin-yaml.sh
+++ b/hack/update-plugin-yaml.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+docker run --rm -v $REPO_ROOT:/home/app ghcr.io/rajatjindal/krew-release-bot:v0.0.46 krew-release-bot template --tag $1 --template-file .krew.yaml > $REPO_ROOT/plugins/clusterctl-operator.yaml


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
```bash
clusterctl krew index add operator https://github.com/kubernetes-sigs/cluster-api-operator.git
clusterctl krew install operator/operator
clusterctl operator … # Is available
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #328
