### PR TITLE
:sparkles: Handle Kubernetes events for waiting CoreProvider in preflight check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,7 +29,7 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - forcetypeassert
     - ginkgolinter
     - goconst

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -37,7 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/flags"
 	"sigs.k8s.io/cluster-api/version"
 	ctrl "sigs.k8s.io/controller-runtime"
-	cache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -194,7 +195,7 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	setupChecks(mgr)
-	setupReconcilers(mgr, watchConfigSecretChanges)
+	setupReconcilers(ctx, mgr, watchConfigSecretChanges)
 	setupWebhooks(mgr)
 
 	// +kubebuilder:scaffold:builder
@@ -218,14 +219,14 @@ func setupChecks(mgr ctrl.Manager) {
 	}
 }
 
-func setupReconcilers(mgr ctrl.Manager, watchConfigSecretChanges bool) {
+func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchConfigSecretChanges bool) {
 	if err := (&providercontroller.GenericProviderReconciler{
 		Provider:                 &operatorv1.CoreProvider{},
 		ProviderList:             &operatorv1.CoreProviderList{},
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
-	}).SetupWithManager(mgr, concurrency(concurrencyNumber)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CoreProvider")
 		os.Exit(1)
 	}
@@ -236,7 +237,7 @@ func setupReconcilers(mgr ctrl.Manager, watchConfigSecretChanges bool) {
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
-	}).SetupWithManager(mgr, concurrency(concurrencyNumber)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InfrastructureProvider")
 		os.Exit(1)
 	}
@@ -247,7 +248,7 @@ func setupReconcilers(mgr ctrl.Manager, watchConfigSecretChanges bool) {
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
-	}).SetupWithManager(mgr, concurrency(concurrencyNumber)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BootstrapProvider")
 		os.Exit(1)
 	}
@@ -258,7 +259,7 @@ func setupReconcilers(mgr ctrl.Manager, watchConfigSecretChanges bool) {
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
-	}).SetupWithManager(mgr, concurrency(concurrencyNumber)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ControlPlaneProvider")
 		os.Exit(1)
 	}
@@ -269,7 +270,7 @@ func setupReconcilers(mgr ctrl.Manager, watchConfigSecretChanges bool) {
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
-	}).SetupWithManager(mgr, concurrency(concurrencyNumber)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AddonProvider")
 		os.Exit(1)
 	}
@@ -280,7 +281,7 @@ func setupReconcilers(mgr ctrl.Manager, watchConfigSecretChanges bool) {
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
-	}).SetupWithManager(mgr, concurrency(concurrencyNumber)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IPAMProvider")
 		os.Exit(1)
 	}
@@ -291,7 +292,7 @@ func setupReconcilers(mgr ctrl.Manager, watchConfigSecretChanges bool) {
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
-	}).SetupWithManager(mgr, concurrency(concurrencyNumber)); err != nil {
+	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RuntimeExtensionProvider")
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/Masterminds/goutils v1.1.1
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-errors/errors v1.5.1
 	github.com/go-logr/logr v1.4.2
@@ -30,7 +31,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
-	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect

--- a/internal/controller/consts.go
+++ b/internal/controller/consts.go
@@ -16,13 +16,7 @@ limitations under the License.
 
 package controller
 
-import "time"
-
 const (
-	// preflightFailedRequeueAfter is how long to wait before trying to reconcile
-	// if some preflight check has failed.
-	preflightFailedRequeueAfter = 30 * time.Second
-
 	// configPath is the path to the clusterctl config file.
 	configPath = "/config/clusterctl.yaml"
 )

--- a/internal/controller/coreprovider_to_providers.go
+++ b/internal/controller/coreprovider_to_providers.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
+	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// newCoreProviderToProviderFuncMapForProviderList maps a ready CoreProvider object to all other provider objects.
+// It lists all the providers and if its PreflightCheckCondition is not True, this object will be added to the resulting request.
+// This means that notifications will only be sent to those objects that have not pass PreflightCheck.
+func newCoreProviderToProviderFuncMapForProviderList(k8sClient client.Client, providerList genericprovider.GenericProviderList) handler.MapFunc {
+	providerListType := fmt.Sprintf("%t", providerList)
+
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		log := ctrl.LoggerFrom(ctx).WithValues("provider", map[string]string{"name": obj.GetName(), "namespace": obj.GetNamespace()}, "providerListType", providerListType)
+		coreProvider, ok := obj.(*operatorv1.CoreProvider)
+
+		if !ok {
+			log.Error(fmt.Errorf("expected a %T but got a %T", operatorv1.CoreProvider{}, obj), "unable to cast object")
+			return nil
+		}
+
+		// We don't want to raise events if CoreProvider is not ready yet.
+		if !conditions.IsTrue(coreProvider, clusterv1.ReadyCondition) {
+			return nil
+		}
+
+		var requests []reconcile.Request
+
+		if err := k8sClient.List(ctx, providerList); err != nil {
+			log.Error(err, "failed to list providers")
+			return nil
+		}
+
+		for _, provider := range providerList.GetItems() {
+			if !conditions.IsTrue(provider, operatorv1.PreflightCheckCondition) {
+				// Raise secondary events for the providers that fail PreflightCheck.
+				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(provider)})
+			}
+		}
+
+		return requests
+	}
+}

