### PR TITLE
📖 🐛 Document plugin installation, and fix template binary path

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -14,29 +14,29 @@ spec:
         os: darwin
         arch: amd64
     {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
     {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: amd64
     {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: arm64
     {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: windows
         arch: amd64
     {{addURIAndSha "https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/{{ .TagName }}/clusterctl-operator_{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
-    bin: clusterctl-operator.exe
+    bin: bin/clusterctl-operator.exe
 

--- a/docs/book/src/02_installation/00.md
+++ b/docs/book/src/02_installation/00.md
@@ -1,0 +1,7 @@
+# Installation
+
+This section describes `cluster-api-operator` components installation instructions.
+
+## [Plugin](./01_plugin.md)
+
+This document describes the plugin installation steps and prerequisites.

--- a/docs/book/src/02_installation/01_plugin.md
+++ b/docs/book/src/02_installation/01_plugin.md
@@ -1,0 +1,30 @@
+# Plugin installation
+
+The `cluster-api-operator` plugin can be installed using krew, the kubectl plugin manager.
+
+## Prerequisites
+
+[krew][] installed on your system. See the krew installation guide for instructions.
+
+[krew]: [https://krew.sigs.k8s.io/docs/user-guide/setup/install/]
+
+## Steps
+
+1. Add the cluster-api-operator plugin index to krew:
+```bash
+clusterctl krew index add operator https://github.com/kubernetes-sigs/cluster-api-operator.git
+```
+
+2. Install the cluster-api-operator plugin:
+```bash
+clusterctl krew install operator/operator
+```
+
+3. Verify the installation:
+```bash
+clusterctl operator
+```
+
+This should print help information for the clusterctl operator plugin.
+
+The `cluster-api-operator` plugin is now installed and ready to use with both `kubectl` and `clusterctl`.

--- a/plugins/clusterctl-operator.yaml
+++ b/plugins/clusterctl-operator.yaml
@@ -15,34 +15,34 @@ spec:
         arch: amd64
     uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.8.0/clusterctl-operator_v0.8.0_darwin_amd64.tar.gz
     sha256: 98c1a85ff35cc0df1208c30fa2059cbc5a881d58ca13a4af5ca7f49e25fcb121
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
     uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.8.0/clusterctl-operator_v0.8.0_darwin_arm64.tar.gz
     sha256: 93e7f0e3a0fbd30f132b167eff8f4b5f30e2a0dcc4efdd638eeeb98cb2eb6038
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: amd64
     uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.8.0/clusterctl-operator_v0.8.0_linux_amd64.tar.gz
     sha256: fe78cc5f7ca675b5d865e5fcea0176152e93044b40677814911e7d5546af227f
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: arm64
     uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.8.0/clusterctl-operator_v0.8.0_linux_arm64.tar.gz
     sha256: 47e6fb9d9490baf4fe05506f3ba5c7c0905c34813e949a24484885771c36c66c
-    bin: clusterctl-operator
+    bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: windows
         arch: amd64
     uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.8.0/clusterctl-operator_v0.8.0_windows_amd64.tar.gz
     sha256: 96e1a0bba6ccc61a7de15ec8c1c0a39c87510ed8a33c093c20e11923258f8668
-    bin: clusterctl-operator.exe
+    bin: bin/clusterctl-operator.exe
 
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This fixes binary path reference inside the released packages in `clusterctl-operator.yaml` plugin and the same in the template, for future releases.

Added a section describing installation steps and pre-requisites in the book.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
