### PR TITLE
🌱 Ensure dependabot branch has a default tag for make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,10 @@ E2E_OPERATOR_IMAGE ?= $(CONTROLLER_IMG):$(TAG)
 # Relase
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 HELM_CHART_TAG := $(shell echo $(RELEASE_TAG) | cut -c 2-)
+ifeq ($(HELM_CHART_TAG),)
+	HELM_CHART_TAG := v0.0.1-test
+	RELEASE_TAG := v0.0.1-test
+endif
 RELEASE_ALIAS_TAG ?= $(PULL_BASE_REF)
 RELEASE_DIR := $(ROOT)/out
 CHART_DIR := $(RELEASE_DIR)/charts/cluster-api-operator


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Dependabot branches don’t have access to release history, `git describe` output is therefore empty. This causes `dependabot_pr.yaml` [job](https://github.com/kubernetes-sigs/cluster-api-operator/actions/runs/8375139988) to fail with the following error:

```
Error: path "/home/runner/work/cluster-api-operator/cluster-api-operator/out/package/cluster-api-operator-.tgz" not found
```

This change adds a default to some specific tag in such scenario.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
