### PR TITLE
✨ adding fetchConfig to InfrastructureProvider template in helmchart

### DIFF
--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -59,6 +59,16 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if and (kindIs "map" $.Values.fetchConfig) (hasKey $.Values.fetchConfig $infrastructureName) }}
+{{- range $key, $value := $.Values.fetchConfig }}
+  {{- if eq $key $infrastructureName }}
+  fetchConfig:
+    {{- range $k, $v := $value }}
+      {{ $k }}: {{ $v }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- if $.Values.configSecret.name }}
   configSecret:
     name: {{ $.Values.configSecret.name }}

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -7,6 +7,7 @@ controlPlane: ""
 infrastructure: ""
 addon: ""
 manager.featureGates: {}
+fetchConfig: {}
 # ---
 # Common configuration secret options
 configSecret: {}


### PR DESCRIPTION
**What this PR does / why we need it**: This adds [fetchConfig](https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api-operator/operator.cluster.x-k8s.io/InfrastructureProvider/v1alpha2) to the `InfrastructureProvider`.  


This can be used like this:
```
infrastructure: "oci"
manager:
  featureGates:
    oci:
      MachinePool: true
      OKE: true
fetchConfig:
  oci:
    url: https://github.com/ts-mini/cluster-api-provider-oci/releases
```

The attempt was to follow the existing patterns of per-provider config, allowing users to set fetchConfigs per provider if needed.  Happy to adjust as needed!