### PR TITLE
🌱 Implement healthz and readyz checks in the deployment

### DIFF
--- a/hack/charts/cluster-api-operator/templates/deployment.yaml
+++ b/hack/charts/cluster-api-operator/templates/deployment.yaml
@@ -123,6 +123,30 @@ spec:
         {{- toYaml . | nindent 12 }}
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
+        {{- $healthAddr := $.Values.healthAddr }}
+        {{- if contains ":" $healthAddr -}}
+        {{ $healthAddr = ( split ":" $.Values.healthAddr)._1 | int }}
+        {{- end }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: {{ $healthAddr | default 9440 }}
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: {{ $healthAddr | default 9440 }}
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
       terminationGracePeriodSeconds: 10
       {{- with .Values.volumes }}
       volumes:

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -23,8 +23,8 @@ image:
     pullPolicy: IfNotPresent
 env:
   manager: []
-healthAddr: ":8081"
 diagnosticsAddress: ":8443"
+healthAddr: ":9440"
 insecureDiagnostics: false
 watchConfigSecret: false
 imagePullSecrets: {}

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -28386,7 +28386,7 @@ spec:
       containers:
       - args:
         - --v=2
-        - --health-addr=:8081
+        - --health-addr=:9440
         - --diagnostics-address=:8443
         - --leader-elect=true
         command:
@@ -28413,6 +28413,26 @@ spec:
               name: cert
               readOnly: true
         terminationMessagePolicy: FallbackToLogsOnError
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 9440
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 9440
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cert


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This change standardizes health check endpoint to use default port of `:9440`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
