### PR TITLE
⚠️ Make helm chart values extensible per component

### DIFF
--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -1,26 +1,8 @@
 # Addon provider
-{{- if .Values.addon }}
-{{- $addons := split ";" .Values.addon }}
-{{- $addonNamespace := "" }}
-{{- $addonName := "" }}
-{{- $addonVersion := "" }}
-{{- range $addon := $addons }}
-{{- $addonArgs := split ":" $addon }}
-{{- $addonArgsLen :=  len $addonArgs }}
-{{-  if eq $addonArgsLen 3 }}
-  {{- $addonNamespace = $addonArgs._0 }}
-  {{- $addonName = $addonArgs._1 }}
-  {{- $addonVersion = $addonArgs._2 }}
-{{-  else if eq $addonArgsLen 2 }}
-  {{- $addonNamespace = print $addonArgs._0 "-addon-system" }}
-  {{- $addonName = $addonArgs._0 }}
-  {{- $addonVersion = $addonArgs._1 }}
-{{-  else if eq $addonArgsLen 1 }}
-  {{- $addonNamespace = print $addonArgs._0 "-addon-system" }}
-  {{- $addonName = $addonArgs._0 }}
-{{- else }}
-  {{- fail "addon provider argument should have the following format helm:v1.0.0 or mynamespace:helm:v1.0.0" }}
-{{- end }}
+{{- range $name, $addon := $.Values.addon }}
+  {{- $addonNamespace := default ( printf "%s-%s" $name "addon-system" ) (get $addon "namespace") }}
+  {{- $addonName := $name }}
+  {{- $addonVersion := get $addon "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -52,5 +34,4 @@ spec:
 {{- if $.Values.secretNamespace }}
   secretNamespace: {{ $.Values.secretNamespace }}
 {{- end }}
-{{- end }} {{/* range $addon := $addons */}}
-{{- end }} {{/* if .Values.addon */}}
+{{- end }} {{/* range $name, $addon := .Values.addon */}}

--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -37,4 +37,21 @@ spec:
 {{- if $addon.manifestPatches }}
   manifestPatches: {{ toYaml $addon.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $addon.additionalManifests }}
+  additionalManifests:
+    name: {{ $addon.additionalManifests.name }}
+    {{- if $addon.additionalManifests.namespace }}
+    namespace: {{ $addon.additionalManifests.namespace }}
+    {{- end }} {{/* if $addon.additionalManifests.namespace */}}
+{{- end }}
+{{- if $addon.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $addon.additionalManifests.name }}
+  namespace: {{ default $addonNamespace $addon.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $addon.additionalManifests.manifests | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $addon := .Values.addon */}}

--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -34,4 +34,7 @@ spec:
 {{- if $.Values.secretNamespace }}
   secretNamespace: {{ $.Values.secretNamespace }}
 {{- end }}
+{{- if $addon.manifestPatches }}
+  manifestPatches: {{ toYaml $addon.manifestPatches | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $addon := .Values.addon */}}

--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -52,5 +52,5 @@ spec:
 {{- if $.Values.secretNamespace }}
   secretNamespace: {{ $.Values.secretNamespace }}
 {{- end }}
-{{- end }}
-{{- end }}
+{{- end }} {{/* range $addon := $addons */}}
+{{- end }} {{/* if .Values.addon */}}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -33,4 +33,7 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $bootstrap.manifestPatches }}
+  manifestPatches: {{ toYaml $bootstrap.manifestPatches | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $bootstrap := .Values.bootstrap */}}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -36,4 +36,21 @@ spec:
 {{- if $bootstrap.manifestPatches }}
   manifestPatches: {{ toYaml $bootstrap.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $bootstrap.additionalManifests }}
