### PR TITLE
🐛 Fix version.sh script

### DIFF
--- a/cmd/plugin/cmd/version.go
+++ b/cmd/plugin/cmd/version.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/cluster-api/version"
+	"sigs.k8s.io/cluster-api-operator/version"
 )
 
 // Version provides the version information of CAPI operator.

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version implements version handling code.
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	gitMajor     string // major version, always numeric
+	gitMinor     string // minor version, numeric possibly followed by "+"
+	gitVersion   string // semantic version, derived by build scripts
+	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string // state of git tree, either "clean" or "dirty"
+	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+// Info exposes information about the version used for the current running code.
+type Info struct {
+	Major        string `json:"major,omitempty"`
+	Minor        string `json:"minor,omitempty"`
+	GitVersion   string `json:"gitVersion,omitempty"`
+	GitCommit    string `json:"gitCommit,omitempty"`
+	GitTreeState string `json:"gitTreeState,omitempty"`
+	BuildDate    string `json:"buildDate,omitempty"`
+	GoVersion    string `json:"goVersion,omitempty"`
+	Compiler     string `json:"compiler,omitempty"`
+	Platform     string `json:"platform,omitempty"`
+}
+
+// Get returns an Info object with all the information about the current running code.
+func Get() Info {
+	return Info{
+		Major:        gitMajor,
+		Minor:        gitMinor,
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// String returns info as a human-friendly version string.
+func (info Info) String() string {
+	return info.GitVersion
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Now when we create capi operator binaries, we don't set ldflags correctly, despite the fact we should.
Example:
```sh
➭ make plugin  
go build -trimpath -ldflags "" -o bin/clusterctl-operator cmd/plugin/main.go
```

After the fix we get correct results:
```sh
➭ make plugin
go build -trimpath -ldflags "-X 'sigs.k8s.io/cluster-api-operator/version.buildDate=2023-12-05T13:32:09Z' -X 'sigs.k8s.io/cluster-api-operator/version.gitCommit=0e775448a54900148578f54ac9230bfe39535205' -X 'sigs.k8s.io/cluster-api-operator/version.gitTreeState=dirty' -X 'sigs.k8s.io/cluster-api-operator/version.gitMajor=0' -X 'sigs.k8s.io/cluster-api-operator/version.gitMinor=7' -X 'sigs.k8s.io/cluster-api-operator/version.gitVersion=v0.7.0-34-0e775448a54900-dirty' -X 'sigs.k8s.io/cluster-api-operator/version.gitReleaseCommit=2d06d31872cba08da4ddbc5a5bde7ea7ad94913e'" -o bin/clusterctl-operator cmd/plugin/main.go
```
Plugin binary also has correct version
```
➭ ./bin/clusterctl-operator version       
CAPI operator version: &version.Info{Major:"0", Minor:"7", GitVersion:"v0.7.0-35-f4603f3a055152-dirty", GitCommit:"f4603f3a0551524163930fa8d046cad475e2e25d", GitTreeState:"dirty", BuildDate:"2023-12-05T13:39:04Z", GoVersion:"go1.21.4", Compiler:"gc", Platform:"darwin/arm64"}
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
