### PR TITLE
🌱 Add ability to build operator images in a private docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@
 # Build the manager binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+ARG deployment_base_image
+ARG deployment_base_image_tag
+ARG goprivate
 
 FROM ${builder_image} as builder
 WORKDIR /workspace
@@ -25,6 +28,7 @@ WORKDIR /workspace
 ARG goproxy=https://proxy.golang.org
 # Run this with docker build --build-arg package=./controlplane/kubeadm or --build-arg package=./bootstrap/kubeadm
 ENV GOPROXY=$goproxy
+ENV GOPRIVATE=$goprivate
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -32,7 +36,8 @@ COPY go.sum go.sum
 
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=secret,id=netrc,required=false,target=/root/.netrc \
+    --mount=type=cache,target=/go/pkg/mod \
   go mod download
 
 # Copy the sources
@@ -50,7 +55,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   -o manager ${path}
 
 # Production image
-FROM gcr.io/distroless/static:nonroot
+FROM ${deployment_base_image}:${deployment_base_image_tag}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR allows to build operator images in a private docker registry infrastructure without having to edit the Makefile and Dockerfile. All parameters can be configured. The current parameters are left equal to the default values before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
