### PR TITLE
🐛 Prevent propagation of OwnerReferences from provider manifests

### DIFF
--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -58,7 +58,12 @@ func customizeObjectsFn(provider genericprovider.GenericProvider) func(objs []un
 
 			if o.GetNamespace() != "" {
 				// only set the ownership on namespaced objects.
-				o.SetOwnerReferences(util.EnsureOwnerRef(provider.GetOwnerReferences(),
+				ownerReferences := o.GetOwnerReferences()
+				if ownerReferences == nil {
+					ownerReferences = []metav1.OwnerReference{}
+				}
+
+				o.SetOwnerReferences(util.EnsureOwnerRef(ownerReferences,
 					metav1.OwnerReference{
 						APIVersion: operatorv1.GroupVersion.String(),
 						Kind:       provider.GetObjectKind().GroupVersionKind().Kind,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Healthcheck implementation expects deployment availability and an ownership reference pointing to the owner resource, to mark the provider as ready. However if the provider manifest is owned by some other resource, the second ownership reference appears on the deployment too, which is unexpected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #350 
