### PR TITLE
Remove the invalid caBundle, required for 1.31

### DIFF
--- a/config/crd/patches/webhook_in_addonproviders.yaml
+++ b/config/crd/patches/webhook_in_addonproviders.yaml
@@ -12,7 +12,6 @@ spec:
       clientConfig:
         # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
         # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_bootstrapproviders.yaml
+++ b/config/crd/patches/webhook_in_bootstrapproviders.yaml
@@ -12,7 +12,6 @@ spec:
       clientConfig:
         # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
         # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_controlplaneproviders.yaml
+++ b/config/crd/patches/webhook_in_controlplaneproviders.yaml
@@ -12,7 +12,6 @@ spec:
       clientConfig:
         # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
         # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_coreproviders.yaml
+++ b/config/crd/patches/webhook_in_coreproviders.yaml
@@ -12,7 +12,6 @@ spec:
       clientConfig:
         # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
         # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_infrastructureproviders.yaml
+++ b/config/crd/patches/webhook_in_infrastructureproviders.yaml
@@ -12,7 +12,6 @@ spec:
       clientConfig:
         # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
         # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_ipamproviders.yaml
+++ b/config/crd/patches/webhook_in_ipamproviders.yaml
@@ -12,7 +12,6 @@ spec:
       clientConfig:
         # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
         # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_runtimeextensionproviders.yaml
+++ b/config/crd/patches/webhook_in_runtimeextensionproviders.yaml
@@ -12,7 +12,6 @@ spec:
       clientConfig:
         # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
         # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -24,7 +24,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: 'default'
@@ -3035,7 +3034,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: 'default'
@@ -7631,7 +7629,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: 'default'
@@ -12230,7 +12227,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: 'default'
@@ -16826,7 +16822,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: 'default'
@@ -21425,7 +21420,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: 'default'
@@ -24436,7 +24430,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capi-operator-webhook-service
           namespace: 'default'


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This removes the invalid CABundle, required for k8s 1.31.
See https://github.com/kubernetes-sigs/cluster-api/pull/10972 for context

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #590 
