### PR TITLE
🐛 don't customize non-manager deployments

### DIFF
--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -29,10 +29,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util"
-
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/util"
 )
 
 const (
@@ -97,11 +95,6 @@ func customizeObjectsFn(provider operatorv1.GenericProvider) func(objs []unstruc
 
 // customizeDeployment customize provider deployment base on provider spec input.
 func customizeDeployment(pSpec operatorv1.ProviderSpec, d *appsv1.Deployment) error {
-	// Ensure that we customize a manager deployment. It must contain "cluster.x-k8s.io/provider" label.
-	if _, ok := d.GetLabels()[clusterv1.ProviderNameLabel]; !ok {
-		return nil
-	}
-
 	// Customize deployment spec first.
 	if pSpec.Deployment != nil {
 		customizeDeploymentSpec(pSpec, d)

--- a/internal/controller/component_customizer_test.go
+++ b/internal/controller/component_customizer_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 )
@@ -41,9 +40,6 @@ func TestCustomizeDeployment(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "manager",
 			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				clusterv1.ProviderNameLabel: "infra-provider",
-			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -87,7 +83,6 @@ func TestCustomizeDeployment(t *testing.T) {
 		inputDeploymentSpec    *operatorv1.DeploymentSpec
 		inputManagerSpec       *operatorv1.ManagerSpec
 		expectedDeploymentSpec func(*appsv1.DeploymentSpec) (*appsv1.DeploymentSpec, bool)
-		noDeployementLabels    bool
 	}{
 		{
 			name:                "empty",
@@ -554,16 +549,6 @@ func TestCustomizeDeployment(t *testing.T) {
 
 				return expectedDS, reflect.DeepEqual(inputDS.Template.Spec.Containers[0], expectedDS.Template.Spec.Containers[0])
 			},
-		},
-		{
-			name: "no provider label on the deployment",
-			inputDeploymentSpec: &operatorv1.DeploymentSpec{
-				NodeSelector: map[string]string{"a": "b"},
-			},
-			expectedDeploymentSpec: func(inputDS *appsv1.DeploymentSpec) (*appsv1.DeploymentSpec, bool) {
-				return &managerDepl.Spec, true
-			},
-			noDeployementLabels: true,
 		},
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
    
To prevent customization of non-manager deployments, we introduce a check that first verifies if there are several deployments. If there are several deployments available, we customize only those with names like "ca*-controller-manager" and skip the others.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
