### PR TITLE
✨ Pass image overrides to in-memory client

### DIFF
--- a/internal/controller/manifests_downloader_test.go
+++ b/internal/controller/manifests_downloader_test.go
@@ -22,6 +22,8 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	configclient "sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
@@ -34,14 +36,12 @@ func TestManifestsDownloader(t *testing.T) {
 
 	fakeclient := fake.NewClientBuilder().WithObjects().Build()
 
-	namespace := "test-namespace"
-
 	p := &phaseReconciler{
 		ctrlClient: fakeclient,
 		provider: &operatorv1.CoreProvider{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster-api",
-				Namespace: namespace,
+				Namespace: "test-namespace",
 			},
 			Spec: operatorv1.CoreProviderSpec{
 				ProviderSpec: operatorv1.ProviderSpec{
@@ -66,4 +66,53 @@ func TestManifestsDownloader(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(exists).To(BeTrue())
+}
+
+func TestProviderDownloadWithOverrides(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx := context.Background()
+
+	fakeclient := fake.NewClientBuilder().WithObjects().Build()
+
+	namespace := "test-namespace"
+
+	reader := configclient.NewMemoryReader()
+	_, err := reader.AddProvider("cluster-api", clusterctlv1.CoreProviderType, "https://github.com/kubernetes-sigs/cluster-api/releases/v1.4.3/core-components.yaml")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	overridesClient, err := configclient.New(ctx, "", configclient.InjectReader(reader))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	overridesClient.Variables().Set("images", `
+all:
+  repository: "myorg.io/local-repo"
+`)
+
+	p := &phaseReconciler{
+		ctrlClient: fakeclient,
+		provider: &operatorv1.CoreProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-api",
+				Namespace: namespace,
+			},
+			Spec: operatorv1.CoreProviderSpec{},
+		},
+		overridesClient: overridesClient,
+	}
+
+	_, err = p.initializePhaseReconciler(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = p.downloadManifests(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = p.load(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	_, err = p.fetch(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(p.components.Images()).To(HaveExactElements([]string{"myorg.io/local-repo/cluster-api-controller:v1.4.3"}))
+	g.Expect(p.components.Version()).To(Equal("v1.4.3"))
 }

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -65,6 +65,7 @@ type phaseReconciler struct {
 	options            repository.ComponentsOptions
 	providerConfig     configclient.Provider
 	configClient       configclient.Client
+	overridesClient    configclient.Client
 	components         repository.Components
 	clusterctlProvider *clusterctlv1.Provider
 }
@@ -126,16 +127,31 @@ func (p *phaseReconciler) initializePhaseReconciler(ctx context.Context) (reconc
 	initConfig, err := configclient.New(ctx, path)
 	if err != nil {
 		return reconcile.Result{}, err
+	} else if path != "" {
+		// Set the image and providers override client
+		p.overridesClient = initConfig
 	}
 
-	providers, err := initConfig.Providers().List()
+	overrideProviders := []configclient.Provider{}
+
+	if p.overridesClient != nil {
+		providers, err := p.overridesClient.Providers().List()
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		overrideProviders = providers
+	}
+
+	reader, err := p.secretReader(ctx, overrideProviders...)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	reader, err := p.secretReader(ctx, providers...)
-	if err != nil {
-		return reconcile.Result{}, err
+	if p.overridesClient != nil {
+		if imageOverrides, err := p.overridesClient.Variables().Get("images"); err == nil {
+			reader.Set("images", imageOverrides)
+		}
 	}
 
 	// Load provider's secret and config url.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This change allows to pass `images` variable overrides to a local `clusterctl.yaml` file, allowing a granular control on default image sources for the provider installations.

Added tests for existing overrides functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
