### PR TITLE
✨ Update index.yaml for v0.13.0 minor release

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,16 @@ apiVersion: v1
 entries:
   cluster-api-operator:
   - apiVersion: v2
+    appVersion: 0.13.0
+    created: "2024-09-03T17:55:47.133363463+02:00"
+    description: Cluster API Operator
+    digest: 21199b64ed8dc4d59da7a1b8d1dbd04fc1423cc4c2664aa83baf8b5971cc2749
+    name: cluster-api-operator
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.13.0/cluster-api-operator-0.13.0.tgz
+    version: 0.13.0
+  - apiVersion: v2
     appVersion: 0.12.0
     created: "2024-07-31T21:04:34.435129+03:00"
     description: Cluster API Operator
@@ -216,4 +226,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.2.0/cluster-api-operator-0.2.0.tgz
     version: 0.2.0
-generated: "2024-07-31T21:04:34.435183+03:00"
+generated: "2024-09-03T17:55:47.133458044+02:00"

--- a/plugins/clusterctl-operator.yaml
+++ b/plugins/clusterctl-operator.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: operator
 spec:
-  version: v0.12.0
+  version: v0.13.0
   homepage: https://github.com/kubernetes-sigs/cluster-api-operator
   shortDescription: Use this clusterctl plugin to bootstrap a management cluster for Cluster API with the Cluster API Operator.
   description: |
@@ -13,36 +13,36 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.12.0/clusterctl-operator_v0.12.0_darwin_amd64.tar.gz
-    sha256: 2d1bb0f8489ed4b64b3e46947bd1ea80c24496077f85c9eb42155b10d57daf2b
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.13.0/clusterctl-operator_v0.13.0_darwin_amd64.tar.gz
+    sha256: 045b36cc4429ec96d0e1c83a4043d6aa91b8d810a787cb23f338ff0b380b88b6
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.12.0/clusterctl-operator_v0.12.0_darwin_arm64.tar.gz
-    sha256: 56a9c1d7c7f4ecfff41ca171b27c1a7bae4978675e3f45440b6d354c0a292fb2
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.13.0/clusterctl-operator_v0.13.0_darwin_arm64.tar.gz
+    sha256: b12b2098fce1c43f1ff32cc0114f90a2f0d194998146fa3af95be532769251fa
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.12.0/clusterctl-operator_v0.12.0_linux_amd64.tar.gz
-    sha256: 0efdea346363b5f0037e68d85550a3be65909c7992b250dc678012556d32e958
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.13.0/clusterctl-operator_v0.13.0_linux_amd64.tar.gz
+    sha256: 5ae09c69434ed8ad5a3b632b4052592815f8f49a4bad8d6f3c883da541dcfe84
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.12.0/clusterctl-operator_v0.12.0_linux_arm64.tar.gz
-    sha256: 0e4f6a27fa5474490243903194f62f41dac054d5ac35343c301aa631826908bd
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.13.0/clusterctl-operator_v0.13.0_linux_arm64.tar.gz
+    sha256: 0bb150f5c673a3a9a6e4fda65957811b13570cf12936c8dfc86495ddc634670b
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.12.0/clusterctl-operator_v0.12.0_windows_amd64.tar.gz
-    sha256: b9948b799f0c8db6699c67bf64690b48cb608ac1baeaf0a7a90f96c653cc98ed
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.13.0/clusterctl-operator_v0.13.0_windows_amd64.tar.gz
+    sha256: bfc47837a1992ea22e44a94b10f7ea02a319370318a5adb488d5c81aac5e3064
     bin: bin/clusterctl-operator.exe
 
 


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR updates index.yaml for v0.13.0. Automatically generated by `make update-helm-repo`.