### PR TITLE
🐛 Fix unsupportedProviderDowngradeMessage message

### DIFF
--- a/internal/controller/preflight_checks.go
+++ b/internal/controller/preflight_checks.go
@@ -231,7 +231,7 @@ func checkProviderVersion(ctx context.Context, providerVersion string, provider 
 				operatorv1.PreflightCheckCondition,
 				operatorv1.UnsupportedProviderDowngradeReason,
 				clusterv1.ConditionSeverityError,
-				fmt.Sprintf(unsupportedProviderDowngradeMessage, provider.GetName(), configclient.ClusterAPIProviderName),
+				fmt.Sprintf(unsupportedProviderDowngradeMessage, provider.GetName()),
 			))
 
 			return fmt.Errorf("downgrade is not supported for provider %q", provider.GetName())


### PR DESCRIPTION


<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Currently we format the message incorrectly, which causes output like:
`Downgrade is not supported for provider aws%!!(MISSING)(EXTRA string=cluster-api)`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
