### PR TITLE
:seedling: Make annotation and component constants public and exportable

### DIFF
--- a/api/v1alpha2/provider_types.go
+++ b/api/v1alpha2/provider_types.go
@@ -25,6 +25,12 @@ import (
 const (
 	ProviderFinalizer         = "provider.cluster.x-k8s.io"
 	ConfigMapVersionLabelName = "provider.cluster.x-k8s.io/version"
+
+	CompressedAnnotation = "provider.cluster.x-k8s.io/compressed"
+
+	MetadataConfigMapKey            = "metadata"
+	ComponentsConfigMapKey          = "components"
+	AdditionalManifestsConfigMapKey = "manifests"
 )
 
 // ProviderSpec is the desired state of the Provider.

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -316,7 +316,7 @@ func (p *phaseReconciler) configmapRepository(ctx context.Context, labelSelector
 			return nil, fmt.Errorf("ConfigMap %s/%s has invalid version:%s (%s)", cm.Namespace, cm.Name, version, errMsg)
 		}
 
-		metadata, ok := cm.Data[metadataConfigMapKey]
+		metadata, ok := cm.Data[operatorv1.MetadataConfigMapKey]
 		if !ok {
 			return nil, fmt.Errorf("ConfigMap %s/%s has no metadata", cm.Namespace, cm.Name)
 		}
@@ -349,14 +349,14 @@ func (p *phaseReconciler) fetchAddionalManifests(ctx context.Context) (string, e
 		}
 	}
 
-	return cm.Data[additionalManifestsConfigMapKey], nil
+	return cm.Data[operatorv1.AdditionalManifestsConfigMapKey], nil
 }
 
 // getComponentsData returns components data based on if it's compressed or not.
 func getComponentsData(cm corev1.ConfigMap) (string, error) {
 	// Data is not compressed, return it immediately.
-	if cm.GetAnnotations()[compressedAnnotation] != "true" {
-		components, ok := cm.Data[componentsConfigMapKey]
+	if cm.GetAnnotations()[operatorv1.CompressedAnnotation] != "true" {
+		components, ok := cm.Data[operatorv1.ComponentsConfigMapKey]
 		if !ok {
 			return "", fmt.Errorf("ConfigMap %s/%s Data has no components", cm.Namespace, cm.Name)
 		}
@@ -365,7 +365,7 @@ func getComponentsData(cm corev1.ConfigMap) (string, error) {
 	}
 
 	// Otherwise we have to decompress the data first.
-	compressedComponents, ok := cm.BinaryData[componentsConfigMapKey]
+	compressedComponents, ok := cm.BinaryData[operatorv1.ComponentsConfigMapKey]
 	if !ok {
 		return "", fmt.Errorf("ConfigMap %s/%s BinaryData has no components", cm.Namespace, cm.Name)
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As developer I'm creating Cluster API operator resources from the golang code and would like to have to utilize common project constants as much as possible to avoid mistakes and reduce number of copy/paste operation.
This PR allows to use constants for the air-gapped installation to be imported from the project API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
