### PR TITLE
🌱 Bump cert-manager version to v1.13.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ CONTROLLER_IMG_TAG ?= $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 LDFLAGS := $(shell $(ROOT)/hack/version.sh)
 
 # Default cert-manager version
-CERT_MANAGER_VERSION ?= v1.12.2
+CERT_MANAGER_VERSION ?= v1.13.2
 
 # E2E configuration
 GINKGO_NOCOLOR ?= false

--- a/hack/cert-manager.sh
+++ b/hack/cert-manager.sh
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CERT_MANAGER_VERSION=v1.12.2
+CERT_MANAGER_VERSION=v1.13.2
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

CAPI v1.6.0 uses cert-manager v1.13.2: https://github.com/kubernetes-sigs/cluster-api/pull/9653. CAPI operator should do the same.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
