### PR TITLE
🐛 Delete all Cluster API CRDs before running air-gapped tests

### DIFF
--- a/test/e2e/air_gapped_test.go
+++ b/test/e2e/air_gapped_test.go
@@ -37,6 +37,9 @@ import (
 
 var _ = Describe("Install Core Provider in an air-gapped environment", func() {
 	It("should successfully create config maps with Core Provider manifests", func() {
+		// Ensure that there are no Cluster API installed
+		deleteClusterAPICRDs(bootstrapClusterProxy)
+
 		bootstrapCluster := bootstrapClusterProxy.GetClient()
 		configMaps := []corev1.ConfigMap{}
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.30.0
 	golang.org/x/tools v0.14.0
 	k8s.io/api v0.28.4
+	k8s.io/apiextensions-apiserver v0.28.4
 	k8s.io/apimachinery v0.28.4
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
@@ -121,7 +122,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.28.4 // indirect
 	k8s.io/apiserver v0.28.4 // indirect
 	k8s.io/client-go v0.28.4 // indirect
 	k8s.io/cluster-bootstrap v0.28.4 // indirect


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Now we don't delete CAPI CRDs when some e2e tests are over. It leads to a failure, when we have CAPI CRDs v1.6.0 and we want to install Core Provider v1.4.3.

To fix it we delete all the CRDs before running air-gapped tests.

Error message:
```
E1215 18:45:55.001141       1 controller.go:324]  "msg"="Reconciler error" "error"="action failed after 10 attempts: failed to patch provider object: CustomResourceDefinition.apiextensions.k8s.io \"ipaddressclaims.ipam.cluster.x-k8s.io\" is invalid: status.storedVersions[0]: Invalid value: \"v1beta1\": must appear in spec.versions" "CoreProvider"={"name":"cluster-api","namespace":"capi-operator-system"} "controller"="coreprovider" "controllerGroup"="operator.cluster.x-k8s.io" "controllerKind"="CoreProvider" "name"="cluster-api" "namespace"="capi-operator-system" "reconcileID"="ac99c777-9b79-4875-80fa-be8457a
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
