### PR TITLE
🐛 Restrict configmap lookup to the provider namespace

### DIFF
--- a/internal/controller/manifests_downloader.go
+++ b/internal/controller/manifests_downloader.go
@@ -127,6 +127,7 @@ func (p *phaseReconciler) checkConfigMapExists(ctx context.Context, labelSelecto
 	labelSet := labels.Set(labelSelector.MatchLabels)
 	listOpts := []client.ListOption{
 		client.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labelSet)},
+		client.InNamespace(p.provider.GetNamespace()),
 	}
 
 	var configMapList corev1.ConfigMapList

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -176,7 +176,7 @@ func (p *phaseReconciler) load(ctx context.Context) (reconcile.Result, error) {
 		return reconcile.Result{}, wrapPhaseError(err, "failed to load additional manifests", operatorv1.ProviderInstalledCondition)
 	}
 
-	p.repo, err = p.configmapRepository(ctx, labelSelector, additionalManifests)
+	p.repo, err = p.configmapRepository(ctx, labelSelector, p.provider.GetNamespace(), additionalManifests)
 	if err != nil {
 		return reconcile.Result{}, wrapPhaseError(err, "failed to load the repository", operatorv1.ProviderInstalledCondition)
 	}
@@ -269,7 +269,7 @@ func (p *phaseReconciler) secretReader(ctx context.Context, providers ...configc
 
 // configmapRepository use clusterctl NewMemoryRepository structure to store the manifests
 // and metadata from a given configmap.
-func (p *phaseReconciler) configmapRepository(ctx context.Context, labelSelector *metav1.LabelSelector, additionalManifests string) (repository.Repository, error) {
+func (p *phaseReconciler) configmapRepository(ctx context.Context, labelSelector *metav1.LabelSelector, namespace, additionalManifests string) (repository.Repository, error) {
 	mr := repository.NewMemoryRepository()
 	mr.WithPaths("", "components.yaml")
 
@@ -280,7 +280,7 @@ func (p *phaseReconciler) configmapRepository(ctx context.Context, labelSelector
 		return nil, err
 	}
 
-	if err = p.ctrlClient.List(ctx, cml, &client.ListOptions{LabelSelector: selector}); err != nil {
+	if err = p.ctrlClient.List(ctx, cml, &client.ListOptions{LabelSelector: selector, Namespace: namespace}); err != nil {
 		return nil, err
 	}
 

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -388,7 +388,7 @@ metadata:
 				g.Expect(fakeclient.Create(ctx, &tt.configMaps[i])).To(Succeed())
 			}
 
-			got, err := p.configmapRepository(context.TODO(), p.provider.GetSpec().FetchConfig.Selector, tt.additionalManifests)
+			got, err := p.configmapRepository(context.TODO(), p.provider.GetSpec().FetchConfig.Selector, "ns1", tt.additionalManifests)
 			if len(tt.wantErr) > 0 {
 				g.Expect(err).Should(MatchError(tt.wantErr))
 				return

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -28,7 +28,8 @@ var (
 )
 
 const (
-	operatorNamespace = "capi-operator-system"
+	operatorNamespace   = "capi-operator-system"
+	capiSystemNamespace = "capi-system"
 
 	previousCAPIVersion = "v1.5.4"
 

--- a/test/e2e/resources/core-cluster-api-v1.5.4.yaml
+++ b/test/e2e/resources/core-cluster-api-v1.5.4.yaml
@@ -1,14 +1,6 @@
 apiVersion: v1
 data:
   components: |
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      labels:
-        cluster.x-k8s.io/provider: cluster-api
-        control-plane: controller-manager
-      name: capi-system
-    ---
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -11797,4 +11789,4 @@ metadata:
     provider.cluster.x-k8s.io/type: core
     provider.cluster.x-k8s.io/version: v1.5.4
   name: core-cluster-api-v1.5.4
-  namespace: capi-operator-system
+  namespace: capi-system

--- a/test/e2e/resources/core-cluster-api-v1.6.0.yaml
+++ b/test/e2e/resources/core-cluster-api-v1.6.0.yaml
@@ -1,14 +1,6 @@
 apiVersion: v1
 data:
   components: |
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      labels:
-        cluster.x-k8s.io/provider: cluster-api
-        control-plane: controller-manager
-      name: capi-system
-    ---
     apiVersion: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     metadata:
@@ -9860,4 +9852,4 @@ metadata:
     provider.cluster.x-k8s.io/type: core
     provider.cluster.x-k8s.io/version: v1.6.0
   name: core-cluster-api-v1.6.0
-  namespace: capi-operator-system
+  namespace: capi-system


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

When we use configmaps as a provider source, we filter them by provided labels and then take the latest version. Unfortunately, we list configmaps in all namespaces, which is not correct.

This PR restricts the search by the provider namespace only.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
