### PR TITLE
✨ Allow accepting self-hosted gitlab installations

### DIFF
--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -642,6 +642,10 @@ func TestRepositoryFactory(t *testing.T) {
 			fetchURL: "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/cluster-api-proviver-aws/v1.4.1/path",
 		},
 		{
+			name:     "gitlab hyphenated repo",
+			fetchURL: "https://gitlab-test.example.org/api/v4/projects/group%2Fproject/packages/generic/cluster-api-proviver-aws/v1.4.1/path",
+		},
+		{
 			name:          "unsupported url",
 			fetchURL:      "https://unsupported.xyz/kubernetes-sigs/cluster-api-provider-aws/releases/v1.4.1/infrastructure-components.yaml",
 			expectedError: true,

--- a/util/util.go
+++ b/util/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
@@ -33,7 +34,7 @@ import (
 const (
 	httpsScheme             = "https"
 	githubDomain            = "github.com"
-	gitlabHostPrefix        = "gitlab."
+	gitlabHostPrefix        = "gitlab"
 	gitlabPackagesAPIPrefix = "/api/v4/projects/"
 )
 
@@ -128,8 +129,9 @@ func RepositoryFactory(ctx context.Context, providerConfig configclient.Provider
 		return repo, err
 	}
 
-	// if the url is a GitLab repository
-	if strings.HasPrefix(rURL.Host, gitlabHostPrefix) && strings.HasPrefix(rURL.Path, gitlabPackagesAPIPrefix) {
+	// if the url is a GitLab repository starting with gitlab- or gitlab.
+	gitlabHostRegex := regexp.MustCompile(`^` + regexp.QuoteMeta(gitlabHostPrefix) + `(-.*)?\.`) // ^gitlab(-.*)?\. to match gitlab- or gitlab.
+	if gitlabHostRegex.MatchString(rURL.Host) && strings.HasPrefix(rURL.Path, gitlabPackagesAPIPrefix) {
 		repo, err := repository.NewGitLabRepository(providerConfig, configVariablesClient)
 		if err != nil {
 			return nil, fmt.Errorf("error creating the GitLab repository client: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**: The current implementation of the gitlab check uses HasPrefix - which doesn't allow for a gitlab whose domain could be different (gitlab-example.domain.com)

**Which issue(s) this PR fixes**:
Fixes #705