+  additionalManifests:
+    name: {{ $bootstrap.additionalManifests.name }}
+    {{- if $bootstrap.additionalManifests.namespace }}
+    namespace: {{ $bootstrap.additionalManifests.namespace }}
+    {{- end }} {{/* if $bootstrap.additionalManifests.namespace */}}
+{{- end }}
+{{- if $bootstrap.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $bootstrap.additionalManifests.name }}
+  namespace: {{ default $bootstrapNamespace $bootstrap.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $bootstrap.additionalManifests.manifests | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $bootstrap := .Values.bootstrap */}}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -51,5 +51,5 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
-{{- end }}
-{{- end }}
+{{- end }} {{/* range $bootstrap := $bootstraps */}}
+{{- end }} {{/* if .Values.bootstrap */}}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -1,26 +1,8 @@
 # Bootstrap provider
-{{- if .Values.bootstrap }}
-{{- $bootstraps := split ";" .Values.bootstrap }}
-{{- $bootstrapNamespace := "" }}
-{{- $bootstrapName := "" }}
-{{- $bootstrapVersion := "" }}
-{{- range $bootstrap := $bootstraps }}
-{{- $bootstrapArgs := split ":" $bootstrap }}
-{{- $bootstrapArgsLen :=  len $bootstrapArgs }}
-{{-  if eq $bootstrapArgsLen 3 }}
-  {{- $bootstrapNamespace = $bootstrapArgs._0 }}
-  {{- $bootstrapName = $bootstrapArgs._1 }}
-  {{- $bootstrapVersion = $bootstrapArgs._2 }}
-{{-  else if eq $bootstrapArgsLen 2 }}
-  {{- $bootstrapNamespace = print $bootstrapArgs._0 "-bootstrap-system" }}
-  {{- $bootstrapName = $bootstrapArgs._0 }}
-  {{- $bootstrapVersion = $bootstrapArgs._1 }}
-{{-  else if eq $bootstrapArgsLen 1 }}
-  {{- $bootstrapNamespace = print $bootstrapArgs._0 "-bootstrap-system" }}
-  {{- $bootstrapName = $bootstrapArgs._0 }}
-{{- else }}
-  {{- fail "bootstrap provider argument should have the following format kubeadm:v1.0.0 or mynamespace:kubeadm:v1.0.0" }}
-{{- end }}
+{{- range $name, $bootstrap := $.Values.bootstrap }}
+  {{- $bootstrapNamespace := default ( printf "%s-%s" $name "bootstrap-system" ) (get $bootstrap "namespace") }}
+  {{- $bootstrapName := $name }}
+  {{- $bootstrapVersion := get $bootstrap "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -51,5 +33,4 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
-{{- end }} {{/* range $bootstrap := $bootstraps */}}
-{{- end }} {{/* if .Values.bootstrap */}}
+{{- end }} {{/* range $name, $bootstrap := .Values.bootstrap */}}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -49,4 +49,21 @@ spec:
 {{- if $controlPlane.manifestPatches }}
   manifestPatches: {{ toYaml $controlPlane.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $controlPlane.additionalManifests }}
+  additionalManifests:
+    name: {{ $controlPlane.additionalManifests.name }}
+    {{- if $controlPlane.additionalManifests.namespace }}
+    namespace: {{ $controlPlane.additionalManifests.namespace }}
+    {{- end }} {{/* if $controlPlane.additionalManifests.namespace */}}
+{{- end }}
+{{- if $controlPlane.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $controlPlane.additionalManifests.name }}
+  namespace: {{ default $controlPlaneNamespace $controlPlane.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $controlPlane.additionalManifests.manifests | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $controlPlane := .Values.controlPlane */}}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -1,26 +1,8 @@
 # Control plane provider
-{{- if .Values.controlPlane }}
-{{- $controlPlanes := split ";" .Values.controlPlane }}
-{{- $controlPlaneNamespace := "" }}
-{{- $controlPlaneName := "" }}
-{{- $controlPlaneVersion := "" }}
-{{- range $controlPlane := $controlPlanes }}
-{{- $controlPlaneArgs := split ":" $controlPlane }}
-{{- $controlPlaneArgsLen :=  len $controlPlaneArgs }}
-{{-  if eq $controlPlaneArgsLen 3 }}
-  {{- $controlPlaneNamespace = $controlPlaneArgs._0 }}
-  {{- $controlPlaneName = $controlPlaneArgs._1 }}
-  {{- $controlPlaneVersion = $controlPlaneArgs._2 }}
-{{-  else if eq $controlPlaneArgsLen 2 }}
-  {{- $controlPlaneNamespace = print $controlPlaneArgs._0 "-control-plane-system" }}
-  {{- $controlPlaneName = $controlPlaneArgs._0 }}
-  {{- $controlPlaneVersion = $controlPlaneArgs._1 }}
-{{-  else if eq $controlPlaneArgsLen 1 }}
-  {{- $controlPlaneNamespace = print $controlPlaneArgs._0 "-control-plane-system" }}
-  {{- $controlPlaneName = $controlPlaneArgs._0 }}
-{{- else }}
-  {{- fail "controlplane provider argument should have the following format kubeadm:v1.0.0 or mynamespace:kubeadm:v1.0.0" }}
-{{-  end }}
+{{- range $name, $controlPlane := $.Values.controlPlane }}
+  {{- $controlPlaneNamespace := default ( printf "%s-%s" $name "control-plane-system" ) (get $controlPlane "namespace") }}
+  {{- $controlPlaneName := $name }}
+  {{- $controlPlaneVersion := get $controlPlane "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -64,5 +46,4 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
-{{- end }} {{/* range $controlPlane := $controlPlanes */}}
-{{- end }} {{/* if .Values.controlPlane */}}
+{{- end }} {{/* range $name, $controlPlane := .Values.controlPlane */}}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -64,5 +64,5 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
-{{- end }}
-{{- end }}
+{{- end }} {{/* range $controlPlane := $controlPlanes */}}
+{{- end }} {{/* if .Values.controlPlane */}}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -46,4 +46,7 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $controlPlane.manifestPatches }}
+  manifestPatches: {{ toYaml $controlPlane.manifestPatches | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $controlPlane := .Values.controlPlane */}}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -46,4 +46,21 @@ spec:
 {{- if $core.manifestPatches }}
   manifestPatches: {{ toYaml $core.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $core.additionalManifests }}
+  additionalManifests:
+    name: {{ $core.additionalManifests.name }}
+    {{- if $core.additionalManifests.namespace }}
+    namespace: {{ $core.additionalManifests.namespace }}
+    {{- end }}
+{{- end }}
+{{- if $core.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $core.additionalManifests.name }}
+  namespace: {{ default $coreNamespace $core.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $core.additionalManifests.manifests | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $core := .Values.core */}}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -60,4 +60,4 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
-{{- end }}
+{{- end }} {{/* if .Values.core */}}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -1,25 +1,8 @@
 # Core provider
-{{- if .Values.core }}
-{{- $coreArgs := split ":" .Values.core }}
-{{- $coreArgsLen :=  len $coreArgs }}
-{{- $coreVersion := "" }}
-{{- $coreNamespace := "" }}
-{{- $coreName := "" }}
-{{- $coreVersion := "" }}
-{{-  if eq $coreArgsLen 3 }}
-  {{- $coreNamespace = $coreArgs._0 }}
-  {{- $coreName = $coreArgs._1 }}
-  {{- $coreVersion = $coreArgs._2 }}
-{{-  else if eq $coreArgsLen 2 }}
-  {{- $coreNamespace = "capi-system" }}
-  {{- $coreName = $coreArgs._0 }}
-  {{- $coreVersion = $coreArgs._1 }}
-{{-  else if eq $coreArgsLen 1 }}
-  {{- $coreNamespace = "capi-system" }}
-  {{- $coreName = $coreArgs._0 }}
-{{- else }}
-  {{- fail "core provider argument should have the following format cluster-api:v1.0.0 or mynamespace:cluster-api:v1.0.0" }}
-{{-  end }}
+{{- range $name, $core := $.Values.core }}
+  {{- $coreNamespace := default "capi-system" (get $core "namespace") }}
+  {{- $coreName := $name }}
+  {{- $coreVersion := get $core "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -60,4 +43,4 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
-{{- end }} {{/* if .Values.core */}}
+{{- end }} {{/* range $name, $core := .Values.core */}}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -43,4 +43,7 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $core.manifestPatches }}
+  manifestPatches: {{ toYaml $core.manifestPatches | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $core := .Values.core */}}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -61,4 +61,7 @@ spec:
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
+{{- if $infra.manifestPatches }}
+  manifestPatches: {{- toYaml $infra.manifestPatches | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $infra := .Values.infrastructure */}}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -79,5 +79,5 @@ spec:
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
-{{- end }}
-{{- end }}
+{{- end }} {{/* range $infrastructure := $infrastructures */}}
+{{- end }} {{/* if .Values.infrastructure */}}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -63,5 +63,22 @@ spec:
 {{- end }}
 {{- if $infra.manifestPatches }}
   manifestPatches: {{- toYaml $infra.manifestPatches | nindent 4 }}
+{{- end }} {{/* if $infra.manifestPatches */}}
+{{- if $infra.additionalManifests }}
+  additionalManifests:
+    name: {{ $infra.additionalManifests.name }}
+    {{- if $infra.additionalManifests.namespace }}
+    namespace: {{ $infra.additionalManifests.namespace }}
+    {{- end }} {{/* if $infra.additionalManifests.namespace */}}
+{{- end }} {{/* if $infra.additionalManifests */}}
+{{- if $infra.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $infra.additionalManifests.name }}
+  namespace: {{ default $infrastructureNamespace $infra.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $infra.additionalManifests.manifests | nindent 4 }}
 {{- end }}
 {{- end }} {{/* range $name, $infra := .Values.infrastructure */}}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -1,26 +1,8 @@
 # Infrastructure providers
-{{- if .Values.infrastructure }}
-{{- $infrastructures := split ";" .Values.infrastructure }}
-{{- $infrastructureNamespace := "" }}
-{{- $infrastructureName := "" }}
-{{- $infrastructureVersion := "" }}
-{{- range $infrastructure := $infrastructures }}
-{{- $infrastructureArgs := split ":" $infrastructure }}
-{{- $infrastructureArgsLen := len $infrastructureArgs }}
-{{-  if eq $infrastructureArgsLen 3 }}
-  {{- $infrastructureNamespace = $infrastructureArgs._0 }}
-  {{- $infrastructureName = $infrastructureArgs._1 }}
-  {{- $infrastructureVersion = $infrastructureArgs._2 }}
-{{-  else if eq $infrastructureArgsLen 2 }}
-  {{- $infrastructureNamespace = print $infrastructureArgs._0 "-infrastructure-system" }}
-  {{- $infrastructureName = $infrastructureArgs._0 }}
-  {{- $infrastructureVersion = $infrastructureArgs._1 }}
-{{-  else if eq $infrastructureArgsLen 1 }}
-  {{- $infrastructureNamespace = print $infrastructureArgs._0 "-infrastructure-system" }}
-  {{- $infrastructureName = $infrastructureArgs._0 }}
-{{- else }}
-  {{- fail "infrastructure provider argument should have the following format aws:v1.0.0 or mynamespace:aws:v1.0.0" }}
-{{- end }}
+{{- range $name, $infra := $.Values.infrastructure }}
+  {{- $infrastructureNamespace := default ( printf "%s-%s" $name "infrastructure-system" ) (get $infra "namespace") }}
+  {{- $infrastructureName := $name }}
+  {{- $infrastructureVersion := get $infra "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -79,5 +61,4 @@ spec:
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
-{{- end }} {{/* range $infrastructure := $infrastructures */}}
-{{- end }} {{/* if .Values.infrastructure */}}
+{{- end }} {{/* range $name, $infra := .Values.infrastructure */}}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -69,5 +69,5 @@ spec:
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
-{{- end }}
-{{- end }}
+{{- end }} {{/* range $ipam := $ipams */}}
+{{- end }} {{/* if .Values.ipam */}}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -48,6 +48,9 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $ipam.manifestPatches }}
+  manifestPatches: {{ toYaml $ipam.manifestPatches | nindent 4 }}
+{{- end }}
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -54,4 +54,21 @@ spec:
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
+{{- if $ipam.additionalManifests }}
+  additionalManifests:
+    name: {{ $ipam.additionalManifests.name }}
+    {{- if $ipam.additionalManifests.namespace }}
+    namespace: {{ $ipam.additionalManifests.namespace }}
+    {{- end }} {{/* if $ipam.additionalManifests.namespace */}}
+{{- end }}
+{{- if $ipam.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $ipam.additionalManifests.name }}
+  namespace: {{ default $ipamNamespace $ipam.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $ipam.additionalManifests.manifests | nindent 4 }}
+{{- end }}
 {{- end }} {{/* range $name, $ipam := .Values.ipam */}}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -1,26 +1,8 @@
 # IPAM providers
-{{- if .Values.ipam }}
-{{- $ipams := split ";" .Values.ipam }}
-{{- $ipamNamespace := "" }}
-{{- $ipamName := "" }}
-{{- $ipamVersion := "" }}
-{{- range $ipam := $ipams }}
-{{- $ipamArgs := split ":" $ipam }}
-{{- $ipamArgsLen := len $ipamArgs }}
-{{-  if eq $ipamArgsLen 3 }}
-  {{- $ipamNamespace = $ipamArgs._0 }}
-  {{- $ipamName = $ipamArgs._1 }}
-  {{- $ipamVersion = $ipamArgs._2 }}
-{{-  else if eq $ipamArgsLen 2 }}
-  {{- $ipamNamespace = print $ipamArgs._0 "-ipam-system" }}
-  {{- $ipamName = $ipamArgs._0 }}
-  {{- $ipamVersion = $ipamArgs._1 }}
-{{-  else if eq $ipamArgsLen 1 }}
-  {{- $ipamNamespace = print $ipamArgs._0 "-ipam-system" }}
-  {{- $ipamName = $ipamArgs._0 }}
-{{- else }}
-  {{- fail "ipam provider argument should have the following format in-cluster:v1.0.0 or mynamespace:in-cluster:v1.0.0" }}
-{{- end }}
+{{- range $name, $ipam := $.Values.ipam }}
+  {{- $ipamNamespace := default ( printf "%s-%s" $name "ipam-system" ) (get $ipam "namespace") }}
+  {{- $ipamName := $name }}
+  {{- $ipamVersion := get $ipam "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -69,5 +51,4 @@ spec:
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
-{{- end }} {{/* range $ipam := $ipams */}}
-{{- end }} {{/* if .Values.ipam */}}
+{{- end }} {{/* range $name, $ipam := .Values.ipam */}}

--- a/hack/charts/cluster-api-operator/values.schema.json
+++ b/hack/charts/cluster-api-operator/values.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "core": {
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "bootstrap": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "controlPlane": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "infrastructure": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "addon": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "ipam": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    }
+  }
+}

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -1,12 +1,30 @@
 ---
 # ---
 # Cluster API provider options
-core: ""
-bootstrap: ""
-controlPlane: ""
-infrastructure: ""
-ipam: ""
-addon: ""
+core: {}
+# cluster-api: {}  # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+bootstrap: {}
+# kubeadm: {}      # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+controlPlane: {}
+# kubeadm: {}      # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+infrastructure: {}
+# docker: {}  # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+addon: {}
+# helm: {}         # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+ipam: {}
+# in-cluster: {}   # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
 manager.featureGates: {}
 fetchConfig: {}
 # ---

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -29,10 +29,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
-	. "sigs.k8s.io/cluster-api-operator/test/framework"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "sigs.k8s.io/cluster-api-operator/test/framework"
 )
 
 var _ = Describe("Create a proper set of manifests when using helm charts", func() {
@@ -148,14 +149,20 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy all providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"core":                   "capi-custom-ns:cluster-api:v1.7.7",
-			"controlPlane":           "kubeadm-control-plane-custom-ns:kubeadm:v1.7.7",
-			"bootstrap":              "kubeadm-bootstrap-custom-ns:kubeadm:v1.7.7",
-			"infrastructure":         "capd-custom-ns:docker:v1.7.7",
-			"ipam":                   "in-cluster-custom-ns:in-cluster:v1.0.0",
-			"addon":                  "helm-custom-ns:helm:v0.2.6",
+			"configSecret.name":               "test-secret-name",
+			"configSecret.namespace":          "test-secret-namespace",
+			"core.cluster-api.namespace":      "capi-custom-ns",
+			"core.cluster-api.version":        "v1.7.7",
+			"controlPlane.kubeadm.namespace":  "kubeadm-control-plane-custom-ns",
+			"controlPlane.kubeadm.version":    "v1.7.7",
+			"bootstrap.kubeadm.namespace":     "kubeadm-bootstrap-custom-ns",
+			"bootstrap.kubeadm.version":       "v1.7.7",
+			"infrastructure.docker.namespace": "capd-custom-ns",
+			"infrastructure.docker.version":   "v1.7.7",
+			"ipam.in-cluster.namespace":       "in-cluster-custom-ns",
+			"ipam.in-cluster.version":         "v1.0.0",
+			"addon.helm.namespace":            "helm-custom-ns",
+			"addon.helm.version":              "v0.2.6",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -166,14 +173,14 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy all providers with custom versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"core":                   "cluster-api:v1.7.7",
-			"controlPlane":           "kubeadm:v1.7.7",
-			"bootstrap":              "kubeadm:v1.7.7",
-			"infrastructure":         "docker:v1.7.7",
-			"ipam":                   "in-cluster:v1.0.0",
-			"addon":                  "helm:v0.2.6",
+			"configSecret.name":             "test-secret-name",
+			"configSecret.namespace":        "test-secret-namespace",
+			"core.cluster-api.version":      "v1.7.7",
+			"controlPlane.kubeadm.version":  "v1.7.7",
+			"bootstrap.kubeadm.version":     "v1.7.7",
+			"infrastructure.docker.version": "v1.7.7",
+			"ipam.in-cluster.version":       "v1.0.0",
+			"addon.helm.version":            "v0.2.6",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -184,14 +191,14 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy all providers with latest version", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"core":                   "cluster-api",
-			"controlPlane":           "kubeadm",
-			"bootstrap":              "kubeadm",
-			"infrastructure":         "docker",
-			"ipam":                   "in-cluster",
-			"addon":                  "helm",
+			"configSecret.name":             "test-secret-name",
+			"configSecret.namespace":        "test-secret-namespace",
+			"core.cluster-api.enabled":      "true",
+			"controlPlane.kubeadm.enabled":  "true",
+			"bootstrap.kubeadm.enabled":     "true",
+			"infrastructure.docker.enabled": "true",
+			"ipam.in-cluster.enabled":       "true",
+			"addon.helm.enabled":            "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -202,9 +209,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core, bootstrap, control plane when only infra is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"infrastructure":         "docker",
+			"configSecret.name":             "test-secret-name",
+			"configSecret.namespace":        "test-secret-namespace",
+			"infrastructure.docker.enabled": "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -215,9 +222,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core when only bootstrap is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"bootstrap":              "kubeadm",
+			"configSecret.name":         "test-secret-name",
+			"configSecret.namespace":    "test-secret-namespace",
+			"bootstrap.kubeadm.enabled": "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -228,9 +235,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core when only control plane is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"controlPlane":           "kubeadm",
+			"configSecret.name":            "test-secret-name",
+			"configSecret.namespace":       "test-secret-namespace",
+			"controlPlane.kubeadm.enabled": "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -241,9 +248,9 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core when only ipam is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"ipam":                   "in-cluster",
+			"configSecret.name":       "test-secret-name",
+			"configSecret.namespace":  "test-secret-namespace",
+			"ipam.in-cluster.enabled": "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -254,10 +261,10 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core, bootstrap, control plane when only infra and ipam is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"infrastructure":         "docker",
-			"ipam":                   "in-cluster",
+			"configSecret.name":             "test-secret-name",
+			"configSecret.namespace":        "test-secret-namespace",
+			"infrastructure.docker.enabled": "true",
+			"ipam.in-cluster.enabled":       "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -268,9 +275,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy multiple infra providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"infrastructure":         "capd-custom-ns:docker:v1.7.7;capz-custom-ns:azure:v1.10.0",
+			"configSecret.name":               "test-secret-name",
+			"configSecret.namespace":          "test-secret-namespace",
+			"infrastructure.docker.namespace": "capd-custom-ns",
+			"infrastructure.docker.version":   "v1.7.7",
+			"infrastructure.azure.namespace":  "capz-custom-ns",
+			"infrastructure.azure.version":    "v1.10.0",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -281,9 +291,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy multiple control plane providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"controlPlane":           "kubeadm-control-plane-custom-ns:kubeadm:v1.7.7;rke2-control-plane-custom-ns:rke2:v0.8.0",
+			"configSecret.name":              "test-secret-name",
+			"configSecret.namespace":         "test-secret-namespace",
+			"controlPlane.kubeadm.namespace": "kubeadm-control-plane-custom-ns",
+			"controlPlane.kubeadm.version":   "v1.7.7",
+			"controlPlane.rke2.namespace":    "rke2-control-plane-custom-ns",
+			"controlPlane.rke2.version":      "v0.8.0",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -294,9 +307,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy multiple bootstrap providers with custom namespace and versions", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"bootstrap":              "kubeadm-bootstrap-custom-ns:kubeadm:v1.7.7;rke2-bootstrap-custom-ns:rke2:v0.8.0",
+			"configSecret.name":           "test-secret-name",
+			"configSecret.namespace":      "test-secret-namespace",
+			"bootstrap.kubeadm.namespace": "kubeadm-bootstrap-custom-ns",
+			"bootstrap.kubeadm.version":   "v1.7.7",
+			"bootstrap.rke2.namespace":    "rke2-bootstrap-custom-ns",
+			"bootstrap.rke2.version":      "v0.8.0",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -309,7 +325,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		manifests, err := helmChart.Run(map[string]string{
 			"configSecret.name":      "test-secret-name",
 			"configSecret.namespace": "test-secret-namespace",
-			"addon":                  "helm",
+			"addon.helm.enabled":     "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -320,10 +336,10 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 
 	It("should deploy core, bootstrap, control plane when only infra and addon is specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":      "test-secret-name",
-			"configSecret.namespace": "test-secret-namespace",
-			"infrastructure":         "docker",
-			"addon":                  "helm",
+			"configSecret.name":             "test-secret-name",
+			"configSecret.namespace":        "test-secret-namespace",
+			"infrastructure.docker.enabled": "true",
+			"addon.helm.enabled":            "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
@@ -333,15 +349,15 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 	})
 	It("should deploy core and infra with feature gates enabled", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":        "aws-variables",
-			"configSecret.namespace":   "default",
-			"infrastructure":           "aws:v2.4.0",
-			"ipam":                     "in-cluster:",
-			"addon":                    "helm:",
-			"image.manager.tag":        "v0.9.1",
-			"cert-manager.enabled":     "false",
-			"cert-manager.installCRDs": "false",
-			"core":                     "cluster-api:v1.6.2",
+			"configSecret.name":                         "aws-variables",
+			"configSecret.namespace":                    "default",
+			"infrastructure.aws.version":                "v2.4.0",
+			"ipam.in-cluster.enabled":                   "true",
+			"addon.helm.enabled":                        "true",
+			"image.manager.tag":                         "v0.9.1",
+			"cert-manager.enabled":                      "false",
+			"cert-manager.installCRDs":                  "false",
+			"core.cluster-api.version":                  "v1.6.2",
 			"manager.featureGates.core.ClusterTopology": "true",
 			"manager.featureGates.core.MachinePool":     "true",
 			"manager.featureGates.aws.ClusterTopology":  "true",
@@ -359,10 +375,10 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		manifests, err := helmChart.Run(map[string]string{
 			"configSecret.name":                "test-secret-name",
 			"configSecret.namespace":           "test-secret-namespace",
-			"core":                             "cluster-api",
-			"infrastructure":                   "azure",
-			"ipam":                             "in-cluster",
-			"addon":                            "helm",
+			"core.cluster-api.enabled":         "true",
+			"infrastructure.azure.enabled":     "true",
+			"ipam.in-cluster.enabled":          "true",
+			"addon.helm.enabled":               "true",
 			"manager.cert-manager.enabled":     "false",
 			"manager.cert-manager.installCRDs": "false",
 		})
@@ -374,12 +390,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 	})
 	It("should deploy all providers when manager is defined but another infrastructure spec field is defined", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"core":           "cluster-api",
-			"controlPlane":   "kubeadm",
-			"bootstrap":      "kubeadm",
-			"infrastructure": "docker",
-			"ipam":           "in-cluster",
-			"addon":          "helm",
+			"core.cluster-api.enabled":                  "true",
+			"controlPlane.kubeadm.enabled":              "true",
+			"bootstrap.kubeadm.enabled":                 "true",
+			"infrastructure.docker.enabled":             "true",
+			"ipam.in-cluster.enabled":                   "true",
+			"addon.helm.enabled":                        "true",
 			"manager.featureGates.core.ClusterTopology": "true",
 			"manager.featureGates.core.MachinePool":     "true",
 		})
@@ -391,12 +407,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 	})
 	It("should deploy kubeadm control plane with manager specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"core":           "cluster-api",
-			"controlPlane":   "kubeadm",
-			"bootstrap":      "kubeadm",
-			"infrastructure": "docker",
-			"ipam":           "in-cluster",
-			"addon":          "helm",
+			"core.cluster-api.enabled":                     "true",
+			"controlPlane.kubeadm.enabled":                 "true",
+			"bootstrap.kubeadm.enabled":                    "true",
+			"infrastructure.docker.enabled":                "true",
+			"ipam.in-cluster.enabled":                      "true",
+			"addon.helm.enabled":                           "true",
 			"manager.featureGates.kubeadm.ClusterTopology": "true",
 			"manager.featureGates.kubeadm.MachinePool":     "true",
 		})

