### PR TITLE
📖  Correct Helm chart install instructions in docs + add warnings about --wait being required

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,9 @@ helm install capi-operator capi-operator/cluster-api-operator --create-namespace
 
 The operator Helm chart supports a "quickstart" option for bootstrapping a management cluster. The user experience is relatively similar to [clusterctl init](https://cluster-api.sigs.k8s.io/clusterctl/commands/init.html?highlight=init#clusterctl-init):
 
+> **Warning**
+> The `--wait` flag is REQUIRED for the helm install command to work with providers. If the --wait flag is not used, the helm install command will not wait for the resources to be created and will return immediately.
+
 ```bash
 helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure=docker:v1.4.2  --wait --timeout 90s # core Cluster API with kubeadm bootstrap and control plane providers will also be installed
 ```
@@ -115,10 +118,13 @@ The operator Helm chart provides multiple ways to configure deployment. For inst
 
 #### Helm installation example
 
-The following command will install cert-manager, CAPI operator itself with modified log level, Core CAPI provider with kubeadm bootstrap and control plane, and Docker infrastructure.
+The following commands will install cert-manager, CAPI operator itself with modified log level, Core CAPI provider with kubeadm bootstrap and control plane, and Docker infrastructure.
 
 ```bash
-helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure=docker:v1.5.0  --set cert-manager.enabled=true --set logLevel=4 --wait --timeout 90s
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm repo update
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure=docker:v1.5.0 --wait --timeout 90s
 ```
 
 ## Configuration

--- a/docs/book/src/01_user/02_quick-start.md
+++ b/docs/book/src/01_user/02_quick-start.md
@@ -28,14 +28,29 @@ kubectl create secret generic "${CREDENTIALS_SECRET_NAME}" --from-literal=AWS_B6
 
 ### Installing Cluster API Operator
 
-Add helm repository:
+Add CAPI Operator & cert manager helm repository:
 
 ```bash
 helm repo add capi-operator https://kubernetes-sigs.github.io/cluster-api-operator
+helm repo add jetstack https://charts.jetstack.io --force-update
 helm repo update
 ```
 
-Deploy Cluster API components with docker provider using a single command during operator installation
+Install cert manager:
+
+```bash
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+```
+
+Deploy Cluster API components with docker provider using a single command during operator installation.
+
+<aside class="note warning">
+
+<h1> Warning </h1>
+
+The `--wait` flag is REQUIRED for the helm install command to work. If the --wait flag is not used, the helm install command will not wait for the resources to be created and will return immediately. This will cause the helm install command to fail because the webhooks will not be ready in time. The --timeout flag is optional and can be used to specify the amount of time to wait for the resources to be created.
+
+</aside>
 
 ```bash
 helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure=docker --set configSecret.name=${CREDENTIALS_SECRET_NAME} --set configSecret.namespace=${CREDENTIALS_SECRET_NAMESPACE}  --wait --timeout 90s

--- a/docs/book/src/02_installation/04_helm-chart-installation.md
+++ b/docs/book/src/02_installation/04_helm-chart-installation.md
@@ -12,6 +12,14 @@ helm install capi-operator capi-operator/cluster-api-operator --create-namespace
 
 The operator Helm chart supports a "quickstart" option for bootstrapping a management cluster. The user experience is relatively similar to [clusterctl init](https://cluster-api.sigs.k8s.io/clusterctl/commands/init.html?highlight=init#clusterctl-init):
 
+<aside class="note warning">
+
+<h1> Warning </h1>
+
+The `--wait` flag is REQUIRED for the helm install command to work with providers.
+
+</aside>
+
 ```bash
 helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure=docker:v1.4.2  --wait --timeout 90s # core Cluster API with kubeadm bootstrap and control plane providers will also be installed
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,14 +27,29 @@ kubectl create secret generic "${CREDENTIALS_SECRET_NAME}" --from-literal=AWS_B6
 
 ### Installing Cluster API Operator
 
-Add helm repository:
+Add CAPI Operator & cert manager helm repository:
 
 ```bash
 helm repo add capi-operator https://kubernetes-sigs.github.io/cluster-api-operator
+helm repo add jetstack https://charts.jetstack.io --force-update
 helm repo update
 ```
 
+Install cert manager:
+
+```bash
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+```
+
 Deploy Cluster API components with docker provider using a single command during operator installation
+
+<aside class="note warning">
+
+<h1> Warning </h1>
+
+The `--wait` flag is REQUIRED for the helm install command to work. If the --wait flag is not used, the helm install command will not wait for the resources to be created and will return immediately. This will cause the helm install command to fail because the webhooks will not be ready in time. The --timeout flag is optional and can be used to specify the amount of time to wait for the resources to be created.
+
+</aside>
 
 ```bash
 helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure=docker --set cert-manager.enabled=true --set configSecret.name=${CREDENTIALS_SECRET_NAME} --set configSecret.namespace=${CREDENTIALS_SECRET_NAMESPACE}  --wait --timeout 90s


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds some fixes to the helm chart install commands in the docs. It also adds some warnings regarding the `--wait` flag being required when installing providers with the helm chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #532
