### PR TITLE
✨Allow to utilize providers from clusterctl.yaml file in /config/clusterctl.yaml

### DIFF
--- a/internal/controller/consts.go
+++ b/internal/controller/consts.go
@@ -27,4 +27,5 @@ const (
 	githubDomain            = "github.com"
 	gitlabHostPrefix        = "gitlab."
 	gitlabPackagesAPIPrefix = "/api/v4/projects/"
+	configPath              = "/config/clusterctl.yaml"
 )

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -72,6 +72,8 @@ func TestSecretReader(t *testing.T) {
 	testValue1 := "test-value1"
 	testKey2 := "test-key2"
 	testValue2 := "test-value2"
+	testKey3 := "test-key3"
+	testValue3 := "test-value3"
 
 	g.Expect(fakeclient.Create(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,7 +86,7 @@ func TestSecretReader(t *testing.T) {
 		},
 	})).To(Succeed())
 
-	configreader, err := p.secretReader(context.TODO())
+	configreader, err := p.secretReader(context.TODO(), configclient.NewProvider(testKey3, testValue3, clusterctlv1.CoreProviderType))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	expectedValue1, err := configreader.Get(testKey1)
@@ -97,7 +99,13 @@ func TestSecretReader(t *testing.T) {
 
 	exptectedProviderData, err := configreader.Get("providers")
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(exptectedProviderData).To(Equal("- name: cluster-api\n  type: CoreProvider\n  url: https://example.com\n"))
+	g.Expect(exptectedProviderData).To(Equal(`- name: test-key3
+  type: CoreProvider
+  url: test-value3
+- name: cluster-api
+  type: CoreProvider
+  url: https://example.com
+`))
 }
 
 func TestConfigmapRepository(t *testing.T) {

--- a/internal/controller/preflight_checks.go
+++ b/internal/controller/preflight_checks.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/google/go-github/v52/github"
 	"golang.org/x/oauth2"
@@ -230,8 +231,15 @@ func coreProviderIsReady(ctx context.Context, c client.Client) (bool, error) {
 // The list of known providers can be found here:
 // https://github.com/kubernetes-sigs/cluster-api/blob/main/cmd/clusterctl/client/config/providers_client.go
 func isPredefinedProvider(ctx context.Context, providerName string, providerType clusterctlv1.ProviderType) (bool, error) {
+	path := configPath
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		path = ""
+	} else if err != nil {
+		return false, err
+	}
+
 	// Initialize a client that contains predefined providers only.
-	configClient, err := configclient.New(ctx, "")
+	configClient, err := configclient.New(ctx, path)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This allows to pass a default clusterctl.yaml file to the operator to fetch provider list from.
The file should be located under `/config/clusterctl.yaml`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
