### PR TITLE
🐛 Use absolute path in update scripts

### DIFF
--- a/hack/update-helm-repo.sh
+++ b/hack/update-helm-repo.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+# Resolve the absolute path of the directory containing the script
+SCRIPT_DIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+REPO_ROOT="$SCRIPT_DIR/.."
 
 cd $REPO_ROOT/hack/chart-update; go run . -release-tag=$1; cd -

--- a/hack/update-plugin-yaml.sh
+++ b/hack/update-plugin-yaml.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+# Resolve the absolute path of the directory containing the script
+SCRIPT_DIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+REPO_ROOT="$SCRIPT_DIR/.."
 
-docker run --rm -v $REPO_ROOT:/home/app ghcr.io/rajatjindal/krew-release-bot:v0.0.46 krew-release-bot template --tag $1 --template-file .krew.yaml > $REPO_ROOT/plugins/clusterctl-operator.yaml
+docker run --rm -v "$REPO_ROOT":/home/app ghcr.io/rajatjindal/krew-release-bot:v0.0.46 krew-release-bot template --tag "$1" --template-file .krew.yaml > "$REPO_ROOT"/plugins/clusterctl-operator.yaml


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Helm/plugin update scripts fail to run on Mac because of relative path, this PR switches to using absolute path in both update scripts


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
