### PR TITLE
🌱 Add new Makefile target to run e2e tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,6 +541,9 @@ clean-release: ## Remove the release folder
 ## E2E
 ## --------------------------------------
 
+.PHONY: test-e2e-local ## Run e2e tests locally
+test-e2e-local: docker-build-e2e test-e2e
+
 .PHONY: test-e2e
 test-e2e: $(KUSTOMIZE)
 	$(MAKE) release-manifests

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,5 +1,13 @@
 # Test
 
+## Run e2e tests locally
+
+To run e2e  tests locally, run the following command
+
+```bash
+make test-e2e-local
+```
+
 ## Compatibility notice
 
 This package is not subject to deprecation notices or compatibility guarantees.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR introduces new Makefile target with `docker-build-e2e` prerequisite target 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #141 
