### PR TITLE
📖 Fix manifestPatches field name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -778,7 +778,7 @@ spec:
 ## Patching provider manifests
 
 Provider manifests can be patched using JSON merge patches. This can be useful when you need to modify the provider manifests that are fetched from the repository. In order to provider
-manifests `spec.ResourcePatches` has to be used where an array of patches can be specified:
+manifests `spec.ManifestPatches` has to be used where an array of patches can be specified:
 
 ```yaml
 ---
@@ -788,13 +788,13 @@ metadata:
   name: cluster-api
   namespace: capi-system
 spec:
-  resourcePatches:
+  manifestPatches:
     - |
-apiVersion: v1
-kind: Service
-metadata:
-labels:
-    test-label: test-value
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+            test-label: test-value
 ```
 
 More information about JSON merge patches can be found here https://datatracker.ietf.org/doc/html/rfc7396

--- a/docs/book/src/03_topics/02_configuration/04_patching-provider-manifests.md
+++ b/docs/book/src/03_topics/02_configuration/04_patching-provider-manifests.md
@@ -1,7 +1,7 @@
 # Patching provider manifests
 
 Provider manifests can be patched using JSON merge patches. This can be useful when you need to modify the provider manifests that are fetched from the repository. In order to provider
-manifests `spec.ResourcePatches` has to be used where an array of patches can be specified:
+manifests `spec.ManifestPatches` has to be used where an array of patches can be specified:
 
 ```yaml
 ---
@@ -11,13 +11,13 @@ metadata:
   name: cluster-api
   namespace: capi-system
 spec:
-  resourcePatches:
+  manifestPatches:
     - |
-apiVersion: v1
-kind: Service
-metadata:
-labels:
-    test-label: test-value
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+            test-label: test-value
 ```
 
 More information about JSON merge patches can be found here <https://datatracker.ietf.org/doc/html/rfc7396>


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs refer to this field as `resourcePatches` while its actually called [`manifestPatches`](https://github.com/kubernetes-sigs/cluster-api-operator/blob/628476cec06411357f07d514dfbf0444dad40c03/api/v1alpha2/provider_types.go#L75) in the code and in the CRD.

I also fixed the indentation in the examples for this field to make sense.

