### PR TITLE
don’t deliver cert-manager CRDs with cluster-api-operator chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publis
 release-chart: $(HELM) $(KUSTOMIZE) $(RELEASE_DIR) $(CHART_DIR) $(CHART_PACKAGE_DIR) ## Builds the chart to publish with a release
 	cp -rf $(ROOT)/hack/charts/cluster-api-operator/. $(CHART_DIR)
 	$(KUSTOMIZE) build ./config/chart > $(CHART_DIR)/templates/operator-components.yaml
-	$(ROOT)/hack/inject-cert-manager-helm.sh $(CERT_MANAGER_VERSION)
+	$(ROOT)/hack/inject-cert-manager-chart-version.sh $(CERT_MANAGER_VERSION)
 	$(HELM) package $(CHART_DIR) --app-version=$(HELM_CHART_TAG) --version=$(HELM_CHART_TAG) --destination=$(CHART_PACKAGE_DIR)
 
 .PHONY: release-staging

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -5,6 +5,7 @@ cert-manager:
   enabled: false
   fullnameOverride: "cert-manager"
   namespace: "cert-manager"
+  installCRDs: true
 # ---
 # Cluster API provider options
 core: ""

--- a/hack/inject-cert-manager-chart-version.sh
+++ b/hack/inject-cert-manager-chart-version.sh
@@ -32,15 +32,9 @@ if [[ ! "$1" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
 fi
 
 VERSION=$1
-URL="https://github.com/cert-manager/cert-manager/releases/download/${VERSION}/cert-manager.crds.yaml"
-OUTPUT_DIR="${CHART_DIR}/crds"
 
 # Create the output directory if it doesn't exist
-mkdir -p "$OUTPUT_DIR"
-
-# Download and save the file
-curl -L -o "${OUTPUT_DIR}/cert-manager.crds.yaml" "$URL"
-echo "Downloaded cert-manager.crds.yaml for ${VERSION} and saved it in ${OUTPUT_DIR}"
+mkdir -p "$CHART_DIR"
 
 # Modify version in Chart.yaml
 CHART_FILE="${CHART_DIR}/Chart.yaml"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR changes the way that the cluster-api-operator chart relates to the cert-manager chart. Rather than package those downstream CRDs with the chart, we can simply dispatch in the cluster-api-operator chart the `cert-manager.installCRDs=true` value config.

So, with this PR, a simple `helm install --repo https://kubernetes-sigs.github.io/cluster-api-operator capi-operator cluster-api-operator` command will no longer include the cert-manager CRDs as part of its resource payload.

To explicitly install the cert-manager chart, including the CRDs that are delivered with the cert-manager chart, as part of the cluster-api-operator helm install, we will do:

- `helm install --repo https://kubernetes-sigs.github.io/cluster-api-operator capi-operator cluster-api-operator --set cert-manager.enabled=true`

If a user wishes to install the cert-manager chart **without the CRDs**, this is the command:

- `helm install --repo https://kubernetes-sigs.github.io/cluster-api-operator capi-operator cluster-api-operator --set cert-manager.enabled=true --set cert-manager.installCRDs=false`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #281