--- a/internal/controller/coreprovider_to_providers_test.go
+++ b/internal/controller/coreprovider_to_providers_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestCoreProviderToProvidersMapper(t *testing.T) {
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name         string
+		coreProvider client.Object
+		expected     []ctrl.Request
+	}{
+		{
+			name: "Core provider Ready condition is True",
+			coreProvider: &operatorv1.CoreProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "core-provider",
+					Namespace: testNamespaceName,
+				},
+				Status: operatorv1.CoreProviderStatus{
+					ProviderStatus: operatorv1.ProviderStatus{
+						Conditions: clusterv1.Conditions{
+							{
+								Type:               clusterv1.ReadyCondition,
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+								Message:            "Provider is ready",
+							},
+						},
+					},
+				},
+			},
+			expected: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: testNamespaceName, Name: "preflight-checks-condition-false"}},
+				{NamespacedName: types.NamespacedName{Namespace: testNamespaceName, Name: "empty-status-conditions"}},
+			},
+		},
+		{
+			name: "Core provider is not ready",
+			coreProvider: &operatorv1.CoreProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "core-provider",
+					Namespace: testNamespaceName,
+				},
+			},
+			expected: []reconcile.Request{},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(setupScheme()).
+		WithObjects(
+			&operatorv1.InfrastructureProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "preflight-checks-condition-false",
+					Namespace: testNamespaceName,
+				},
+				Spec: operatorv1.InfrastructureProviderSpec{
+					ProviderSpec: operatorv1.ProviderSpec{},
+				},
+				Status: operatorv1.InfrastructureProviderStatus{
+					ProviderStatus: operatorv1.ProviderStatus{
+						Conditions: clusterv1.Conditions{
+							{
+								Type:               operatorv1.PreflightCheckCondition,
+								Status:             corev1.ConditionFalse,
+								LastTransitionTime: metav1.Now(),
+								Reason:             operatorv1.WaitingForCoreProviderReadyReason,
+								Message:            "Core provider is not ready",
+							},
+						},
+					},
+				},
+			},
+			&operatorv1.InfrastructureProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "preflight-checks-condition-true",
+					Namespace: testNamespaceName,
+				},
+				Spec: operatorv1.InfrastructureProviderSpec{
+					ProviderSpec: operatorv1.ProviderSpec{},
+				},
+				Status: operatorv1.InfrastructureProviderStatus{
+					ProviderStatus: operatorv1.ProviderStatus{
+						Conditions: clusterv1.Conditions{
+							{
+								Type:               operatorv1.PreflightCheckCondition,
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Now(),
+								Message:            "Core provider is ready",
+							},
+						},
+					},
+				},
+			},
+			&operatorv1.InfrastructureProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-status-conditions",
+					Namespace: testNamespaceName,
+				},
+				Spec: operatorv1.InfrastructureProviderSpec{
+					ProviderSpec: operatorv1.ProviderSpec{},
+				},
+			},
+		).
+		Build()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := newCoreProviderToProviderFuncMapForProviderList(k8sClient, &operatorv1.InfrastructureProviderList{})(ctx, tc.coreProvider)
+			g.Expect(requests).To(HaveLen(len(tc.expected)))
+			g.Expect(requests).To(ContainElements(tc.expected))
+		})
+	}
+}

--- a/internal/controller/genericprovider_controller_test.go
+++ b/internal/controller/genericprovider_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
@@ -298,13 +299,8 @@ func TestReconcilerPreflightConditions(t *testing.T) {
 						return false
 					}
 
