### PR TITLE
🌱 Use 1.21 golang version for tools

### DIFF
--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -26,7 +26,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # tag=v5.0.0
       with:
-        go-version: ${{ steps.vars.outputs.go_version }}
+        # go-version: ${{ steps.vars.outputs.go_version }} // TODO: we have to use go version consistent with test infra jobs
+        go-version: '1.21'
     - uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # tag=v4.0.1
       name: Restore go cache
       with:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Test-infra jobs are already using 1.21 under the hood, so we can’t use go 1.20 for jobs here. This causes `dependabot_pr.yaml` to create a conflicting change in `make verify` as opposed to current main.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
