### PR TITLE
:bug: Collect correct manifest config map per provider while performing upgrade

### DIFF
--- a/internal/controller/manifests_downloader_test.go
+++ b/internal/controller/manifests_downloader_test.go
@@ -62,7 +62,7 @@ func TestManifestsDownloader(t *testing.T) {
 		MatchLabels: p.prepareConfigMapLabels(),
 	}
 
-	exists, err := p.checkConfigMapExists(ctx, labelSelector)
+	exists, err := p.checkConfigMapExists(ctx, labelSelector, p.provider.GetNamespace())
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(exists).To(BeTrue())


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Clusterctl upgrade logic validates other installed providers, while performing upgrade for version compatibility. Operator stores this data in a ConfigMap to allow air-gapped support. This ensures we fetch correct configMap first, to validate version against correct metadata.yaml.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #446 
