### PR TITLE
🐛 Revert "don’t deliver cert-manager CRDs with cluster-api-operator chart"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publis
 release-chart: $(HELM) $(KUSTOMIZE) $(RELEASE_DIR) $(CHART_DIR) $(CHART_PACKAGE_DIR) ## Builds the chart to publish with a release
 	cp -rf $(ROOT)/hack/charts/cluster-api-operator/. $(CHART_DIR)
 	$(KUSTOMIZE) build ./config/chart > $(CHART_DIR)/templates/operator-components.yaml
-	$(ROOT)/hack/inject-cert-manager-chart-version.sh $(CERT_MANAGER_VERSION)
+	$(ROOT)/hack/inject-cert-manager-helm.sh $(CERT_MANAGER_VERSION)
 	$(HELM) package $(CHART_DIR) --app-version=$(HELM_CHART_TAG) --version=$(HELM_CHART_TAG) --destination=$(CHART_PACKAGE_DIR)
 
 .PHONY: release-staging

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -5,7 +5,6 @@ cert-manager:
   enabled: false
   fullnameOverride: "cert-manager"
   namespace: "cert-manager"
-  installCRDs: true
 # ---
 # Cluster API provider options
 core: ""

--- a/hack/inject-cert-manager-helm.sh
+++ b/hack/inject-cert-manager-helm.sh
@@ -32,9 +32,15 @@ if [[ ! "$1" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
 fi
 
 VERSION=$1
+URL="https://github.com/cert-manager/cert-manager/releases/download/${VERSION}/cert-manager.crds.yaml"
+OUTPUT_DIR="${CHART_DIR}/crds"
 
 # Create the output directory if it doesn't exist
-mkdir -p "$CHART_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# Download and save the file
+curl -L -o "${OUTPUT_DIR}/cert-manager.crds.yaml" "$URL"
+echo "Downloaded cert-manager.crds.yaml for ${VERSION} and saved it in ${OUTPUT_DIR}"
 
 # Modify version in Chart.yaml
 CHART_FILE="${CHART_DIR}/Chart.yaml"


### PR DESCRIPTION
This reverts commit c8a9022ba90e00c259ef5a8c4ca6a69d69180ed4.

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

PR #453 broke installation of cert-manager CRDs, so we revert that regression.

The reason why cert-manager CRDs were placed in "crds" folder, is because in this case Helm [applies](https://helm.sh/docs/topics/charts/#custom-resource-definitions-crds) them earlier, before all other manifests. Also Helm guarantees that if these CRDs are already presented in the system, it won't [overwrite](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you) them.

If we template everything together, both cert-manager resources and CRDs will be applied simultaneously, and we get this error:
```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "capi-operator-serving-cert" namespace: "capi-operator-system" from "": no matches for kind "Certificate" in version "cert-manager.io/v1" ensure CRDs are installed first, resource mapping not found for name: "capi-operator-selfsigned-issuer" namespace: "capi-operator-system" from "": no matches for kind "Issuer" in version "cert-manager.io/v1" ensure CRDs are installed first]
``` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
