### PR TITLE
🌱 Remove downgrade e2e tests

### DIFF
--- a/test/e2e/minimal_configuration_test.go
+++ b/test/e2e/minimal_configuration_test.go
@@ -267,33 +267,6 @@ metadata:
 			e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 	})
 
-	It("should successfully downgrade a CoreProvider (latest -> v1.4.2)", func() {
-		bootstrapCluster := bootstrapClusterProxy.GetClient()
-		coreProvider := &operatorv1.CoreProvider{}
-		key := client.ObjectKey{Namespace: operatorNamespace, Name: coreProviderName}
-		Expect(bootstrapCluster.Get(ctx, key, coreProvider)).To(Succeed())
-
-		coreProvider.Spec.Version = previousCAPIVersion
-
-		Expect(bootstrapCluster.Update(ctx, coreProvider)).To(Succeed())
-
-		By("Waiting for the core provider deployment to be ready")
-		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
-			Getter:     bootstrapCluster,
-			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: coreProviderDeploymentName, Namespace: operatorNamespace}},
-		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
-
-		By("Waiting for core provider to be ready and status.InstalledVersion to be set")
-		WaitFor(ctx, For(coreProvider).In(bootstrapCluster).ToSatisfy(
-			HaveStatusCondition(&coreProvider.Status.Conditions, operatorv1.ProviderInstalledCondition)),
-			e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
-
-		By("Waiting for the core provider to have status.InstalledVersion to be set")
-		WaitFor(ctx, For(coreProvider).In(bootstrapCluster).ToSatisfy(func() bool {
-			return ptr.Equal(coreProvider.Status.InstalledVersion, &coreProvider.Spec.Version)
-		}), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
-	})
-
 	It("should successfully upgrade a CoreProvider (v1.4.2 -> latest)", func() {
 		bootstrapCluster := bootstrapClusterProxy.GetClient()
 		coreProvider := &operatorv1.CoreProvider{ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Currently, e2e tests are failing because downgrade tests don't pass. I think it makes sense to not support downgrades in operator. Users can delete providers manually and recreate it with a smaller version, taking the risk of data loss because of CRD changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
