### PR TITLE
🐛 avoid empty manager field in ControlPlaneProvider when no features gates provided

### DIFF
--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -45,8 +45,8 @@ spec:
   version: {{ $controlPlaneVersion }}
 {{- end }}
 {{- if $.Values.manager }}
-  manager:
 {{- if hasKey $.Values.manager.featureGates $controlPlaneName }}
+  manager:
 {{- range $key, $value := $.Values.manager.featureGates }}
   {{- if eq $key $controlPlaneName }}
     featureGates:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Handle cases where manager values is present for other provider than the controlplaneprovider one.
This will make sure the manager field for a specific control plane provider is added only if featureGates for this one are present.

Example with current/v0.15.1 chart:
```
# Source: cluster-api-operator/charts/cluster-api-operator/templates/infra-conditions.yaml
apiVersion: operator.cluster.x-k8s.io/v1alpha2
kind: ControlPlaneProvider
metadata:
  name: kubeadm
  namespace: capi-kubeadm-control-plane-system
  annotations:
    "helm.sh/hook": "post-install,post-upgrade"
    "helm.sh/hook-weight": "2"
    "argocd.argoproj.io/sync-wave": "2"
spec:
  manager:
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
