### PR TITLE
✨ Add a preflight check to prevent provider downgrades

### DIFF
--- a/api/v1alpha2/conditions_consts.go
+++ b/api/v1alpha2/conditions_consts.go
@@ -61,6 +61,9 @@ const (
 
 	// NoDeploymentAvailableConditionReason documents that there is no Available condition for provider deployment yet.
 	NoDeploymentAvailableConditionReason = "NoDeploymentAvailableConditionReason"
+
+	// UnsupportedProviderDowngradeReason documents that the provider downgrade is not supported.
+	UnsupportedProviderDowngradeReason = "UnsupportedProviderDowngradeReason"
 )
 
 const (


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Cluster API doesn't support provider downgrades due to potential breaking changes in CRDs. Currently, if users try to downgrade for example from v1.6.1 to v1.5.2, they get a error:

```
invalid provider metadata: version v1.6.1 (the current version) for the provider capi-system/cluster-api does not match any release series
```
This is not really informative, so it is better to add a preflight check to fail earlier and provide more descriptive error messages.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