--- a/test/e2e/resources/multiple-infra-custom-ns-versions.yaml
+++ b/test/e2e/resources/multiple-infra-custom-ns-versions.yaml
@@ -36,7 +36,7 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "1"
     "argocd.argoproj.io/sync-wave": "1"
-  name: capd-custom-ns
+  name: capz-custom-ns
 ---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: v1
@@ -46,7 +46,7 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "1"
     "argocd.argoproj.io/sync-wave": "1"
-  name: capz-custom-ns
+  name: capd-custom-ns
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -96,22 +96,6 @@ spec:
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
-  name: docker
-  namespace: capd-custom-ns
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "2"
-    "argocd.argoproj.io/sync-wave": "2"
-spec:
-  version: v1.7.7
-  configSecret:
-    name: test-secret-name
-    namespace: test-secret-namespace
----
-# Source: cluster-api-operator/templates/infra.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha2
-kind: InfrastructureProvider
-metadata:
   name: azure
   namespace: capz-custom-ns
   annotations:
@@ -120,6 +104,22 @@ metadata:
     "argocd.argoproj.io/sync-wave": "2"
 spec:
   version: v1.10.0
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/infra.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: docker
+  namespace: capd-custom-ns
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  version: v1.7.7
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
When deploying clusters to AKS using Workload Identity [an annotation](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster#create-a-kubernetes-service-account) is required on the service account and [a label](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster#deploy-your-application) is required on the pod. By extending the chart to expose the [already existing functionality to patch provider manifests](https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/04_patching-provider-manifests) this PR allows for setting up AKS clusters using Workload Identity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