-					for _, cond := range p.GetStatus().Conditions {
-						if cond.Type == operatorv1.PreflightCheckCondition {
-							t.Log(t.Name(), p.GetName(), cond)
-							if cond.Status == corev1.ConditionTrue {
-								return true
-							}
-						}
+					if conditions.IsTrue(p, operatorv1.PreflightCheckCondition) {
+						return true
 					}
 				}
 

--- a/internal/controller/healthcheck/suite_test.go
+++ b/internal/controller/healthcheck/suite_test.go
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 		Provider:     &operatorv1.CoreProvider{},
 		ProviderList: &operatorv1.CoreProviderList{},
 		Client:       env,
-	}).SetupWithManager(env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start CoreProviderReconciler: %v", err))
 	}
 

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -110,7 +110,7 @@ func newPhaseReconciler(r GenericProviderReconciler, provider genericprovider.Ge
 
 // preflightChecks a wrapper around the preflight checks.
 func (p *phaseReconciler) preflightChecks(ctx context.Context) (reconcile.Result, error) {
-	return preflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
+	return reconcile.Result{}, preflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
 }
 
 // initializePhaseReconciler initializes phase reconciler.

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -96,9 +96,9 @@ func TestSecretReader(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(expectedValue2).To(Equal(testValue2))
 
-	exptectedProviderData, err := configreader.Get("providers")
+	expectedProviderData, err := configreader.Get("providers")
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(exptectedProviderData).To(Equal(`- name: test-key3
+	g.Expect(expectedProviderData).To(Equal(`- name: test-key3
   type: CoreProvider
   url: test-value3
 - name: cluster-api

--- a/internal/controller/preflight_checks_test.go
+++ b/internal/controller/preflight_checks_test.go
@@ -607,7 +607,7 @@ func TestPreflightChecks(t *testing.T) {
 				gs.Expect(fakeclient.Create(ctx, c)).To(Succeed())
 			}
 
-			_, err := preflightChecks(context.Background(), fakeclient, tc.providers[0], tc.providerList)
+			err := preflightChecks(context.Background(), fakeclient, tc.providers[0], tc.providerList)
 			if tc.expectedError {
 				gs.Expect(err).To(HaveOccurred())
 			} else {
@@ -704,7 +704,7 @@ func TestPreflightChecksUpgradesDowngrades(t *testing.T) {
 
 			gs.Expect(fakeclient.Create(ctx, provider)).To(Succeed())
 
-			_, err := preflightChecks(context.Background(), fakeclient, provider, &operatorv1.CoreProviderList{})
+			err := preflightChecks(context.Background(), fakeclient, provider, &operatorv1.CoreProviderList{})
 			if tc.expectedError {
 				gs.Expect(err).To(HaveOccurred())
 			} else {

--- a/internal/controller/secrets_to_providers.go
+++ b/internal/controller/secrets_to_providers.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Masterminds/goutils"
+	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,9 +29,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	configSecretNameField      = "spec.configSecret.name"      //nolint:gosec
+	configSecretNamespaceField = "spec.configSecret.namespace" //nolint:gosec
+)
+
 // newSecretToProviderFuncMapForProviderList maps a Kubernetes secret to all the providers that reference it.
-// It lists all the providers and checks whether the secret is referenced as the provider's config secret.
-// If the providers references a secret without a namespace, it will assume the secret is in the same namespace as the provider.
+// It lists all the providers matching spec.configSecret.name values with the secret name querying by index.
+// If the provider references a secret without a namespace, it will assume the secret is in the same namespace as the provider.
 func newSecretToProviderFuncMapForProviderList(k8sClient client.Client, providerList genericprovider.GenericProviderList) handler.MapFunc {
 	providerListType := fmt.Sprintf("%t", providerList)
 
@@ -38,35 +45,37 @@ func newSecretToProviderFuncMapForProviderList(k8sClient client.Client, provider
 
 		var requests []reconcile.Request
 
-		if err := k8sClient.List(ctx, providerList); err != nil {
+		configSecretMatcher := client.MatchingFields{configSecretNameField: secret.GetName(), configSecretNamespaceField: secret.GetNamespace()}
+		if err := k8sClient.List(ctx, providerList, configSecretMatcher); err != nil {
 			log.Error(err, "failed to list providers")
 			return nil
 		}
 
 		for _, provider := range providerList.GetItems() {
 			log = log.WithValues("provider", map[string]string{"name": provider.GetName(), "namespace": provider.GetNamespace()})
-
-			spec := provider.GetSpec()
-
-			if spec.ConfigSecret == nil {
-				log.V(5).Info("Provider does not reference a config secret")
-				continue
-			}
-
-			configNamespace := spec.ConfigSecret.Namespace
-			if configNamespace == "" {
-				log.V(5).Info("Provider configSecret namespace is empty, using provider namespace")
-
-				configNamespace = provider.GetNamespace()
-			}
-
-			if configNamespace == secret.GetNamespace() && spec.ConfigSecret.Name == secret.GetName() {
-				log.V(2).Info("Found provider using config secret")
-
-				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(provider)})
-			}
+			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(provider)})
 		}
 
 		return requests
 	}
+}
+
+// configSecretNameIndexFunc is indexing config Secret name field.
+var configSecretNameIndexFunc = func(obj client.Object) []string {
+	provider, ok := obj.(operatorv1.GenericProvider)
+	if !ok || provider.GetSpec().ConfigSecret == nil {
+		return nil
+	}
+
+	return []string{provider.GetSpec().ConfigSecret.Name}
+}
+
+// configSecretNamespaceIndexFunc is indexing config Secret namespace field.
+var configSecretNamespaceIndexFunc = func(obj client.Object) []string {
+	provider, ok := obj.(operatorv1.GenericProvider)
+	if !ok || provider.GetSpec().ConfigSecret == nil {
+		return nil
+	}
+
+	return []string{goutils.DefaultString(provider.GetSpec().ConfigSecret.Namespace, provider.GetNamespace())}
 }

--- a/internal/controller/secrets_to_providers_test.go
+++ b/internal/controller/secrets_to_providers_test.go
@@ -36,6 +36,8 @@ func TestProviderSecretMapper(t *testing.T) {
 
 	k8sClient := fake.NewClientBuilder().
 		WithScheme(setupScheme()).
+		WithIndex(&operatorv1.InfrastructureProvider{}, configSecretNameField, configSecretNameIndexFunc).
+		WithIndex(&operatorv1.InfrastructureProvider{}, configSecretNamespaceField, configSecretNamespaceIndexFunc).
 		WithObjects(
 			&operatorv1.InfrastructureProvider{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 		ProviderList:             &operatorv1.CoreProviderList{},
 		Client:                   env,
 		WatchConfigSecretChanges: true,
-	}).SetupWithManager(env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start CoreProviderReconciler: %v", err))
 	}
 
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 		ProviderList:             &operatorv1.InfrastructureProviderList{},
 		Client:                   env,
 		WatchConfigSecretChanges: true,
-	}).SetupWithManager(env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start InfrastructureProviderReconciler: %v", err))
 	}
 
@@ -67,7 +67,7 @@ func TestMain(m *testing.M) {
 		ProviderList:             &operatorv1.BootstrapProviderList{},
 		Client:                   env,
 		WatchConfigSecretChanges: true,
-	}).SetupWithManager(env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start BootstrapProviderReconciler: %v", err))
 	}
 
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 		ProviderList:             &operatorv1.ControlPlaneProviderList{},
 		Client:                   env,
 		WatchConfigSecretChanges: true,
-	}).SetupWithManager(env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start ControlPlaneProviderReconciler: %v", err))
 	}
 

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -298,26 +298,13 @@ func (e *Environment) CreateNamespace(ctx context.Context, generateName string) 
 }
 
 func (e *Environment) EnsureNamespaceExists(ctx context.Context, namespace string) error {
-	// Check if the namespace exists
-	ns := &corev1.Namespace{}
-
-	err := e.Client.Get(ctx, client.ObjectKey{Name: namespace}, ns)
-	if err == nil {
-		return nil
-	}
-
-	if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("unexpected error during namespace checking: %w", err)
-	}
-
-	// Create the namespace if it doesn't exist
 	newNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},
 	}
 
-	if err := e.Client.Create(ctx, newNamespace); err != nil {
+	if err := e.Client.Create(ctx, newNamespace); client.IgnoreAlreadyExists(err) != nil {
 		return fmt.Errorf("unable to create namespace %s: %w", namespace, err)
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR allows you to avoid from polling in reconcile loop every 30 seconds, and move to catching events from the CoreProvider object when Ready condition become True. We should avoid re-querying at intervals where possible.

Also, configSecret request is optimized if option is enabled. Since a cluster can have a large number of secret objects, it is a very expensive procedure to go through all the providers each time secrets are catches without an index. The number of provider objects in the cluster is small enough that the index on the name/namespace fields will not be very large.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
