### PR TITLE
🐛 Bump gcb-docker-gcloud image tag in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
**What this PR does / why we need it**:
After a recent discussion over the slack [thread](https://kubernetes.slack.com/archives/C09QZ4DQB/p1738139430595509) the root cause for CI failures in https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/post-cluster-api-operator-push-images seems to be the old image used in cloudbuild which does not support go 1.23. 
This PR bumps gcb-docker-gcloud image tag in cloudbuild to latest which should support go version 1.23.x

Similar issue: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2297

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
