### PR TITLE
:bug: Fix infra Helm chart logic for additionalDeployments

### DIFF
--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -1,13 +1,3 @@
-{{- define "recursivePrinter" }}
-{{- range $key, $value := . }}
-{{- if kindIs "map" $value }}
-  {{ $key }}:
-  {{- include "recursivePrinter" $value | indent 2 }}
-{{- else }}
-  {{ $key }}: {{ $value }}
-{{- end }}
-{{- end }}
-{{- end }}
 # Infrastructure providers
 {{- if .Values.infrastructure }}
 {{- $infrastructures := split ";" .Values.infrastructure }}
@@ -77,8 +67,7 @@ spec:
     {{- end }}
 {{- end }}
 {{- if $.Values.additionalDeployments }}
-  additionalDeployments:
-  {{- include "recursivePrinter" $.Values.additionalDeployments | indent 2 }}
+  additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR fixes a bug where the `additionalDeployments` field was bring printed incorrectly when using a values.yaml file. The `recursivePrinter` is not needed, and we can just use `toYaml` instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
