### PR TITLE
Add helm.sh/resource-policy: keep to CRDs to prevent deletion

### DIFF
--- a/config/chart/kustomization.yaml
+++ b/config/chart/kustomization.yaml
@@ -23,6 +23,11 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
+patches:
+- path: patches/keep-crds.yaml
+  target:
+    kind: CustomResourceDefinition
+
 patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/config/chart/patches/keep-crds.yaml
+++ b/config/chart/patches/keep-crds.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  name: any

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: 'default/capi-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: addonproviders.operator.cluster.x-k8s.io
@@ -1623,6 +1624,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: 'default/capi-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: bootstrapproviders.operator.cluster.x-k8s.io
@@ -4825,6 +4827,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: 'default/capi-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: controlplaneproviders.operator.cluster.x-k8s.io
@@ -8030,6 +8033,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: 'default/capi-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: coreproviders.operator.cluster.x-k8s.io
@@ -11232,6 +11236,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: 'default/capi-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: infrastructureproviders.operator.cluster.x-k8s.io
@@ -14437,6 +14442,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: 'default/capi-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: ipamproviders.operator.cluster.x-k8s.io
@@ -16054,6 +16060,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: 'default/capi-operator-serving-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   labels:
     clusterctl.cluster.x-k8s.io/core: capi-operator
   name: runtimeextensionproviders.operator.cluster.x-k8s.io


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

When CAPI Operator chart used as a dependency, the removal of the chart hosting the dependency causes CRDs to be removed. This happens because CRDs are generated as a part of `base` and therefore are managed by helm 3. Helm [docs](https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource) define `keep` policy as:
> skip deleting this resource when a helm operation (such as helm uninstall, helm upgrade or helm rollback) **would result in its deletion**

Setting this annotation should not prevent CRD upgrades, when resource is changed only.

Typically this removal happens after the main deployment is removed, and before any or all of the `*Provider` resources are removed. Provider resources has a finalizer, nothing can remove at this point, so the deletion hangs and later fails. Happens because CRD removal requires all resources it defines to be cleaned up before being removed itself.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
