### PR TITLE
✨ Execute provider upgrades when a version changes

### DIFF
--- a/api/v1alpha2/conditions_consts.go
+++ b/api/v1alpha2/conditions_consts.go
@@ -47,6 +47,9 @@ const (
 	// ComponentsFetchErrorReason documents that an error occurred fetching the components.
 	ComponentsFetchErrorReason = "ComponentsFetchError"
 
+	// ComponentsUpgradeErrorReason documents that an error occurred while upgrading the components.
+	ComponentsUpgradeErrorReason = "ComponentsUpgradeError"
+
 	// OldComponentsDeletionErrorReason documents that an error occurred deleting the old components prior to upgrading.
 	OldComponentsDeletionErrorReason = "OldComponentsDeletionError"
 
@@ -63,4 +66,7 @@ const (
 const (
 	// ProviderInstalledCondition documents a Provider that has been installed.
 	ProviderInstalledCondition clusterv1.ConditionType = "ProviderInstalled"
+
+	// ProviderUpgradedCondition documents a Provider that has been recently upgraded.
+	ProviderUpgradedCondition clusterv1.ConditionType = "ProviderUpgraded"
 )

--- a/internal/controller/client_proxy.go
+++ b/internal/controller/client_proxy.go
@@ -24,17 +24,82 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// clientProxy implements the Proxy interface from the clusterctl. It is used to
+// interact with the management cluster.
+type clientProxy struct {
+	client.Client
+}
+
+func (c clientProxy) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	switch l := list.(type) {
+	case *clusterctlv1.ProviderList:
+		return listProviders(ctx, c.Client, l)
+	default:
+		return c.Client.List(ctx, l, opts...)
+	}
+}
+
+func (c clientProxy) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	switch o := obj.(type) {
+	case *clusterctlv1.Provider:
+		return nil
+	default:
+		return c.Client.Get(ctx, key, o, opts...)
+	}
+}
+
+func (c clientProxy) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	switch o := obj.(type) {
+	case *clusterctlv1.Provider:
+		return nil
+	default:
+		return c.Client.Patch(ctx, o, patch, opts...)
+	}
+}
+
+func listProviders(ctx context.Context, cl client.Client, list *clusterctlv1.ProviderList) error {
+	providers := []operatorv1.GenericProviderList{
+		&operatorv1.CoreProviderList{},
+		&operatorv1.InfrastructureProviderList{},
+		&operatorv1.BootstrapProviderList{},
+		&operatorv1.ControlPlaneProviderList{},
+		&operatorv1.AddonProviderList{},
+		&operatorv1.IPAMProviderList{},
+	}
+
+	for _, group := range providers {
+		g, ok := group.(client.ObjectList)
+		if !ok {
+			continue
+		}
+
+		if err := cl.List(ctx, g); err != nil {
+			return err
+		}
+
+		for _, p := range group.GetItems() {
+			list.Items = append(list.Items, getProvider(p, ""))
+		}
+	}
+
+	return nil
+}
+
 // controllerProxy implements the Proxy interface from the clusterctl. It is used to
 // interact with the management cluster.
 type controllerProxy struct {
-	ctrlClient client.Client
+	ctrlClient clientProxy
 	ctrlConfig *rest.Config
 }
 

--- a/internal/controller/client_proxy.go
+++ b/internal/controller/client_proxy.go
@@ -32,6 +32,7 @@ import (
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -217,4 +218,26 @@ func listObjByGVK(ctx context.Context, c client.Client, groupVersion, kind strin
 	}
 
 	return objList, nil
+}
+
+type repositoryProxy struct {
+	repository.Client
+
+	components repository.Components
+}
+
+type repositoryClient struct {
+	components repository.Components
+}
+
+func (r repositoryClient) Raw(ctx context.Context, options repository.ComponentsOptions) ([]byte, error) {
+	return nil, nil
+}
+
+func (r repositoryClient) Get(ctx context.Context, options repository.ComponentsOptions) (repository.Components, error) {
+	return r.components, nil
+}
+
+func (r repositoryProxy) Components() repository.ComponentsClient {
+	return repositoryClient{r.components}
 }

--- a/internal/controller/genericprovider_controller.go
+++ b/internal/controller/genericprovider_controller.go
@@ -157,8 +157,9 @@ func (r *GenericProviderReconciler) reconcile(ctx context.Context, provider gene
 		reconciler.downloadManifests,
 		reconciler.load,
 		reconciler.fetch,
-		reconciler.preInstall,
+		reconciler.upgrade,
 		reconciler.install,
+		reconciler.reportStatus,
 	}
 
 	res := reconcile.Result{}

--- a/internal/controller/manifests_downloader.go
+++ b/internal/controller/manifests_downloader.go
@@ -65,7 +65,7 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 
 	exists, err := p.checkConfigMapExists(ctx, labelSelector)
 	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, "failed to check that config map with manifests exists")
+		return reconcile.Result{}, wrapPhaseError(err, "failed to check that config map with manifests exists", operatorv1.ProviderInstalledCondition)
 	}
 
 	if exists {
@@ -80,7 +80,7 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 	if err != nil {
 		err = fmt.Errorf("failed to create repo from provider url for provider %q: %w", p.provider.GetName(), err)
 
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason)
+		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	spec := p.provider.GetSpec()
@@ -98,14 +98,14 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 	if err != nil {
 		err = fmt.Errorf("failed to read %q from the repository for provider %q: %w", metadataFile, p.provider.GetName(), err)
 
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason)
+		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	componentsFile, err := repo.GetFile(ctx, spec.Version, repo.ComponentsPath())
 	if err != nil {
 		err = fmt.Errorf("failed to read %q from the repository for provider %q: %w", componentsFile, p.provider.GetName(), err)
 
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason)
+		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	withCompression := needToCompress(metadataFile, componentsFile)
@@ -113,7 +113,7 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 	if err := p.createManifestsConfigMap(ctx, metadataFile, componentsFile, withCompression); err != nil {
 		err = fmt.Errorf("failed to create config map for provider %q: %w", p.provider.GetName(), err)
 
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason)
+		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This would execute a correct upgrade procedure when a Provider version changes.
Fixes: https://github.com/kubernetes-sigs/cluster-api-operator/issues/404

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
