### PR TITLE
🐛 Remove metricsBindAddr from helmchart

### DIFF
--- a/hack/charts/cluster-api-operator/templates/deployment.yaml
+++ b/hack/charts/cluster-api-operator/templates/deployment.yaml
@@ -100,10 +100,10 @@ spec:
           {{- if $.Values.diagnosticsAddress }}
           {{- $diagnosticsPort := $.Values.diagnosticsAddress }}
           {{- if contains ":" $diagnosticsPort -}}
-          {{ $diagnosticsPort = ( split ":" $.Values.diagnosticsAddress)._1 }}
+          {{ $diagnosticsPort = ( split ":" $.Values.diagnosticsAddress)._1 | int }}
           {{- end }}
         - containerPort: {{ $diagnosticsPort | int }}
-          name: diagnostics
+          name: metrics
           protocol: TCP
           {{- end }}
         {{- with .Values.resources.manager }}

--- a/hack/charts/cluster-api-operator/templates/deployment.yaml
+++ b/hack/charts/cluster-api-operator/templates/deployment.yaml
@@ -97,6 +97,15 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+          {{- if $.Values.diagnosticsAddress }}
+          {{- $diagnosticsPort := $.Values.diagnosticsAddress }}
+          {{- if contains ":" $diagnosticsPort -}}
+          {{ $diagnosticsPort = ( split ":" $.Values.diagnosticsAddress)._1 }}
+          {{- end }}
+        - containerPort: {{ $diagnosticsPort | int }}
+          name: diagnostics
+          protocol: TCP
+          {{- end }}
         {{- with .Values.resources.manager }}
         resources:
         {{- toYaml . | nindent 12 }}

--- a/hack/charts/cluster-api-operator/templates/deployment.yaml
+++ b/hack/charts/cluster-api-operator/templates/deployment.yaml
@@ -65,9 +65,6 @@ spec:
         {{- if .Values.healthAddr }}
         - --health-addr={{ .Values.healthAddr }}
         {{- end }}
-        {{- if .Values.metricsBindAddr }}
-        - --metrics-bind-addr={{ .Values.metricsBindAddr }}
-        {{- end }}
         {{- if .Values.diagnosticsAddress }}
         - --diagnostics-address={{ .Values.diagnosticsAddress }}
         {{- end }}
@@ -99,9 +96,6 @@ spec:
         ports:
         - containerPort: 9443
           name: webhook-server
-          protocol: TCP
-        - containerPort: {{ ( split ":" $.Values.metricsBindAddr)._1 | int }}
-          name: metrics
           protocol: TCP
         {{- with .Values.resources.manager }}
         resources:

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -24,7 +24,6 @@ image:
 env:
   manager: []
 healthAddr: ":8081"
-metricsBindAddr: "127.0.0.1:8080"
 diagnosticsAddress: "8443"
 insecureDiagnostics: false
 watchConfigSecret: false

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -24,7 +24,7 @@ image:
 env:
   manager: []
 healthAddr: ":8081"
-diagnosticsAddress: "8443"
+diagnosticsAddress: ":8443"
 insecureDiagnostics: false
 watchConfigSecret: false
 imagePullSecrets: {}

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -28387,7 +28387,7 @@ spec:
       - args:
         - --v=2
         - --health-addr=:8081
-        - --diagnostics-address=8443
+        - --diagnostics-address=:8443
         - --leader-elect=true
         command:
         - /manager

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -28387,7 +28387,6 @@ spec:
       - args:
         - --v=2
         - --health-addr=:8081
-        - --metrics-bind-addr=127.0.0.1:8080
         - --diagnostics-address=8443
         - --leader-elect=true
         command:
@@ -28399,8 +28398,8 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        - containerPort: 8080
-          name: metrics
+        - containerPort: 8443
+          name: diagnostics
           protocol: TCP
         resources:
             limits:

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -28399,7 +28399,7 @@ spec:
           name: webhook-server
           protocol: TCP
         - containerPort: 8443
-          name: diagnostics
+          name: metrics
           protocol: TCP
         resources:
             limits:


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the [deprecated and now removed](https://github.com/kubernetes-sigs/cluster-api/pull/11140) _--metrics-bind-addr_ flag from the helmchart.

**Which issue(s) this PR fixes**
Fixes #664 
