### PR TITLE
🌱 Update helm chart index.yaml to v0.15.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,16 @@ apiVersion: v1
 entries:
   cluster-api-operator:
   - apiVersion: v2
+    appVersion: 0.15.0
+    created: "2024-12-18T15:41:02.023104281+01:00"
+    description: Cluster API Operator
+    digest: 9eae8cc5ab2e0e9b1e74ce1dcd95c0df8add977c292eb1728eb8a2419c387355
+    name: cluster-api-operator
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.15.0/cluster-api-operator-0.15.0.tgz
+    version: 0.15.0
+  - apiVersion: v2
     appVersion: 0.14.0
     created: "2024-10-09T19:42:11.812579+03:00"
     description: Cluster API Operator
@@ -236,4 +246,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.2.0/cluster-api-operator-0.2.0.tgz
     version: 0.2.0
-generated: "2024-10-09T19:42:11.812675+03:00"
+generated: "2024-12-18T15:41:02.023216652+01:00"

--- a/plugins/clusterctl-operator.yaml
+++ b/plugins/clusterctl-operator.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: operator
 spec:
-  version: v0.14.0
+  version: v0.15.0
   homepage: https://github.com/kubernetes-sigs/cluster-api-operator
   shortDescription: Use this clusterctl plugin to bootstrap a management cluster for Cluster API with the Cluster API Operator.
   description: |
@@ -13,36 +13,36 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/clusterctl-operator_v0.14.0_darwin_amd64.tar.gz
-    sha256: a8c2c1480ad75c9a72ca68d35e383def7fcc8e8ed6936bcec71c5e8dfa7a33c1
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.15.0/clusterctl-operator_v0.15.0_darwin_amd64.tar.gz
+    sha256: a4dca66d4419e0846ac8fbb2f8a98d052ab60c2b97df727e1a796261603fdd3f
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/clusterctl-operator_v0.14.0_darwin_arm64.tar.gz
-    sha256: be030376b92c143be532399c0bd5eb35ae3a2f0c481f3858e63cee8569ecaa39
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.15.0/clusterctl-operator_v0.15.0_darwin_arm64.tar.gz
+    sha256: 100333d6d97989ea97ccc06b26684c353ac12723d527487d334121bb59f12136
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/clusterctl-operator_v0.14.0_linux_amd64.tar.gz
-    sha256: 684e04304ef5cb745c3cb56b54ec815f936ca27c4510c007422a9dc549c3ffde
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.15.0/clusterctl-operator_v0.15.0_linux_amd64.tar.gz
+    sha256: 758c3427197b7d288320758295e2bcd8447de0e7a9b272f628077a6c3125aaef
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/clusterctl-operator_v0.14.0_linux_arm64.tar.gz
-    sha256: ed63a6d0daf7dc5149053215b0d54d0dbf9de298d1c74f52af93f228fd710834
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.15.0/clusterctl-operator_v0.15.0_linux_arm64.tar.gz
+    sha256: dd89fa9203958eeb0579c26f19d9e41ddce1fe6291ad34ff7f6c16c41d768b13
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.14.0/clusterctl-operator_v0.14.0_windows_amd64.tar.gz
-    sha256: f0434e1f50cf01b9920e6052b03c8bea7c4c1529df50b82e21a7ff6a83bff8fb
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.15.0/clusterctl-operator_v0.15.0_windows_amd64.tar.gz
+    sha256: b557afb943086a8b002de8e71818746d5ed35f76e1716296d359f0a49e7a3ae4
     bin: bin/clusterctl-operator.exe
 
 


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR updates index.yaml for v0.15.0.

Automatically generated by `make update-helm-repo`.