### PR TITLE
🌱 Use go version without the patch number in go.mod files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-operator
 
-go 1.23.0
+go 1.23
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/hack/chart-update/go.mod
+++ b/hack/chart-update/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-operator/hack/chart-update
 
-go 1.23.0
+go 1.23
 
 require (
 	github.com/google/go-github/v50 v50.2.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-operator/hack/tools
 
-go 1.23.0
+go 1.23
 
 replace (
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.9.4

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-operator/test
 
-go 1.23.0
+go 1.23
 
 replace sigs.k8s.io/cluster-api-operator => ../
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like we need to avoid using go version with patch number included in the go.mod files 

```
go: downloading sigs.k8s.io/kustomize/kustomize/v5 v5.6.0
go: sigs.k8s.io/kustomize/kustomize/v5@v5.6.0 (in sigs.k8s.io/kustomize/kustomize/v5@v5.6.0): go.mod:3: invalid go version '1.22.7': must match format 1.23
make[2]: *** [Makefile:204: /workspace/hack/tools/bin/kustomize-v5.6.0] Error 1
```

Similar issue was reported in https://github.com/siderolabs/conform/issues/251 and suggestion was to remove patch number from the version. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


Unfortunately, when running locally the same target (`make release-manifests`) it passes and there is no way to test it other then merging and watching the job in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cluster-api-operator-push-images
