### PR TITLE
🐛 Fix helm chart e2e tests: MatchYAML to Equal

### DIFF
--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -38,7 +38,7 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $coreVersion $.Values.configSecret.name }}
+{{- if or $coreVersion $.Values.configSecret.name $.Values.manager }}
 spec:
 {{- end}}
 {{- if $coreVersion }}

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		manifests, err := fullRun.Run(nil)
 		Expect(err).ToNot(HaveOccurred())
 		fullChartInstall, err := os.ReadFile(filepath.Join(customManifestsFolder, "full-chart-install.yaml"))
-		Expect(manifests).To(MatchYAML(string(fullChartInstall)))
+		Expect(manifests).To(Equal(string(fullChartInstall)))
 	})
 
 	It("should not deploy providers when none specified", func() {
@@ -158,7 +158,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "all-providers-custom-ns-versions.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy all providers with custom versions", func() {
@@ -175,7 +175,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "all-providers-custom-versions.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy all providers with latest version", func() {
@@ -192,7 +192,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "all-providers-latest-versions.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy core, bootstrap, control plane when only infra is specified", func() {
@@ -205,7 +205,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-infra.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy core when only bootstrap is specified", func() {
@@ -218,7 +218,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-bootstrap.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy core when only control plane is specified", func() {
@@ -231,7 +231,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-control-plane.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy multiple infra providers with custom namespace and versions", func() {
@@ -244,7 +244,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "multiple-infra-custom-ns-versions.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy multiple control plane providers with custom namespace and versions", func() {
@@ -257,7 +257,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "multiple-control-plane-custom-ns-versions.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy multiple bootstrap providers with custom namespace and versions", func() {
@@ -270,7 +270,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "multiple-bootstrap-custom-ns-versions.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy core when only addon is specified", func() {
@@ -283,7 +283,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-addon.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 
 	It("should deploy core, bootstrap, control plane when only infra and addon is specified", func() {
@@ -297,7 +297,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-infra-and-addon.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 	It("should deploy core and infra with feature gates enabled", func() {
 		manifests, err := helmChart.Run(map[string]string{
@@ -320,23 +320,23 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "feature-gates.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 	It("should deploy all providers with manager defined but no feature gates enabled", func() {
 		manifests, err := helmChart.Run(map[string]string{
 			"configSecret.name":                "test-secret-name",
 			"configSecret.namespace":           "test-secret-namespace",
+			"core":                             "cluster-api",
 			"infrastructure":                   "azure",
 			"addon":                            "helm",
-			"core":                             "cluster-api",
 			"manager.cert-manager.enabled":     "false",
 			"manager.cert-manager.installCRDs": "false",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
-		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "all-providers-latest-versions.yaml"))
+		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "all-providers-manager-defined-no-feature-gates.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 	It("should deploy all providers when manager is defined but another infrastructure spec field is defined", func() {
 		manifests, err := helmChart.Run(map[string]string{
@@ -352,7 +352,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "manager-defined-missing-other-infra-spec.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 	It("should deploy kubeadm control plane with manager specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
@@ -368,6 +368,6 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "kubeadm-manager-defined.yaml"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(manifests).To(MatchYAML(string(expectedManifests)))
+		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
 })

--- a/test/e2e/resources/all-providers-custom-ns-versions.yaml
+++ b/test/e2e/resources/all-providers-custom-ns-versions.yaml
@@ -57,7 +57,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  version: v0.1.0-alpha.9
+  version: v0.2.6
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/all-providers-custom-versions.yaml
+++ b/test/e2e/resources/all-providers-custom-versions.yaml
@@ -57,7 +57,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  version: v0.1.0-alpha.9
+  version: v0.2.6
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
+++ b/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
@@ -9,24 +9,6 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: helm-addon-system
 ---
-# Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "1"
-  name: kubeadm-bootstrap-system
----
-# Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "1"
-  name: kubeadm-control-plane-system
----
 # Source: cluster-api-operator/templates/core.yaml
 apiVersion: v1
 kind: Namespace
@@ -36,6 +18,26 @@ metadata:
     "helm.sh/hook-weight": "1"
   name: capi-system
 ---
+# Source: cluster-api-operator/templates/infra-conditions.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: capi-kubeadm-bootstrap-system
+---
+# Source: cluster-api-operator/templates/infra-conditions.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: capi-kubeadm-control-plane-system
+---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: v1
 kind: Namespace
@@ -44,7 +46,7 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "1"
     "argocd.argoproj.io/sync-wave": "1"
-  name: docker-infrastructure-system
+  name: azure-infrastructure-system
 ---
 # Source: cluster-api-operator/templates/addon.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -57,30 +59,36 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 ---
-# Source: cluster-api-operator/templates/bootstrap.yaml
+# Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider
 metadata:
   name: kubeadm
-  namespace: kubeadm-bootstrap-system
+  namespace: capi-kubeadm-bootstrap-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
-# Source: cluster-api-operator/templates/control-plane.yaml
+# Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
-  namespace: kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
 spec:
   manager:
-    featureGates:
-      ClusterTopology: true
-      MachinePool: true
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/core.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -94,16 +102,22 @@ metadata:
     "argocd.argoproj.io/sync-wave": "2"
 spec:
   manager:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
-  name: docker
-  namespace: docker-infrastructure-system
+  name: azure
+  namespace: azure-infrastructure-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
   manager:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace

--- a/test/e2e/resources/feature-gates.yaml
+++ b/test/e2e/resources/feature-gates.yaml
@@ -85,6 +85,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
+  manager:
   configSecret:
     name: aws-variables
     namespace: default

--- a/test/e2e/resources/manager-defined-missing-other-infra-spec.yaml
+++ b/test/e2e/resources/manager-defined-missing-other-infra-spec.yaml
@@ -66,10 +66,6 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
-spec:
-  configSecret:
-    name: test-secret-name
-    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/control-plane.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -81,9 +77,6 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
 spec:
-  configSecret:
-    name: test-secret-name
-    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/core.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -96,9 +89,10 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  configSecret:
-    name: test-secret-name
-    namespace: test-secret-namespace
+  manager:
+    featureGates:
+      ClusterTopology: true
+      MachinePool: true
 ---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -111,10 +105,4 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  configSecret:
-    name: test-secret-name
-    namespace: test-secret-namespace
   manager:
-    featureGates:
-      ClusterTopology: true
-      MachinePool: true


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does**

In this PR, I’ve reverted MatchYAML to Equal, fixed all the broken tests. Also, I discovered and fixed a bug in the core provider specification condition.

**Why we need it**:

While working on PR [#688,](https://github.com/kubernetes-sigs/cluster-api-operator/pull/688) I’ve observed that a significant number of Helm chart e2e tests are false positives. This is because the generated YAML files in the test/e2e/resources directory do not accurately reflect the expected results from the test cases.

I believe this issue arises because `MatchYAML` is being used instead of `Equal` ([#549](https://github.com/kubernetes-sigs/cluster-api-operator/pull/549)). `MatchYAML` only compares the first YAML document within a file, as demonstrated in a quick example.

```
package main_test

import (
	"testing"

	. "github.com/onsi/ginkgo/v2"
	. "github.com/onsi/gomega"
)

func TestGomega(t *testing.T) {
	RegisterFailHandler(Fail)
	RunSpecs(t, "Gomega Suite")
}

var _ = Describe("MatchYAML compares only the first document", func() {
	It("equals", func() {
		yaml1 := `---
hello: world
---
actually: do not care about this document
`
		yaml2 := `---
hello: world
---
even if it is not a valid yaml
`
		Expect(yaml1).To(MatchYAML(yaml2))
	})
})
```