### PR TITLE
:sparkles: Add featureGates to ControlPlaneProvider

### DIFF
--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -38,11 +38,24 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
-{{- if or $controlPlaneVersion $.Values.configSecret.name }}
+{{- if or $controlPlaneVersion $.Values.configSecret.name $.Values.manager }}
 spec:
 {{- end}}
 {{- if $controlPlaneVersion }}
   version: {{ $controlPlaneVersion }}
+{{- end }}
+{{- if $.Values.manager }}
+  manager:
+{{- if hasKey $.Values.manager.featureGates $controlPlaneName }}
+{{- range $key, $value := $.Values.manager.featureGates }}
+  {{- if eq $key $controlPlaneName }}
+    featureGates:
+    {{- range $k, $v := $value }}
+      {{ $k }}: {{ $v }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if $.Values.configSecret.name }}
   configSecret:

--- a/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
@@ -53,6 +53,15 @@ metadata:
     "argocd.argoproj.io/sync-wave": "2"
 {{- with .Values.configSecret }}
 spec:
+{{- if $.Values.manager }}
+  manager:
+{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.kubeadm }}
+    featureGates:
+    {{- range $key, $value := $.Values.manager.featureGates.kubeadm }}
+      {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+{{- end }}
   configSecret:
     name: {{ .name }}
     {{- if .namespace }}

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -261,4 +261,20 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).To(MatchYAML(string(expectedManifests)))
 	})
+	It("should deploy kubeadm control plane with manager specified", func() {
+		manifests, err := helmChart.Run(map[string]string{
+			"core":           "cluster-api",
+			"controlPlane":   "kubeadm",
+			"bootstrap":      "kubeadm",
+			"infrastructure": "docker",
+			"addon":          "helm",
+			"manager.featureGates.kubeadm.ClusterTopology": "true",
+			"manager.featureGates.kubeadm.MachinePool":     "true",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).ToNot(BeEmpty())
+		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "kubeadm-manager-defined.yaml"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+	})
 })

--- a/test/e2e/resources/kubeadm-manager-defined.yaml
+++ b/test/e2e/resources/kubeadm-manager-defined.yaml
@@ -1,0 +1,108 @@
+---
+# Source: cluster-api-operator/templates/addon.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: helm-addon-system
+---
+# Source: cluster-api-operator/templates/bootstrap.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+  name: kubeadm-bootstrap-system
+---
+# Source: cluster-api-operator/templates/control-plane.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+  name: kubeadm-control-plane-system
+---
+# Source: cluster-api-operator/templates/core.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+  name: capi-system
+---
+# Source: cluster-api-operator/templates/infra.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: docker-infrastructure-system
+---
+# Source: cluster-api-operator/templates/addon.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: AddonProvider
+metadata:
+  name: helm
+  namespace: helm-addon-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+---
+# Source: cluster-api-operator/templates/bootstrap.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: kubeadm-bootstrap-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+---
+# Source: cluster-api-operator/templates/control-plane.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: kubeadm-control-plane-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+spec:
+  manager:
+    featureGates:
+      ClusterTopology: true
+      MachinePool: true
+---
+# Source: cluster-api-operator/templates/core.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+  manager:
+---
+# Source: cluster-api-operator/templates/infra.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: docker
+  namespace: docker-infrastructure-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  manager:


### PR DESCRIPTION
<!-- ✨ (feature additions) -->

**What this PR does / why we need it**:

This PR adds support for specifying featureGates in the ControlPlaneProvider. This is particularly necessary when using infrastructure=docker, as we need to pass CLUSTER_TOPOLOGY=true to the kubeadm provider. Currently, there is no way to do this, and this feature is essential for enabling cluster topology features in kubeadm.

**Usage Example**:

To use this feature, you can install the capi-operator with Helm and specify the feature gates in your values file. Here is an example:

```bash
helm install capi-operator cluster-api-operator/cluster-api-operator --version 0.10.1 -n capi-operator-system --create-namespace --values ./example-values.yaml
```

`example-values.yaml`:
```yaml
cert-manager:
  enabled: false
  installCRDs: false
infrastructure: docker:v1.7.2
core: cluster-api:v1.7.2
controlPlane: kubeadm:v1.7.2
manager:
  featureGates:
    core:
      ClusterTopology: true
      MachinePool: true
    docker:
      ClusterTopology: true
      MachinePool: true
    kubeadm:
      ClusterTopology: true
      MachinePool: true
```

**Sample Output**:

Here is a portion of the expanded manifest showing the applied feature gates:

```yaml
# Source: cluster-api-operator/templates/control-plane.yaml
apiVersion: operator.cluster.x-k8s.io/v1alpha2
kind: ControlPlaneProvider
metadata:
  name: kubeadm
  namespace: kubeadm-control-plane-system
  annotations:
    "helm.sh/hook": "post-install"
    "helm.sh/hook-weight": "2"
spec:
  version: v1.7.2
  manager:
    featureGates:
      ClusterTopology: true
      MachinePool: true
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
