### PR TITLE
🐛: fix unknown provider errors when using fetchConfigs

### DIFF
--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -573,8 +573,6 @@ func getProvider(provider operatorv1.GenericProvider, defaultVersion string) clu
 }
 
 func (p *phaseReconciler) getCustomProviders(ctx context.Context) ([]operatorv1.GenericProvider, error) {
-	log := ctrl.LoggerFrom(ctx)
-
 	customProviders := []operatorv1.GenericProvider{}
 	currProviderName := p.provider.GetName()
 	currProviderType := p.provider.GetType()
@@ -604,8 +602,6 @@ func (p *phaseReconciler) getCustomProviders(ctx context.Context) ([]operatorv1.
 			if provider.GetName() == currProviderName && provider.GetType() == currProviderType || provider.GetSpec().FetchConfig == nil {
 				continue
 			}
-
-			log.Info("custom provider found", provider.GetName(), provider.GetType(), provider.GetNamespace())
 
 			customProviders = append(customProviders, genericProviderListItems[i])
 		}

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -147,7 +147,7 @@ func (p *phaseReconciler) initializePhaseReconciler(ctx context.Context) (reconc
 		return reconcile.Result{}, err
 	}
 
-	// Get all providers using fetchConfig that aren't the current provider.
+	// Get all custom providers using fetchConfig that aren't the current provider.
 	customProviders, err := util.GetCustomProviders(ctx, p.ctrlClient, p.provider)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/test/e2e/air_gapped_test.go
+++ b/test/e2e/air_gapped_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapped environment", func() {
-	It("should successfully create config maps with Core and Bootstrap Provider manifests", func() {
+	It("should successfully create config maps with Controlplane, Core, and Bootstrap Provider manifests", func() {
 		// Ensure that there are no Cluster API installed
 		deleteClusterAPICRDs(bootstrapClusterProxy)
 
@@ -62,7 +62,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		}
 
 		By("Creating provider namespaces")
-		for _, namespaceName := range []string{capkbSystemNamespace, capkcpSystemNamespace, capiSystemNamespace} {
+		for _, namespaceName := range []string{cabpkSystemNamespace, cacpkSystemNamespace, capiSystemNamespace} {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespaceName,
@@ -82,7 +82,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		bootstrapProvider := &operatorv1.BootstrapProvider{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      customProviderName,
-				Namespace: capkbSystemNamespace,
+				Namespace: cabpkSystemNamespace,
 			},
 			Spec: operatorv1.BootstrapProviderSpec{
 				ProviderSpec: operatorv1.ProviderSpec{
@@ -105,7 +105,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Waiting for the bootstrap provider deployment to be ready")
 		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
 			Getter:     bootstrapClusterProxy.GetClient(),
-			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: bootstrapProviderDeploymentName, Namespace: capkbSystemNamespace}},
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: bootstrapProviderDeploymentName, Namespace: cabpkSystemNamespace}},
 		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		By("Waiting for bootstrap provider to be ready")
@@ -166,7 +166,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		controlPlaneProvider := &operatorv1.ControlPlaneProvider{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      customProviderName,
-				Namespace: capkcpSystemNamespace,
+				Namespace: cacpkSystemNamespace,
 			},
 			Spec: operatorv1.ControlPlaneProviderSpec{
 				ProviderSpec: operatorv1.ProviderSpec{
@@ -189,7 +189,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Waiting for the controlplane provider deployment to be ready")
 		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
 			Getter:     bootstrapClusterProxy.GetClient(),
-			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: cpProviderDeploymentName, Namespace: capkcpSystemNamespace}},
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: cpProviderDeploymentName, Namespace: cacpkSystemNamespace}},
 		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		By("Waiting for controlplane provider to be ready")
@@ -210,13 +210,13 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		coreProvider := &operatorv1.CoreProvider{}
 		controlPlaneProvider := &operatorv1.ControlPlaneProvider{}
 
-		bootstrapKey := client.ObjectKey{Namespace: capkbSystemNamespace, Name: customProviderName}
+		bootstrapKey := client.ObjectKey{Namespace: cabpkSystemNamespace, Name: customProviderName}
 		Expect(bootstrapCluster.Get(ctx, bootstrapKey, bootstrapProvider)).To(Succeed())
 
 		coreKey := client.ObjectKey{Namespace: capiSystemNamespace, Name: coreProviderName}
 		Expect(bootstrapCluster.Get(ctx, coreKey, coreProvider)).To(Succeed())
 
-		cpKey := client.ObjectKey{Namespace: capkcpSystemNamespace, Name: customProviderName}
+		cpKey := client.ObjectKey{Namespace: cacpkSystemNamespace, Name: customProviderName}
 		Expect(bootstrapCluster.Get(ctx, cpKey, controlPlaneProvider)).To(Succeed())
 
 		bootstrapProvider.Spec.Version = nextCAPIVersion
@@ -233,7 +233,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Waiting for the bootstrap provider deployment to be ready")
 		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
 			Getter:     bootstrapClusterProxy.GetClient(),
-			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: bootstrapProviderDeploymentName, Namespace: capkbSystemNamespace}},
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: bootstrapProviderDeploymentName, Namespace: cabpkSystemNamespace}},
 		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		By("Waiting for bootstrap provider to be ready")
@@ -265,7 +265,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Waiting for the controlplane provider deployment to be ready")
 		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
 			Getter:     bootstrapClusterProxy.GetClient(),
-			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: cpProviderDeploymentName, Namespace: capkcpSystemNamespace}},
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: cpProviderDeploymentName, Namespace: cacpkSystemNamespace}},
 		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		By("Waiting for controlplane provider to be ready")
@@ -283,7 +283,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		bootstrapCluster := bootstrapClusterProxy.GetClient()
 		bootstrapProvider := &operatorv1.BootstrapProvider{ObjectMeta: metav1.ObjectMeta{
 			Name:      customProviderName,
-			Namespace: capkbSystemNamespace,
+			Namespace: cabpkSystemNamespace,
 		}}
 
 		Expect(bootstrapCluster.Delete(ctx, bootstrapProvider)).To(Succeed())
@@ -291,7 +291,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Waiting for the bootstrap provider deployment to be deleted")
 		WaitForDelete(ctx, For(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 			Name:      bootstrapProviderDeploymentName,
-			Namespace: capkbSystemNamespace,
+			Namespace: cabpkSystemNamespace,
 		}}).In(bootstrapCluster), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		By("Waiting for the bootstrap provider object to be deleted")
@@ -323,7 +323,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Deleting capkb-system namespace")
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: capkbSystemNamespace,
+				Name: cabpkSystemNamespace,
 			},
 		}
 		Expect(bootstrapCluster.Delete(ctx, namespace)).To(Succeed())
@@ -383,7 +383,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		bootstrapCluster := bootstrapClusterProxy.GetClient()
 		ControlPlaneProvider := &operatorv1.ControlPlaneProvider{ObjectMeta: metav1.ObjectMeta{
 			Name:      customProviderName,
-			Namespace: capkcpSystemNamespace,
+			Namespace: cacpkSystemNamespace,
 		}}
 
 		Expect(bootstrapCluster.Delete(ctx, ControlPlaneProvider)).To(Succeed())
@@ -391,7 +391,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Waiting for the controlplane provider deployment to be deleted")
 		WaitForDelete(ctx, For(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
 			Name:      cpProviderDeploymentName,
-			Namespace: capkcpSystemNamespace,
+			Namespace: cacpkSystemNamespace,
 		}}).In(bootstrapCluster), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		By("Waiting for the controlplane provider object to be deleted")
@@ -423,7 +423,7 @@ var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapp
 		By("Deleting capkcp-system namespace")
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: capkcpSystemNamespace,
+				Name: cacpkSystemNamespace,
 			},
 		}
 		Expect(bootstrapCluster.Delete(ctx, namespace)).To(Succeed())

--- a/test/e2e/air_gapped_test.go
+++ b/test/e2e/air_gapped_test.go
@@ -34,37 +34,89 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var _ = Describe("Install Core Provider in an air-gapped environment", func() {
-	It("should successfully create config maps with Core Provider manifests", func() {
+var _ = Describe("Install Controlplane, Core, Bootstrap Providers in an air-gapped environment", func() {
+	It("should successfully create config maps with Core and Bootstrap Provider manifests", func() {
 		// Ensure that there are no Cluster API installed
 		deleteClusterAPICRDs(bootstrapClusterProxy)
 
 		bootstrapCluster := bootstrapClusterProxy.GetClient()
 		configMaps := []corev1.ConfigMap{}
+		configMapFiles := []string{
+			"core-cluster-api-v1.7.7.yaml",
+			"core-cluster-api-v1.8.0.yaml",
+			"bootstrap-kubeadm-v1.7.7.yaml",
+			"bootstrap-kubeadm-v1.8.0.yaml",
+			"controlplane-kubeadm-v1.7.7.yaml",
+			"controlplane-kubeadm-v1.8.0.yaml",
+		}
 
-		for _, fileName := range []string{"core-cluster-api-v1.7.7.yaml", "core-cluster-api-v1.8.0.yaml"} {
-			coreProviderComponents, err := os.ReadFile(customManifestsFolder + fileName)
-			Expect(err).ToNot(HaveOccurred(), "Failed to read the core provider manifests file")
+		for _, fileName := range configMapFiles {
+			providerComponents, err := os.ReadFile(customManifestsFolder + fileName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to read the provider manifests file")
 
 			var configMap corev1.ConfigMap
 
-			Expect(yaml.Unmarshal(coreProviderComponents, &configMap)).To(Succeed())
+			Expect(yaml.Unmarshal(providerComponents, &configMap)).To(Succeed())
 
 			configMaps = append(configMaps, configMap)
 		}
 
-		By("Creating capi-system namespace")
-		namespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: capiSystemNamespace,
-			},
+		By("Creating provider namespaces")
+		for _, namespaceName := range []string{capkbSystemNamespace, capkcpSystemNamespace, capiSystemNamespace} {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			}
+			Expect(bootstrapCluster.Create(ctx, namespace)).To(Succeed())
 		}
-		Expect(bootstrapCluster.Create(ctx, namespace)).To(Succeed())
 
-		By("Applying core provider manifests to the cluster")
+		By("Applying provider manifests to the cluster")
 		for _, cm := range configMaps {
 			Expect(bootstrapCluster.Create(ctx, &cm)).To(Succeed())
 		}
+	})
+
+	It("should successfully create a BootstrapProvider from a config map", func() {
+		bootstrapCluster := bootstrapClusterProxy.GetClient()
+		bootstrapProvider := &operatorv1.BootstrapProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customProviderName,
+				Namespace: capkbSystemNamespace,
+			},
+			Spec: operatorv1.BootstrapProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{
+					FetchConfig: &operatorv1.FetchConfiguration{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"provider.cluster.x-k8s.io/name":    "kubeadm",
+								"provider.cluster.x-k8s.io/type":    "bootstrap",
+								"provider.cluster.x-k8s.io/version": "v1.7.7",
+							},
+						},
+					},
+					Version: previousCAPIVersion,
+				},
+			},
+		}
+
+		Expect(bootstrapCluster.Create(ctx, bootstrapProvider)).To(Succeed())
+
+		By("Waiting for the bootstrap provider deployment to be ready")
+		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+			Getter:     bootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: bootstrapProviderDeploymentName, Namespace: capkbSystemNamespace}},
+		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for bootstrap provider to be ready")
+		WaitFor(ctx, For(bootstrapProvider).In(bootstrapCluster).ToSatisfy(
+			HaveStatusCondition(&bootstrapProvider.Status.Conditions, operatorv1.ProviderInstalledCondition),
+		), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for status.InstalledVersion to be set")
+		WaitFor(ctx, For(bootstrapProvider).In(bootstrapCluster).ToSatisfy(func() bool {
+			return ptr.Equal(bootstrapProvider.Status.InstalledVersion, ptr.To(bootstrapProvider.Spec.Version))
+		}), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 	})
 
 	It("should successfully create a CoreProvider from a config map", func() {
@@ -79,8 +131,9 @@ var _ = Describe("Install Core Provider in an air-gapped environment", func() {
 					FetchConfig: &operatorv1.FetchConfiguration{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"provider.cluster.x-k8s.io/name": "cluster-api",
-								"provider.cluster.x-k8s.io/type": "core",
+								"provider.cluster.x-k8s.io/name":    "cluster-api",
+								"provider.cluster.x-k8s.io/type":    "core",
+								"provider.cluster.x-k8s.io/version": "v1.7.7",
 							},
 						},
 					},
@@ -108,15 +161,90 @@ var _ = Describe("Install Core Provider in an air-gapped environment", func() {
 		}), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 	})
 
-	It("should successfully upgrade a CoreProvider (v1.7.7 -> latest)", func() {
+	It("should successfully create a ControlPlaneProvider from a config map", func() {
 		bootstrapCluster := bootstrapClusterProxy.GetClient()
+		controlPlaneProvider := &operatorv1.ControlPlaneProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customProviderName,
+				Namespace: capkcpSystemNamespace,
+			},
+			Spec: operatorv1.ControlPlaneProviderSpec{
+				ProviderSpec: operatorv1.ProviderSpec{
+					FetchConfig: &operatorv1.FetchConfiguration{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"provider.cluster.x-k8s.io/name":    "kubeadm",
+								"provider.cluster.x-k8s.io/type":    "controlplane",
+								"provider.cluster.x-k8s.io/version": "v1.7.7",
+							},
+						},
+					},
+					Version: previousCAPIVersion,
+				},
+			},
+		}
+
+		Expect(bootstrapCluster.Create(ctx, controlPlaneProvider)).To(Succeed())
+
+		By("Waiting for the controlplane provider deployment to be ready")
+		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+			Getter:     bootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: cpProviderDeploymentName, Namespace: capkcpSystemNamespace}},
+		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for controlplane provider to be ready")
+		WaitFor(ctx, For(controlPlaneProvider).In(bootstrapCluster).ToSatisfy(
+			HaveStatusCondition(&controlPlaneProvider.Status.Conditions, operatorv1.ProviderInstalledCondition),
+		), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for status.InstalledVersion to be set")
+		WaitFor(ctx, For(controlPlaneProvider).In(bootstrapCluster).ToSatisfy(func() bool {
+			return ptr.Equal(controlPlaneProvider.Status.InstalledVersion, ptr.To(controlPlaneProvider.Spec.Version))
+		}), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+	})
+
+	It("should successfully upgrade BootstrapProvider, ControlPlaneProvider, CoreProvider (v1.7.7 -> v1.8.0)", func() {
+		bootstrapCluster := bootstrapClusterProxy.GetClient()
+
+		bootstrapProvider := &operatorv1.BootstrapProvider{}
 		coreProvider := &operatorv1.CoreProvider{}
-		key := client.ObjectKey{Namespace: capiSystemNamespace, Name: coreProviderName}
-		Expect(bootstrapCluster.Get(ctx, key, coreProvider)).To(Succeed())
+		controlPlaneProvider := &operatorv1.ControlPlaneProvider{}
 
-		coreProvider.Spec.Version = ""
+		bootstrapKey := client.ObjectKey{Namespace: capkbSystemNamespace, Name: customProviderName}
+		Expect(bootstrapCluster.Get(ctx, bootstrapKey, bootstrapProvider)).To(Succeed())
 
+		coreKey := client.ObjectKey{Namespace: capiSystemNamespace, Name: coreProviderName}
+		Expect(bootstrapCluster.Get(ctx, coreKey, coreProvider)).To(Succeed())
+
+		cpKey := client.ObjectKey{Namespace: capkcpSystemNamespace, Name: customProviderName}
+		Expect(bootstrapCluster.Get(ctx, cpKey, controlPlaneProvider)).To(Succeed())
+
+		bootstrapProvider.Spec.Version = nextCAPIVersion
+		bootstrapProvider.Spec.FetchConfig.Selector.MatchLabels["provider.cluster.x-k8s.io/version"] = nextCAPIVersion
+		coreProvider.Spec.Version = nextCAPIVersion
+		coreProvider.Spec.FetchConfig.Selector.MatchLabels["provider.cluster.x-k8s.io/version"] = nextCAPIVersion
+		controlPlaneProvider.Spec.Version = nextCAPIVersion
+		controlPlaneProvider.Spec.FetchConfig.Selector.MatchLabels["provider.cluster.x-k8s.io/version"] = nextCAPIVersion
+
+		Expect(bootstrapCluster.Update(ctx, bootstrapProvider)).To(Succeed())
 		Expect(bootstrapCluster.Update(ctx, coreProvider)).To(Succeed())
+		Expect(bootstrapCluster.Update(ctx, controlPlaneProvider)).To(Succeed())
+
+		By("Waiting for the bootstrap provider deployment to be ready")
+		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+			Getter:     bootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: bootstrapProviderDeploymentName, Namespace: capkbSystemNamespace}},
+		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for bootstrap provider to be ready")
+		WaitFor(ctx, For(bootstrapProvider).In(bootstrapCluster).ToSatisfy(
+			HaveStatusCondition(&bootstrapProvider.Status.Conditions, operatorv1.ProviderInstalledCondition),
+		), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for bootstrap provider status.InstalledVersion to be set")
+		WaitFor(ctx, For(bootstrapProvider).In(bootstrapCluster).ToSatisfy(func() bool {
+			return ptr.Equal(bootstrapProvider.Status.InstalledVersion, ptr.To(bootstrapProvider.Spec.Version))
+		}), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
 
 		By("Waiting for the core provider deployment to be ready")
 		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
@@ -133,6 +261,72 @@ var _ = Describe("Install Core Provider in an air-gapped environment", func() {
 		WaitFor(ctx, For(coreProvider).In(bootstrapCluster).ToSatisfy(func() bool {
 			return ptr.Equal(coreProvider.Status.InstalledVersion, ptr.To(coreProvider.Spec.Version))
 		}), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for the controlplane provider deployment to be ready")
+		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+			Getter:     bootstrapClusterProxy.GetClient(),
+			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: cpProviderDeploymentName, Namespace: capkcpSystemNamespace}},
+		}, e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for controlplane provider to be ready")
+		WaitFor(ctx, For(controlPlaneProvider).In(bootstrapCluster).ToSatisfy(
+			HaveStatusCondition(&coreProvider.Status.Conditions, operatorv1.ProviderInstalledCondition),
+		), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for status.InstalledVersion to be set")
+		WaitFor(ctx, For(controlPlaneProvider).In(bootstrapCluster).ToSatisfy(func() bool {
+			return ptr.Equal(controlPlaneProvider.Status.InstalledVersion, ptr.To(controlPlaneProvider.Spec.Version))
+		}), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+	})
+
+	It("should successfully delete a BootstrapProvider", func() {
+		bootstrapCluster := bootstrapClusterProxy.GetClient()
+		bootstrapProvider := &operatorv1.BootstrapProvider{ObjectMeta: metav1.ObjectMeta{
+			Name:      customProviderName,
+			Namespace: capkbSystemNamespace,
+		}}
+
+		Expect(bootstrapCluster.Delete(ctx, bootstrapProvider)).To(Succeed())
+
+		By("Waiting for the bootstrap provider deployment to be deleted")
+		WaitForDelete(ctx, For(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name:      bootstrapProviderDeploymentName,
+			Namespace: capkbSystemNamespace,
+		}}).In(bootstrapCluster), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for the bootstrap provider object to be deleted")
+		WaitForDelete(
+			ctx, For(bootstrapProvider).In(bootstrapCluster),
+			e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+	})
+
+	It("should successfully delete config maps with Bootstrap Provider manifests", func() {
+		bootstrapCluster := bootstrapClusterProxy.GetClient()
+		configMaps := []corev1.ConfigMap{}
+
+		for _, fileName := range []string{"bootstrap-kubeadm-v1.7.7.yaml", "bootstrap-kubeadm-v1.8.0.yaml"} {
+			bootstrapProviderComponents, err := os.ReadFile(customManifestsFolder + fileName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to read the bootstrap provider manifests file")
+
+			var configMap corev1.ConfigMap
+
+			Expect(yaml.Unmarshal(bootstrapProviderComponents, &configMap)).To(Succeed())
+
+			configMaps = append(configMaps, configMap)
+		}
+
+		By("Deleting config maps with bootstrap provider manifests")
+		for _, cm := range configMaps {
+			Expect(bootstrapCluster.Delete(ctx, &cm)).To(Succeed())
+		}
+
+		By("Deleting capkb-system namespace")
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: capkbSystemNamespace,
+			},
+		}
+		Expect(bootstrapCluster.Delete(ctx, namespace)).To(Succeed())
 	})
 
 	It("should successfully delete a CoreProvider", func() {
@@ -180,6 +374,56 @@ var _ = Describe("Install Core Provider in an air-gapped environment", func() {
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: capiSystemNamespace,
+			},
+		}
+		Expect(bootstrapCluster.Delete(ctx, namespace)).To(Succeed())
+	})
+
+	It("should successfully delete a ControlPlaneProvider", func() {
+		bootstrapCluster := bootstrapClusterProxy.GetClient()
+		ControlPlaneProvider := &operatorv1.ControlPlaneProvider{ObjectMeta: metav1.ObjectMeta{
+			Name:      customProviderName,
+			Namespace: capkcpSystemNamespace,
+		}}
+
+		Expect(bootstrapCluster.Delete(ctx, ControlPlaneProvider)).To(Succeed())
+
+		By("Waiting for the controlplane provider deployment to be deleted")
+		WaitForDelete(ctx, For(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name:      cpProviderDeploymentName,
+			Namespace: capkcpSystemNamespace,
+		}}).In(bootstrapCluster), e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+		By("Waiting for the controlplane provider object to be deleted")
+		WaitForDelete(
+			ctx, For(ControlPlaneProvider).In(bootstrapCluster),
+			e2eConfig.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+	})
+
+	It("should successfully delete config maps with ControlPlane Provider manifests", func() {
+		bootstrapCluster := bootstrapClusterProxy.GetClient()
+		configMaps := []corev1.ConfigMap{}
+
+		for _, fileName := range []string{"controlplane-kubeadm-v1.7.7.yaml", "controlplane-kubeadm-v1.8.0.yaml"} {
+			controlPlaneProviderComponents, err := os.ReadFile(customManifestsFolder + fileName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to read the controlplane provider manifests file")
+
+			var configMap corev1.ConfigMap
+
+			Expect(yaml.Unmarshal(controlPlaneProviderComponents, &configMap)).To(Succeed())
+
+			configMaps = append(configMaps, configMap)
+		}
+
+		By("Deleting config maps with controlplane provider manifests")
+		for _, cm := range configMaps {
+			Expect(bootstrapCluster.Delete(ctx, &cm)).To(Succeed())
+		}
+
+		By("Deleting capkcp-system namespace")
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: capkcpSystemNamespace,
 			},
 		}
 		Expect(bootstrapCluster.Delete(ctx, namespace)).To(Succeed())

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -27,11 +27,11 @@ import (
 var ctx = context.Background()
 
 const (
-	operatorNamespace     = "capi-operator-system"
-	capkbSystemNamespace  = "capi-kubeadm-bootstrap-system"
-	capkcpSystemNamespace = "capi-kubeadm-control-plane-system"
-	capiSystemNamespace   = "capi-system"
-	capiOperatorRelease   = "capi-operator"
+	operatorNamespace    = "capi-operator-system"
+	cabpkSystemNamespace = "capi-kubeadm-bootstrap-system"
+	cacpkSystemNamespace = "capi-kubeadm-control-plane-system"
+	capiSystemNamespace  = "capi-system"
+	capiOperatorRelease  = "capi-operator"
 
 	previousCAPIVersion        = "v1.7.7"
 	nextCAPIVersion            = "v1.8.0"

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -27,12 +27,14 @@ import (
 var ctx = context.Background()
 
 const (
-	operatorNamespace   = "capi-operator-system"
-	capiSystemNamespace = "capi-system"
-	capiOperatorRelease = "capi-operator"
+	operatorNamespace     = "capi-operator-system"
+	capkbSystemNamespace  = "capi-kubeadm-bootstrap-system"
+	capkcpSystemNamespace = "capi-kubeadm-control-plane-system"
+	capiSystemNamespace   = "capi-system"
+	capiOperatorRelease   = "capi-operator"
 
-	previousCAPIVersion = "v1.7.7"
-
+	previousCAPIVersion        = "v1.7.7"
+	nextCAPIVersion            = "v1.8.0"
 	coreProviderName           = configclient.ClusterAPIProviderName
 	coreProviderDeploymentName = "capi-controller-manager"
 
@@ -53,4 +55,5 @@ const (
 	ipamProviderDeploymentName = "capi-ipam-in-cluster-controller-manager"
 
 	customManifestsFolder = "resources/"
+	customProviderName    = "kubeadm-custom"
 )

--- a/test/e2e/resources/bootstrap-kubeadm-v1.7.7.yaml
+++ b/test/e2e/resources/bootstrap-kubeadm-v1.7.7.yaml
@@ -1,0 +1,6975 @@
+apiVersion: v1
+data:
+  components: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+        controller-gen.kubebuilder.io/version: v0.14.0
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-bootstrap-webhook-service
+              namespace: capi-kubeadm-bootstrap-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: bootstrap.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmConfig
+        listKind: KubeadmConfigList
+        plural: kubeadmconfigs
+        singular: kubeadmconfig
+      scope: Namespaced
+      versions:
+      - deprecated: true
+        name: v1alpha3
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfig is the Schema for the kubeadmconfigs API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: |-
+                  KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                  Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server
+                          control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that
+                              we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          CertificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the
+                          controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          type:
+                            description: Type defines the DNS add-on to be used
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          Etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              External describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  CertFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  KeyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              Local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  DataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                          `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                          will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          KubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          Networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              PodSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      useHyperKubeImage:
+                        description: UseHyperKubeImage controls if hyperkube should be
+                          used for Kubernetes components instead of their respective separate
+                          images
+                        type: boolean
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to
+                          setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the
+                                command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be
+                                used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                Overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any", "none",
+                                and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to
+                          setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                Layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                TableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files in
+                        cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to
+                            populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g.
+                            "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store
+                            the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored
+                            as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                Description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                Expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                Groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                Token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                TTL defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                Usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the
+                              API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the
+                      join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          CACertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                          TODO: revisit when there is defaulting from k/k
+                        type: string
+                      controlPlane:
+                        description: |-
+                          ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the
+                              API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                        type: object
+                      discovery:
+                        description: |-
+                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                          TODO: revisit when there is defaulting from k/k
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              BootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name
+                                  to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  CACertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  Token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  UnsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            - unsafeSkipCAVerification
+                            type: object
+                          file:
+                            description: |-
+                              File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual
+                                  file path or URL to the kubeconfig file from which to
+                                  load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              TLSBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+
+                      This will add about 40KB to userdata
+
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the
+                            user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for
+                            the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as
+                            inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the
+                            user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      Verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              status:
+                description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+                properties:
+                  bootstrapData:
+                    description: |-
+                      BootstrapData will be a cloud-init script for now.
+
+
+                      Deprecated: Switch to DataSecretName.
+                    format: byte
+                    type: string
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmConfig.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script.
+                    type: string
+                  failureMessage:
+                    description: FailureMessage will be set on non-retryable errors
+                    type: string
+                  failureReason:
+                    description: FailureReason will be set on non-retryable errors
+                    type: string
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Ready indicates the BootstrapData field is ready to be
+                      consumed
+                    type: boolean
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          status: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmConfig
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfig is the Schema for the kubeadmconfigs API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: |-
+                  KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                  Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server
+                          control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that
+                              we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          CertificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the
+                          controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          Etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              External describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  CertFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  KeyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              Local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  DataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                          `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                          will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          KubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          Networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              PodSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to
+                          setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the
+                                command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be
+                                used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                Overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any", "none",
+                                and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to
+                          setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                Layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                TableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files in
+                        cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to
+                            populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g.
+                            "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store
+                            the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored
+                            as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                Description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                Expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                Groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                Token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                TTL defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                Usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the
+                              API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the
+                      join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          CACertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                          TODO: revisit when there is defaulting from k/k
+                        type: string
+                      controlPlane:
+                        description: |-
+                          ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the
+                              API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: |-
+                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                          TODO: revisit when there is defaulting from k/k
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              BootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name
+                                  to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  CACertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  Token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  UnsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: |-
+                              File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual
+                                  file path or URL to the kubeconfig file from which to
+                                  load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              TLSBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+
+                      This will add about 40KB to userdata
+
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the
+                            user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for
+                            the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as
+                            inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the
+                            user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      Verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              status:
+                description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmConfig.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script.
+                    type: string
+                  failureMessage:
+                    description: FailureMessage will be set on non-retryable errors
+                    type: string
+                  failureReason:
+                    description: FailureReason will be set on non-retryable errors
+                    type: string
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Ready indicates the BootstrapData field is ready to be
+                      consumed
+                    type: boolean
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          status: {}
+      - additionalPrinterColumns:
+        - description: Cluster
+          jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+          name: Cluster
+          type: string
+        - description: Time duration since creation of KubeadmConfig
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: |-
+                  KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                  Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server
+                          control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that
+                              we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          CertificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the
+                          controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          Etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              External describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  CertFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  KeyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              Local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  DataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          * If not set, the default registry of kubeadm will be used, i.e.
+                            * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                            * k8s.gcr.io (old registry): all older versions
+                            Please note that when imageRepository is not set we don't allow upgrades to
+                            versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                            a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                            >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                          * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                           `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                            and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          KubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          Networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              PodSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to
+                          setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the
+                                command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be
+                                used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                Overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any", "none",
+                                and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to
+                          setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                Layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                TableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files in
+                        cloud-init.
+                      properties:
+                        append:
+                          description: Append specifies whether to append Content to existing
+                            file if Path exists.
+                          type: boolean
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to
+                            populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g.
+                            "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store
+                            the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    - ignition
+                    type: string
+                  ignition:
+                    description: Ignition contains Ignition specific configuration.
+                    properties:
+                      containerLinuxConfig:
+                        description: ContainerLinuxConfig contains CLC specific configuration.
+                        properties:
+                          additionalConfig:
+                            description: |-
+                              AdditionalConfig contains additional configuration to be merged with the Ignition
+                              configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                              The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                            type: string
+                          strict:
+                            description: Strict controls if AdditionalConfig should be
+                              strictly parsed. If so, warnings are treated as errors.
+                            type: boolean
+                        type: object
+                    type: object
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored
+                            as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                Description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                Expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                Groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                Token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                TTL defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                Usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the
+                              API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              ImagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          Patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          SkipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the
+                      join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          CACertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                          TODO: revisit when there is defaulting from k/k
+                        type: string
+                      controlPlane:
+                        description: |-
+                          ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the
+                              API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: |-
+                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                          TODO: revisit when there is defaulting from k/k
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              BootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name
+                                  to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  CACertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  Token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  UnsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: |-
+                              File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfig:
+                                description: |-
+                                  KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                  The file is generated at the path specified in KubeConfigPath.
+
+
+                                  Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                  Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                properties:
+                                  cluster:
+                                    description: |-
+                                      Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                      By default the following fields are automatically populated:
+                                      - Server with the Cluster's ControlPlaneEndpoint.
+                                      - CertificateAuthorityData with the Cluster's CA certificate.
+                                    properties:
+                                      certificateAuthorityData:
+                                        description: |-
+                                          CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                          Defaults to the Cluster's CA certificate if empty.
+                                        format: byte
+                                        type: string
+                                      insecureSkipTLSVerify:
+                                        description: InsecureSkipTLSVerify skips the validity
+                                          check for the server's certificate. This will
+                                          make your HTTPS connections insecure.
+                                        type: boolean
+                                      proxyURL:
+                                        description: |-
+                                          ProxyURL is the URL to the proxy to be used for all requests made by this
+                                          client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                          this configuration is not provided or the empty string, the client
+                                          attempts to construct a proxy configuration from http_proxy and
+                                          https_proxy environment variables. If these environment variables are not
+                                          set, the client does not attempt to proxy requests.
+
+
+                                          socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                          attach, port forward).
+                                        type: string
+                                      server:
+                                        description: |-
+                                          Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                          Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                        type: string
+                                      tlsServerName:
+                                        description: TLSServerName is used to check server
+                                          certificate. If TLSServerName is empty, the
+                                          hostname used to contact the server is used.
+                                        type: string
+                                    type: object
+                                  user:
+                                    description: |-
+                                      User contains information that describes identity information.
+                                      This is used to tell the kubernetes cluster who you are.
+                                    properties:
+                                      authProvider:
+                                        description: AuthProvider specifies a custom authentication
+                                          plugin for the kubernetes cluster.
+                                        properties:
+                                          config:
+                                            additionalProperties:
+                                              type: string
+                                            description: Config holds the parameters for
+                                              the authentication plugin.
+                                            type: object
+                                          name:
+                                            description: Name is the name of the authentication
+                                              plugin.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      exec:
+                                        description: Exec specifies a custom exec-based
+                                          authentication plugin for the kubernetes cluster.
+                                        properties:
+                                          apiVersion:
+                                            description: |-
+                                              Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                              the same encoding version as the input.
+                                              Defaults to client.authentication.k8s.io/v1 if not set.
+                                            type: string
+                                          args:
+                                            description: Arguments to pass to the command
+                                              when executing it.
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: Command to execute.
+                                            type: string
+                                          env:
+                                            description: |-
+                                              Env defines additional environment variables to expose to the process. These
+                                              are unioned with the host's environment, as well as variables client-go uses
+                                              to pass argument to the plugin.
+                                            items:
+                                              description: |-
+                                                KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                credential plugin.
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          provideClusterInfo:
+                                            description: |-
+                                              ProvideClusterInfo determines whether or not to provide cluster information,
+                                              which could potentially contain very large CA data, to this exec plugin as a
+                                              part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                              to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                              reading this environment variable.
+                                            type: boolean
+                                        required:
+                                        - command
+                                        type: object
+                                    type: object
+                                required:
+                                - user
+                                type: object
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual
+                                  file path or URL to the kubeconfig file from which to
+                                  load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              TLSBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              ImagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          Patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          SkipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+
+                      This will add about 40KB to userdata
+
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                      Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                      When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the
+                            user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for
+                            the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as
+                            inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        passwdFrom:
+                          description: PasswdFrom is a referenced source of passwd to
+                            populate the passwd.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this password.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the
+                            user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      Verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              status:
+                description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmConfig.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script.
+                    type: string
+                  failureMessage:
+                    description: FailureMessage will be set on non-retryable errors
+                    type: string
+                  failureReason:
+                    description: FailureReason will be set on non-retryable errors
+                    type: string
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Ready indicates the BootstrapData field is ready to be
+                      consumed
+                    type: boolean
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+        controller-gen.kubebuilder.io/version: v0.14.0
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-bootstrap-webhook-service
+              namespace: capi-kubeadm-bootstrap-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: bootstrap.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmConfigTemplate
+        listKind: KubeadmConfigTemplateList
+        plural: kubeadmconfigtemplates
+        singular: kubeadmconfigtemplate
+      scope: Namespaced
+      versions:
+      - deprecated: true
+        name: v1alpha3
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+                properties:
+                  template:
+                    description: KubeadmConfigTemplateResource defines the Template structure.
+                    properties:
+                      spec:
+                        description: |-
+                          KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                          Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the
+                                  API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout
+                                      that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  CertificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  type:
+                                    description: Type defines the DNS add-on to be used
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  Etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      External describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          CertFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          KeyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      Local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          DataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative
+                                          Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                  `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                                  will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  KubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  Networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s
+                                      services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      PodSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      ServiceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the
+                                  scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              useHyperKubeImage:
+                                description: UseHyperKubeImage controls if hyperkube should
+                                  be used for Kubernetes components instead of their respective
+                                  separate images
+                                type: boolean
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems
+                                  to setup.
+                                items:
+                                  description: Filesystem defines the file systems to
+                                    be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to
+                                        add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label
+                                        to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        Overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition
+                                        to use. The valid options are: "auto|any", "auto",
+                                        "any", "none", and <NUM>, where NUM is the actual
+                                        partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions
+                                  to setup.
+                                items:
+                                  description: Partition defines how to create and layout
+                                    a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        Layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        TableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data
+                              upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content
+                                    to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the
+                                    file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file,
+                                    e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where
+                                    to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to
+                                    assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap
+                              data
+                            enum:
+                            - cloud-config
+                            type: string
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        Description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        Expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        Groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        Token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        TTL defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        Usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - advertiseAddress
+                                - bindPort
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  CACertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on this
+                                      node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - advertiseAddress
+                                    - bindPort
+                                    type: object
+                                type: object
+                              discovery:
+                                description: |-
+                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                  TODO: revisit when there is defaulting from k/k
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      BootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain
+                                          name to the API server from which info will
+                                          be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          CACertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          Token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          UnsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    - unsafeSkipCAVerification
+                                    type: object
+                                  file:
+                                    description: |-
+                                      File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      TLSBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                      TODO: revisit when there is defaulting from k/k
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be
+                              setup.
+                            items:
+                              description: MountPoints defines input for generated mounts
+                                in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to
+                              run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+
+                              This will add about 40KB to userdata
+
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user
+                                in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the
+                                    user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to
+                                    use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the
+                                    user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login
+                                    should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for
+                                    the user
+                                  type: string
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group
+                                    for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh
+                                    authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              Verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: false
+        storage: false
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmConfigTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+                properties:
+                  template:
+                    description: KubeadmConfigTemplateResource defines the Template structure.
+                    properties:
+                      spec:
+                        description: |-
+                          KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                          Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the
+                                  API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout
+                                      that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  CertificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  Etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      External describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          CertFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          KeyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      Local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          DataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative
+                                          Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                  `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                                  will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  KubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  Networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s
+                                      services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      PodSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      ServiceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the
+                                  scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems
+                                  to setup.
+                                items:
+                                  description: Filesystem defines the file systems to
+                                    be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to
+                                        add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label
+                                        to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        Overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition
+                                        to use. The valid options are: "auto|any", "auto",
+                                        "any", "none", and <NUM>, where NUM is the actual
+                                        partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions
+                                  to setup.
+                                items:
+                                  description: Partition defines how to create and layout
+                                    a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        Layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        TableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data
+                              upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content
+                                    to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the
+                                    file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file,
+                                    e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where
+                                    to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to
+                                    assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap
+                              data
+                            enum:
+                            - cloud-config
+                            type: string
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        Description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        Expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        Groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        Token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        TTL defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        Usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  CACertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on this
+                                      node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: |-
+                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                  TODO: revisit when there is defaulting from k/k
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      BootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain
+                                          name to the API server from which info will
+                                          be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          CACertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          Token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          UnsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: |-
+                                      File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      TLSBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be
+                              setup.
+                            items:
+                              description: MountPoints defines input for generated mounts
+                                in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to
+                              run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+
+                              This will add about 40KB to userdata
+
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user
+                                in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the
+                                    user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to
+                                    use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the
+                                    user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login
+                                    should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for
+                                    the user
+                                  type: string
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group
+                                    for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh
+                                    authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              Verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmConfigTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
+              API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+                properties:
+                  template:
+                    description: KubeadmConfigTemplateResource defines the Template structure.
+                    properties:
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      spec:
+                        description: |-
+                          KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                          Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the
+                                  API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout
+                                      that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  CertificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  Etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      External describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          CertFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          KeyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      Local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          DataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative
+                                          Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  * If not set, the default registry of kubeadm will be used, i.e.
+                                    * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                    * k8s.gcr.io (old registry): all older versions
+                                    Please note that when imageRepository is not set we don't allow upgrades to
+                                    versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                    a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                    >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                                  * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                   `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                    and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  KubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  Networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s
+                                      services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      PodSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      ServiceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the
+                                  scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems
+                                  to setup.
+                                items:
+                                  description: Filesystem defines the file systems to
+                                    be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to
+                                        add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label
+                                        to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        Overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition
+                                        to use. The valid options are: "auto|any", "auto",
+                                        "any", "none", and <NUM>, where NUM is the actual
+                                        partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions
+                                  to setup.
+                                items:
+                                  description: Partition defines how to create and layout
+                                    a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        Layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        TableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data
+                              upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                append:
+                                  description: Append specifies whether to append Content
+                                    to existing file if Path exists.
+                                  type: boolean
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content
+                                    to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the
+                                    file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file,
+                                    e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where
+                                    to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to
+                                    assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap
+                              data
+                            enum:
+                            - cloud-config
+                            - ignition
+                            type: string
+                          ignition:
+                            description: Ignition contains Ignition specific configuration.
+                            properties:
+                              containerLinuxConfig:
+                                description: ContainerLinuxConfig contains CLC specific
+                                  configuration.
+                                properties:
+                                  additionalConfig:
+                                    description: |-
+                                      AdditionalConfig contains additional configuration to be merged with the Ignition
+                                      configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                                      The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                    type: string
+                                  strict:
+                                    description: Strict controls if AdditionalConfig should
+                                      be strictly parsed. If so, warnings are treated
+                                      as errors.
+                                    type: boolean
+                                type: object
+                            type: object
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        Description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        Expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        Groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        Token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        TTL defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        Usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      ImagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  Patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  SkipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  CACertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on this
+                                      node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: |-
+                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                  TODO: revisit when there is defaulting from k/k
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      BootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain
+                                          name to the API server from which info will
+                                          be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          CACertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          Token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          UnsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: |-
+                                      File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfig:
+                                        description: |-
+                                          KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                          The file is generated at the path specified in KubeConfigPath.
+
+
+                                          Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                          Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                        properties:
+                                          cluster:
+                                            description: |-
+                                              Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                              By default the following fields are automatically populated:
+                                              - Server with the Cluster's ControlPlaneEndpoint.
+                                              - CertificateAuthorityData with the Cluster's CA certificate.
+                                            properties:
+                                              certificateAuthorityData:
+                                                description: |-
+                                                  CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                                  Defaults to the Cluster's CA certificate if empty.
+                                                format: byte
+                                                type: string
+                                              insecureSkipTLSVerify:
+                                                description: InsecureSkipTLSVerify skips
+                                                  the validity check for the server's
+                                                  certificate. This will make your HTTPS
+                                                  connections insecure.
+                                                type: boolean
+                                              proxyURL:
+                                                description: |-
+                                                  ProxyURL is the URL to the proxy to be used for all requests made by this
+                                                  client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                                  this configuration is not provided or the empty string, the client
+                                                  attempts to construct a proxy configuration from http_proxy and
+                                                  https_proxy environment variables. If these environment variables are not
+                                                  set, the client does not attempt to proxy requests.
+
+
+                                                  socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                                  attach, port forward).
+                                                type: string
+                                              server:
+                                                description: |-
+                                                  Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                                  Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                                type: string
+                                              tlsServerName:
+                                                description: TLSServerName is used to
+                                                  check server certificate. If TLSServerName
+                                                  is empty, the hostname used to contact
+                                                  the server is used.
+                                                type: string
+                                            type: object
+                                          user:
+                                            description: |-
+                                              User contains information that describes identity information.
+                                              This is used to tell the kubernetes cluster who you are.
+                                            properties:
+                                              authProvider:
+                                                description: AuthProvider specifies a
+                                                  custom authentication plugin for the
+                                                  kubernetes cluster.
+                                                properties:
+                                                  config:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: Config holds the parameters
+                                                      for the authentication plugin.
+                                                    type: object
+                                                  name:
+                                                    description: Name is the name of the
+                                                      authentication plugin.
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              exec:
+                                                description: Exec specifies a custom exec-based
+                                                  authentication plugin for the kubernetes
+                                                  cluster.
+                                                properties:
+                                                  apiVersion:
+                                                    description: |-
+                                                      Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                      the same encoding version as the input.
+                                                      Defaults to client.authentication.k8s.io/v1 if not set.
+                                                    type: string
+                                                  args:
+                                                    description: Arguments to pass to
+                                                      the command when executing it.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  command:
+                                                    description: Command to execute.
+                                                    type: string
+                                                  env:
+                                                    description: |-
+                                                      Env defines additional environment variables to expose to the process. These
+                                                      are unioned with the host's environment, as well as variables client-go uses
+                                                      to pass argument to the plugin.
+                                                    items:
+                                                      description: |-
+                                                        KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                        credential plugin.
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  provideClusterInfo:
+                                                    description: |-
+                                                      ProvideClusterInfo determines whether or not to provide cluster information,
+                                                      which could potentially contain very large CA data, to this exec plugin as a
+                                                      part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                      to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                      reading this environment variable.
+                                                    type: boolean
+                                                required:
+                                                - command
+                                                type: object
+                                            type: object
+                                        required:
+                                        - user
+                                        type: object
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      TLSBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      ImagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  Patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  SkipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be
+                              setup.
+                            items:
+                              description: MountPoints defines input for generated mounts
+                                in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to
+                              run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+
+                              This will add about 40KB to userdata
+
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                              Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                              When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user
+                                in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the
+                                    user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to
+                                    use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the
+                                    user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login
+                                    should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for
+                                    the user
+                                  type: string
+                                passwdFrom:
+                                  description: PasswdFrom is a referenced source of passwd
+                                    to populate the passwd.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this password.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group
+                                    for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh
+                                    authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              Verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources: {}
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-manager
+      namespace: capi-kubeadm-bootstrap-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-leader-election-role
+      namespace: capi-kubeadm-bootstrap-system
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-manager-role
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - events
+      - secrets
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - bootstrap.cluster.x-k8s.io
+      resources:
+      - kubeadmconfigs
+      - kubeadmconfigs/finalizers
+      - kubeadmconfigs/status
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - clusters
+      - clusters/status
+      - machinepools
+      - machinepools/status
+      - machines
+      - machines/status
+      - machinesets
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-leader-election-rolebinding
+      namespace: capi-kubeadm-bootstrap-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: capi-kubeadm-bootstrap-leader-election-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-bootstrap-manager
+      namespace: capi-kubeadm-bootstrap-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: capi-kubeadm-bootstrap-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-bootstrap-manager
+      namespace: capi-kubeadm-bootstrap-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      ports:
+      - port: 443
+        targetPort: webhook-server
+      selector:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        control-plane: controller-manager
+      name: capi-kubeadm-bootstrap-controller-manager
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          cluster.x-k8s.io/provider: bootstrap-kubeadm
+          control-plane: controller-manager
+      template:
+        metadata:
+          labels:
+            cluster.x-k8s.io/provider: bootstrap-kubeadm
+            control-plane: controller-manager
+        spec:
+          containers:
+          - args:
+            - --leader-elect
+            - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+            - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+            - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+            - --bootstrap-token-ttl=${KUBEADM_BOOTSTRAP_TOKEN_TTL:=15m}
+            command:
+            - /manager
+            env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            image: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.7
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              runAsGroup: 65532
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: capi-kubeadm-bootstrap-manager
+          terminationGracePeriodSeconds: 10
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+          volumes:
+          - name: cert
+            secret:
+              secretName: capi-kubeadm-bootstrap-webhook-service-cert
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-serving-cert
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      dnsNames:
+      - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc
+      - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc.cluster.local
+      issuerRef:
+        kind: Issuer
+        name: capi-kubeadm-bootstrap-selfsigned-issuer
+      secretName: capi-kubeadm-bootstrap-webhook-service-cert
+      subject:
+        organizations:
+        - k8s-sig-cluster-lifecycle
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-selfsigned-issuer
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      selfSigned: {}
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-mutating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+      failurePolicy: Fail
+      name: default.kubeadmconfig.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigs
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+      failurePolicy: Fail
+      name: default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigtemplates
+      sideEffects: None
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-validating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation.kubeadmconfig.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigs
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigtemplates
+      sideEffects: None
+  metadata: |
+    # maps release series of major.minor to cluster-api contract version
+    # the contract version may change between minor or major versions, but *not*
+    # between patch versions.
+    #
+    # update this file only when a new major or minor version is released
+    apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+    kind: Metadata
+    releaseSeries:
+      - major: 1
+        minor: 7
+        contract: v1beta1
+      - major: 1
+        minor: 6
+        contract: v1beta1
+      - major: 1
+        minor: 5
+        contract: v1beta1
+      - major: 1
+        minor: 4
+        contract: v1beta1
+      - major: 1
+        minor: 3
+        contract: v1beta1
+      - major: 1
+        minor: 2
+        contract: v1beta1
+      - major: 1
+        minor: 1
+        contract: v1beta1
+      - major: 1
+        minor: 0
+        contract: v1beta1
+kind: ConfigMap
+metadata:
+  labels:
+    provider.cluster.x-k8s.io/name: kubeadm
+    provider.cluster.x-k8s.io/type: bootstrap
+    provider.cluster.x-k8s.io/version: v1.7.7
+  name: bootstrap-kubeadm-v1.7.7
+  namespace: capi-kubeadm-bootstrap-system

--- a/test/e2e/resources/bootstrap-kubeadm-v1.8.0.yaml
+++ b/test/e2e/resources/bootstrap-kubeadm-v1.8.0.yaml
@@ -1,0 +1,8043 @@
+apiVersion: v1
+data:
+  components: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+        controller-gen.kubebuilder.io/version: v0.15.0
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-bootstrap-webhook-service
+              namespace: capi-kubeadm-bootstrap-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: bootstrap.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmConfig
+        listKind: KubeadmConfigList
+        plural: kubeadmconfigs
+        singular: kubeadmconfig
+      scope: Namespaced
+      versions:
+      - deprecated: true
+        name: v1alpha3
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfig is the Schema for the kubeadmconfigs API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: |-
+                  KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                  Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server
+                          control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that
+                              we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          CertificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the
+                          controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          type:
+                            description: Type defines the DNS add-on to be used
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          Etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              External describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  CertFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  KeyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              Local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  DataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                          `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                          will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          KubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          Networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              PodSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      useHyperKubeImage:
+                        description: UseHyperKubeImage controls if hyperkube should be
+                          used for Kubernetes components instead of their respective separate
+                          images
+                        type: boolean
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to
+                          setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the
+                                command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be
+                                used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                Overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any", "none",
+                                and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to
+                          setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                Layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                TableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files in
+                        cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to
+                            populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g.
+                            "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store
+                            the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored
+                            as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                Description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                Expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                Groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                Token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                TTL defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                Usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the
+                              API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the
+                      join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          CACertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                          TODO: revisit when there is defaulting from k/k
+                        type: string
+                      controlPlane:
+                        description: |-
+                          ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the
+                              API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                        type: object
+                      discovery:
+                        description: |-
+                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                          TODO: revisit when there is defaulting from k/k
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              BootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name
+                                  to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  CACertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  Token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  UnsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            - unsafeSkipCAVerification
+                            type: object
+                          file:
+                            description: |-
+                              File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual
+                                  file path or URL to the kubeconfig file from which to
+                                  load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              TLSBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+
+                      This will add about 40KB to userdata
+
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the
+                            user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for
+                            the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as
+                            inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the
+                            user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      Verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              status:
+                description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+                properties:
+                  bootstrapData:
+                    description: |-
+                      BootstrapData will be a cloud-init script for now.
+
+
+                      Deprecated: Switch to DataSecretName.
+                    format: byte
+                    type: string
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmConfig.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script.
+                    type: string
+                  failureMessage:
+                    description: FailureMessage will be set on non-retryable errors
+                    type: string
+                  failureReason:
+                    description: FailureReason will be set on non-retryable errors
+                    type: string
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Ready indicates the BootstrapData field is ready to be
+                      consumed
+                    type: boolean
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          status: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmConfig
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfig is the Schema for the kubeadmconfigs API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: |-
+                  KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                  Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server
+                          control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that
+                              we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          CertificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the
+                          controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          Etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              External describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  CertFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  KeyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              Local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  DataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                          `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                          will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          KubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          Networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              PodSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to
+                          setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the
+                                command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be
+                                used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                Overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any", "none",
+                                and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to
+                          setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                Layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                TableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files in
+                        cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to
+                            populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g.
+                            "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store
+                            the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored
+                            as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                Description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                Expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                Groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                Token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                TTL defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                Usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the
+                              API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the
+                      join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          CACertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                          TODO: revisit when there is defaulting from k/k
+                        type: string
+                      controlPlane:
+                        description: |-
+                          ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the
+                              API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: |-
+                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                          TODO: revisit when there is defaulting from k/k
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              BootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name
+                                  to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  CACertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  Token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  UnsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: |-
+                              File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual
+                                  file path or URL to the kubeconfig file from which to
+                                  load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              TLSBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+
+                      This will add about 40KB to userdata
+
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the
+                            user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for
+                            the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as
+                            inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the
+                            user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      Verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              status:
+                description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmConfig.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script.
+                    type: string
+                  failureMessage:
+                    description: FailureMessage will be set on non-retryable errors
+                    type: string
+                  failureReason:
+                    description: FailureReason will be set on non-retryable errors
+                    type: string
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Ready indicates the BootstrapData field is ready to be
+                      consumed
+                    type: boolean
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          status: {}
+      - additionalPrinterColumns:
+        - description: Cluster
+          jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+          name: Cluster
+          type: string
+        - description: Time duration since creation of KubeadmConfig
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: |-
+                  KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                  Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server
+                          control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that
+                              we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          CertificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the
+                          controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: |-
+                              ImageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          Etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              External describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: |-
+                                  CertFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: |-
+                                  KeyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              Local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  DataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must
+                                        be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath
+                                                is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for
+                                                volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults to
+                                                "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the
+                                            pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select
+                                                from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          * If not set, the default registry of kubeadm will be used, i.e.
+                            * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                            * k8s.gcr.io (old registry): all older versions
+                            Please note that when imageRepository is not set we don't allow upgrades to
+                            versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                            a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                            >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                          * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                           `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                            and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          KubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        type: string
+                      networking:
+                        description: |-
+                          Networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: |-
+                              PodSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              ServiceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs is an extra set of flags to pass to the control plane component.
+                              TODO: This is temporary and ideally we would like to switch all components to
+                              use ComponentConfig + ConfigMaps.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable present
+                                in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's value.
+                                    Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap or
+                                            its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes,
+                                            optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the pod's
+                                        namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its
+                                            key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    HostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where
+                                    hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to
+                          setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the
+                                command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be
+                                used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: |-
+                                Overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any", "none",
+                                and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: |-
+                                ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to
+                          setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: |-
+                                Layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                TableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files in
+                        cloud-init.
+                      properties:
+                        append:
+                          description: Append specifies whether to append Content to existing
+                            file if Path exists.
+                          type: boolean
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to
+                            populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g.
+                            "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store
+                            the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    - ignition
+                    type: string
+                  ignition:
+                    description: Ignition contains Ignition specific configuration.
+                    properties:
+                      containerLinuxConfig:
+                        description: ContainerLinuxConfig contains CLC specific configuration.
+                        properties:
+                          additionalConfig:
+                            description: |-
+                              AdditionalConfig contains additional configuration to be merged with the Ignition
+                              configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                              The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                            type: string
+                          strict:
+                            description: Strict controls if AdditionalConfig should be
+                              strictly parsed. If so, warnings are treated as errors.
+                            type: boolean
+                        type: object
+                    type: object
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are
+                      the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored
+                            as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                Description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: |-
+                                Expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                Groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: |-
+                                Token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                TTL defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                Usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the
+                              API server to advertise.
+                            type: string
+                          bindPort:
+                            description: |-
+                              BindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              ImagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          imagePullSerial:
+                            description: |-
+                              ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                              Default: true (defaulted in kubeadm)
+                            type: boolean
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          Patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          SkipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the
+                      join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          CACertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                          TODO: revisit when there is defaulting from k/k
+                        type: string
+                      controlPlane:
+                        description: |-
+                          ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the
+                              API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: |-
+                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                          TODO: revisit when there is defaulting from k/k
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              BootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name
+                                  to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  CACertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: |-
+                                  Token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  UnsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: |-
+                              File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfig:
+                                description: |-
+                                  KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                  The file is generated at the path specified in KubeConfigPath.
+
+
+                                  Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                  Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                properties:
+                                  cluster:
+                                    description: |-
+                                      Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                      By default the following fields are automatically populated:
+                                      - Server with the Cluster's ControlPlaneEndpoint.
+                                      - CertificateAuthorityData with the Cluster's CA certificate.
+                                    properties:
+                                      certificateAuthorityData:
+                                        description: |-
+                                          CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                          Defaults to the Cluster's CA certificate if empty.
+                                        format: byte
+                                        type: string
+                                      insecureSkipTLSVerify:
+                                        description: InsecureSkipTLSVerify skips the validity
+                                          check for the server's certificate. This will
+                                          make your HTTPS connections insecure.
+                                        type: boolean
+                                      proxyURL:
+                                        description: |-
+                                          ProxyURL is the URL to the proxy to be used for all requests made by this
+                                          client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                          this configuration is not provided or the empty string, the client
+                                          attempts to construct a proxy configuration from http_proxy and
+                                          https_proxy environment variables. If these environment variables are not
+                                          set, the client does not attempt to proxy requests.
+
+
+                                          socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                          attach, port forward).
+                                        type: string
+                                      server:
+                                        description: |-
+                                          Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                          Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                        type: string
+                                      tlsServerName:
+                                        description: TLSServerName is used to check server
+                                          certificate. If TLSServerName is empty, the
+                                          hostname used to contact the server is used.
+                                        type: string
+                                    type: object
+                                  user:
+                                    description: |-
+                                      User contains information that describes identity information.
+                                      This is used to tell the kubernetes cluster who you are.
+                                    properties:
+                                      authProvider:
+                                        description: AuthProvider specifies a custom authentication
+                                          plugin for the kubernetes cluster.
+                                        properties:
+                                          config:
+                                            additionalProperties:
+                                              type: string
+                                            description: Config holds the parameters for
+                                              the authentication plugin.
+                                            type: object
+                                          name:
+                                            description: Name is the name of the authentication
+                                              plugin.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      exec:
+                                        description: Exec specifies a custom exec-based
+                                          authentication plugin for the kubernetes cluster.
+                                        properties:
+                                          apiVersion:
+                                            description: |-
+                                              Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                              the same encoding version as the input.
+                                              Defaults to client.authentication.k8s.io/v1 if not set.
+                                            type: string
+                                          args:
+                                            description: Arguments to pass to the command
+                                              when executing it.
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: Command to execute.
+                                            type: string
+                                          env:
+                                            description: |-
+                                              Env defines additional environment variables to expose to the process. These
+                                              are unioned with the host's environment, as well as variables client-go uses
+                                              to pass argument to the plugin.
+                                            items:
+                                              description: |-
+                                                KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                credential plugin.
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          provideClusterInfo:
+                                            description: |-
+                                              ProvideClusterInfo determines whether or not to provide cluster information,
+                                              which could potentially contain very large CA data, to this exec plugin as a
+                                              part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                              to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                              reading this environment variable.
+                                            type: boolean
+                                        required:
+                                        - command
+                                        type: object
+                                    type: object
+                                required:
+                                - user
+                                type: object
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual
+                                  file path or URL to the kubeconfig file from which to
+                                  load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              TLSBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node API
+                              object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight
+                              errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              ImagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          imagePullSerial:
+                            description: |-
+                              ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                              Default: true (defaulted in kubeadm)
+                            type: boolean
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: |-
+                              Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to
+                                    a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint
+                                    key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          Patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          SkipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before
+                      kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+
+                      This will add about 40KB to userdata
+
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                      Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                      When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the
+                            user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for
+                            the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as
+                            inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        passwdFrom:
+                          description: PasswdFrom is a referenced source of passwd to
+                            populate the passwd.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this password.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map
+                                    for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the
+                            user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: |-
+                      Verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              status:
+                description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmConfig.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores
+                      the bootstrap data script.
+                    type: string
+                  failureMessage:
+                    description: FailureMessage will be set on non-retryable errors
+                    type: string
+                  failureReason:
+                    description: FailureReason will be set on non-retryable errors
+                    type: string
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Ready indicates the BootstrapData field is ready to be
+                      consumed
+                    type: boolean
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+        controller-gen.kubebuilder.io/version: v0.15.0
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-bootstrap-webhook-service
+              namespace: capi-kubeadm-bootstrap-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: bootstrap.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmConfigTemplate
+        listKind: KubeadmConfigTemplateList
+        plural: kubeadmconfigtemplates
+        singular: kubeadmconfigtemplate
+      scope: Namespaced
+      versions:
+      - deprecated: true
+        name: v1alpha3
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+                properties:
+                  template:
+                    description: KubeadmConfigTemplateResource defines the Template structure.
+                    properties:
+                      spec:
+                        description: |-
+                          KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                          Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the
+                                  API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout
+                                      that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  CertificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  type:
+                                    description: Type defines the DNS add-on to be used
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  Etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      External describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          CertFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          KeyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      Local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          DataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative
+                                          Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                  `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                                  will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  KubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  Networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s
+                                      services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      PodSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      ServiceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the
+                                  scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              useHyperKubeImage:
+                                description: UseHyperKubeImage controls if hyperkube should
+                                  be used for Kubernetes components instead of their respective
+                                  separate images
+                                type: boolean
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems
+                                  to setup.
+                                items:
+                                  description: Filesystem defines the file systems to
+                                    be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to
+                                        add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label
+                                        to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        Overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition
+                                        to use. The valid options are: "auto|any", "auto",
+                                        "any", "none", and <NUM>, where NUM is the actual
+                                        partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions
+                                  to setup.
+                                items:
+                                  description: Partition defines how to create and layout
+                                    a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        Layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        TableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data
+                              upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content
+                                    to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the
+                                    file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file,
+                                    e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where
+                                    to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to
+                                    assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap
+                              data
+                            enum:
+                            - cloud-config
+                            type: string
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        Description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        Expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        Groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        Token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        TTL defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        Usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - advertiseAddress
+                                - bindPort
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  CACertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on this
+                                      node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - advertiseAddress
+                                    - bindPort
+                                    type: object
+                                type: object
+                              discovery:
+                                description: |-
+                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                  TODO: revisit when there is defaulting from k/k
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      BootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain
+                                          name to the API server from which info will
+                                          be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          CACertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          Token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          UnsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    - unsafeSkipCAVerification
+                                    type: object
+                                  file:
+                                    description: |-
+                                      File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      TLSBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                      TODO: revisit when there is defaulting from k/k
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be
+                              setup.
+                            items:
+                              description: MountPoints defines input for generated mounts
+                                in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to
+                              run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+
+                              This will add about 40KB to userdata
+
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user
+                                in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the
+                                    user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to
+                                    use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the
+                                    user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login
+                                    should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for
+                                    the user
+                                  type: string
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group
+                                    for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh
+                                    authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              Verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: false
+        storage: false
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmConfigTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+                properties:
+                  template:
+                    description: KubeadmConfigTemplateResource defines the Template structure.
+                    properties:
+                      spec:
+                        description: |-
+                          KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                          Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the
+                                  API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout
+                                      that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  CertificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  Etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      External describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          CertFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          KeyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      Local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          DataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative
+                                          Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                  `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                                  will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  KubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  Networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s
+                                      services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      PodSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      ServiceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the
+                                  scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems
+                                  to setup.
+                                items:
+                                  description: Filesystem defines the file systems to
+                                    be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to
+                                        add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label
+                                        to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        Overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition
+                                        to use. The valid options are: "auto|any", "auto",
+                                        "any", "none", and <NUM>, where NUM is the actual
+                                        partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions
+                                  to setup.
+                                items:
+                                  description: Partition defines how to create and layout
+                                    a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        Layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        TableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data
+                              upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content
+                                    to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the
+                                    file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file,
+                                    e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where
+                                    to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to
+                                    assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap
+                              data
+                            enum:
+                            - cloud-config
+                            type: string
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        Description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        Expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        Groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        Token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        TTL defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        Usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  CACertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on this
+                                      node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: |-
+                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                  TODO: revisit when there is defaulting from k/k
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      BootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain
+                                          name to the API server from which info will
+                                          be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          CACertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          Token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          UnsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: |-
+                                      File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      TLSBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be
+                              setup.
+                            items:
+                              description: MountPoints defines input for generated mounts
+                                in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to
+                              run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+
+                              This will add about 40KB to userdata
+
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user
+                                in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the
+                                    user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to
+                                    use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the
+                                    user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login
+                                    should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for
+                                    the user
+                                  type: string
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group
+                                    for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh
+                                    authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              Verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmConfigTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
+              API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+                properties:
+                  template:
+                    description: KubeadmConfigTemplateResource defines the Template structure.
+                    properties:
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      spec:
+                        description: |-
+                          KubeadmConfigSpec defines the desired state of KubeadmConfig.
+                          Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the
+                                  API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment variable
+                                        present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment variable's
+                                            value. Cannot be used if value is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the
+                                                    FieldPath is written in terms of,
+                                                    defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select
+                                                    in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format
+                                                    of the exposed resources, defaults
+                                                    to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to
+                                                    select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret in
+                                                the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret to
+                                                    select from.  Must be a valid secret
+                                                    key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout
+                                      that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  CertificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment variable
+                                        present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment variable's
+                                            value. Cannot be used if value is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the
+                                                    FieldPath is written in terms of,
+                                                    defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select
+                                                    in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format
+                                                    of the exposed resources, defaults
+                                                    to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to
+                                                    select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret in
+                                                the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret to
+                                                    select from.  Must be a valid secret
+                                                    key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  Etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      External describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          CertFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          KeyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      Local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          DataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      extraEnvs:
+                                        description: |-
+                                          ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment variable.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: |-
+                                                Variable references $(VAR_NAME) are expanded
+                                                using the previously defined environment variables in the container and
+                                                any service environment variables. If a variable cannot be resolved,
+                                                the reference in the input string will be unchanged. Double $$ are reduced
+                                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                Escaped references will never be expanded, regardless of whether the variable
+                                                exists or not.
+                                                Defaults to "".
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if value
+                                                is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        ConfigMap or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: |-
+                                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema
+                                                        the FieldPath is written in terms
+                                                        of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to
+                                                        select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name: required
+                                                        for volumes, optional for env
+                                                        vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret
+                                                    in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret
+                                                        to select from.  Must be a valid
+                                                        secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        Secret or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative
+                                          Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  * If not set, the default registry of kubeadm will be used, i.e.
+                                    * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                    * k8s.gcr.io (old registry): all older versions
+                                    Please note that when imageRepository is not set we don't allow upgrades to
+                                    versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                    a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                    >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                                  * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                   `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                    and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  KubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                type: string
+                              networking:
+                                description: |-
+                                  Networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s
+                                      services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      PodSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      ServiceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the
+                                  scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs is an extra set of flags to pass to the control plane component.
+                                      TODO: This is temporary and ideally we would like to switch all components to
+                                      use ComponentConfig + ConfigMaps.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment variable
+                                        present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment variable's
+                                            value. Cannot be used if value is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the
+                                                    FieldPath is written in terms of,
+                                                    defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select
+                                                    in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format
+                                                    of the exposed resources, defaults
+                                                    to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to
+                                                    select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret in
+                                                the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret to
+                                                    select from.  Must be a valid secret
+                                                    key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            HostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the
+                                            pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod
+                                            template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems
+                                  to setup.
+                                items:
+                                  description: Filesystem defines the file systems to
+                                    be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to
+                                        add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system
+                                        type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label
+                                        to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        Overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition
+                                        to use. The valid options are: "auto|any", "auto",
+                                        "any", "none", and <NUM>, where NUM is the actual
+                                        partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions
+                                  to setup.
+                                items:
+                                  description: Partition defines how to create and layout
+                                    a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        Layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        TableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data
+                              upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                append:
+                                  description: Append specifies whether to append Content
+                                    to existing file if Path exists.
+                                  type: boolean
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content
+                                    to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the
+                                    file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file,
+                                    e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where
+                                    to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to
+                                    assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap
+                              data
+                            enum:
+                            - cloud-config
+                            - ignition
+                            type: string
+                          ignition:
+                            description: Ignition contains Ignition specific configuration.
+                            properties:
+                              containerLinuxConfig:
+                                description: ContainerLinuxConfig contains CLC specific
+                                  configuration.
+                                properties:
+                                  additionalConfig:
+                                    description: |-
+                                      AdditionalConfig contains additional configuration to be merged with the Ignition
+                                      configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                                      The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                    type: string
+                                  strict:
+                                    description: Strict controls if AdditionalConfig should
+                                      be strictly parsed. If so, warnings are treated
+                                      as errors.
+                                    type: boolean
+                                type: object
+                            type: object
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        Description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        Expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        Groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: |-
+                                        Token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        TTL defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        Usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      ImagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  imagePullSerial:
+                                    description: |-
+                                      ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                      Default: true (defaulted in kubeadm)
+                                    type: boolean
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  Patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  SkipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  CACertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on this
+                                      node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: |-
+                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                  TODO: revisit when there is defaulting from k/k
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      BootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain
+                                          name to the API server from which info will
+                                          be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          CACertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: |-
+                                          Token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          UnsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: |-
+                                      File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfig:
+                                        description: |-
+                                          KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                          The file is generated at the path specified in KubeConfigPath.
+
+
+                                          Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                          Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                        properties:
+                                          cluster:
+                                            description: |-
+                                              Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                              By default the following fields are automatically populated:
+                                              - Server with the Cluster's ControlPlaneEndpoint.
+                                              - CertificateAuthorityData with the Cluster's CA certificate.
+                                            properties:
+                                              certificateAuthorityData:
+                                                description: |-
+                                                  CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                                  Defaults to the Cluster's CA certificate if empty.
+                                                format: byte
+                                                type: string
+                                              insecureSkipTLSVerify:
+                                                description: InsecureSkipTLSVerify skips
+                                                  the validity check for the server's
+                                                  certificate. This will make your HTTPS
+                                                  connections insecure.
+                                                type: boolean
+                                              proxyURL:
+                                                description: |-
+                                                  ProxyURL is the URL to the proxy to be used for all requests made by this
+                                                  client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                                  this configuration is not provided or the empty string, the client
+                                                  attempts to construct a proxy configuration from http_proxy and
+                                                  https_proxy environment variables. If these environment variables are not
+                                                  set, the client does not attempt to proxy requests.
+
+
+                                                  socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                                  attach, port forward).
+                                                type: string
+                                              server:
+                                                description: |-
+                                                  Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                                  Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                                type: string
+                                              tlsServerName:
+                                                description: TLSServerName is used to
+                                                  check server certificate. If TLSServerName
+                                                  is empty, the hostname used to contact
+                                                  the server is used.
+                                                type: string
+                                            type: object
+                                          user:
+                                            description: |-
+                                              User contains information that describes identity information.
+                                              This is used to tell the kubernetes cluster who you are.
+                                            properties:
+                                              authProvider:
+                                                description: AuthProvider specifies a
+                                                  custom authentication plugin for the
+                                                  kubernetes cluster.
+                                                properties:
+                                                  config:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: Config holds the parameters
+                                                      for the authentication plugin.
+                                                    type: object
+                                                  name:
+                                                    description: Name is the name of the
+                                                      authentication plugin.
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              exec:
+                                                description: Exec specifies a custom exec-based
+                                                  authentication plugin for the kubernetes
+                                                  cluster.
+                                                properties:
+                                                  apiVersion:
+                                                    description: |-
+                                                      Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                      the same encoding version as the input.
+                                                      Defaults to client.authentication.k8s.io/v1 if not set.
+                                                    type: string
+                                                  args:
+                                                    description: Arguments to pass to
+                                                      the command when executing it.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  command:
+                                                    description: Command to execute.
+                                                    type: string
+                                                  env:
+                                                    description: |-
+                                                      Env defines additional environment variables to expose to the process. These
+                                                      are unioned with the host's environment, as well as variables client-go uses
+                                                      to pass argument to the plugin.
+                                                    items:
+                                                      description: |-
+                                                        KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                        credential plugin.
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  provideClusterInfo:
+                                                    description: |-
+                                                      ProvideClusterInfo determines whether or not to provide cluster information,
+                                                      which could potentially contain very large CA data, to this exec plugin as a
+                                                      part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                      to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                      reading this environment variable.
+                                                    type: boolean
+                                                required:
+                                                - command
+                                                type: object
+                                            type: object
+                                        required:
+                                        - user
+                                        type: object
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      TLSBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice
+                                      of pre-flight errors to be ignored when the current
+                                      node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      ImagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  imagePullSerial:
+                                    description: |-
+                                      ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                      Default: true (defaulted in kubeadm)
+                                    type: boolean
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied
+                                            to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to
+                                            the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  Patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  SkipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be
+                              setup.
+                            items:
+                              description: MountPoints defines input for generated mounts
+                                in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands
+                              to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to
+                              run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+
+                              This will add about 40KB to userdata
+
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                              Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                              When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user
+                                in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the
+                                    user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups
+                                    for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to
+                                    use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the
+                                    user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login
+                                    should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for
+                                    the user
+                                  type: string
+                                passwdFrom:
+                                  description: PasswdFrom is a referenced source of passwd
+                                    to populate the passwd.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should
+                                        populate this password.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's
+                                            data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group
+                                    for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh
+                                    authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: |-
+                              Verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources: {}
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-manager
+      namespace: capi-kubeadm-bootstrap-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-leader-election-role
+      namespace: capi-kubeadm-bootstrap-system
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-manager-role
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - secrets
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - bootstrap.cluster.x-k8s.io
+      resources:
+      - kubeadmconfigs
+      - kubeadmconfigs/status
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - clusters
+      - clusters/status
+      - machinepools
+      - machinepools/status
+      - machines
+      - machines/status
+      - machinesets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-leader-election-rolebinding
+      namespace: capi-kubeadm-bootstrap-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: capi-kubeadm-bootstrap-leader-election-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-bootstrap-manager
+      namespace: capi-kubeadm-bootstrap-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: capi-kubeadm-bootstrap-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-bootstrap-manager
+      namespace: capi-kubeadm-bootstrap-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      ports:
+      - port: 443
+        targetPort: webhook-server
+      selector:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        control-plane: controller-manager
+      name: capi-kubeadm-bootstrap-controller-manager
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          cluster.x-k8s.io/provider: bootstrap-kubeadm
+          control-plane: controller-manager
+      template:
+        metadata:
+          labels:
+            cluster.x-k8s.io/provider: bootstrap-kubeadm
+            control-plane: controller-manager
+        spec:
+          containers:
+          - args:
+            - --leader-elect
+            - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+            - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+            - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+            - --bootstrap-token-ttl=${KUBEADM_BOOTSTRAP_TOKEN_TTL:=15m}
+            command:
+            - /manager
+            env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            image: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.8.0
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              runAsGroup: 65532
+              runAsUser: 65532
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: capi-kubeadm-bootstrap-manager
+          terminationGracePeriodSeconds: 10
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+          volumes:
+          - name: cert
+            secret:
+              secretName: capi-kubeadm-bootstrap-webhook-service-cert
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-serving-cert
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      dnsNames:
+      - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc
+      - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc.cluster.local
+      issuerRef:
+        kind: Issuer
+        name: capi-kubeadm-bootstrap-selfsigned-issuer
+      secretName: capi-kubeadm-bootstrap-webhook-service-cert
+      subject:
+        organizations:
+        - k8s-sig-cluster-lifecycle
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-selfsigned-issuer
+      namespace: capi-kubeadm-bootstrap-system
+    spec:
+      selfSigned: {}
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-mutating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+      failurePolicy: Fail
+      name: default.kubeadmconfig.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigs
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+      failurePolicy: Fail
+      name: default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigtemplates
+      sideEffects: None
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+      name: capi-kubeadm-bootstrap-validating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation.kubeadmconfig.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigs
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - bootstrap.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmconfigtemplates
+      sideEffects: None
+  metadata: |
+    # maps release series of major.minor to cluster-api contract version
+    # the contract version may change between minor or major versions, but *not*
+    # between patch versions.
+    #
+    # update this file only when a new major or minor version is released
+    apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+    kind: Metadata
+    releaseSeries:
+      - major: 1
+        minor: 8
+        contract: v1beta1
+      - major: 1
+        minor: 7
+        contract: v1beta1
+      - major: 1
+        minor: 6
+        contract: v1beta1
+      - major: 1
+        minor: 5
+        contract: v1beta1
+      - major: 1
+        minor: 4
+        contract: v1beta1
+      - major: 1
+        minor: 3
+        contract: v1beta1
+      - major: 1
+        minor: 2
+        contract: v1beta1
+      - major: 1
+        minor: 1
+        contract: v1beta1
+      - major: 1
+        minor: 0
+        contract: v1beta1
+kind: ConfigMap
+metadata:
+  labels:
+    provider.cluster.x-k8s.io/name: kubeadm
+    provider.cluster.x-k8s.io/type: bootstrap
+    provider.cluster.x-k8s.io/version: v1.8.0
+  name: bootstrap-kubeadm-v1.8.0
+  namespace: capi-kubeadm-bootstrap-system

--- a/test/e2e/resources/controlplane-kubeadm-v1.7.7.yaml
+++ b/test/e2e/resources/controlplane-kubeadm-v1.7.7.yaml
@@ -1,0 +1,7184 @@
+apiVersion: v1
+data:
+  components: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+        controller-gen.kubebuilder.io/version: v0.14.0
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-control-plane-webhook-service
+              namespace: capi-kubeadm-control-plane-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: controlplane.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmControlPlane
+        listKind: KubeadmControlPlaneList
+        plural: kubeadmcontrolplanes
+        shortNames:
+        - kcp
+        singular: kubeadmcontrolplane
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: This denotes whether or not the control plane has the uploaded
+            kubeadm-config configmap
+          jsonPath: .status.initialized
+          name: Initialized
+          type: boolean
+        - description: KubeadmControlPlane API Server is ready to receive requests
+          jsonPath: .status.ready
+          name: API Server Available
+          type: boolean
+        - description: Kubernetes version associated with this control plane
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        - description: Total number of non-terminated machines targeted by this control
+            plane
+          jsonPath: .status.replicas
+          name: Replicas
+          type: integer
+        - description: Total number of fully running and ready control plane machines
+          jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane that have the desired template spec
+          jsonPath: .status.updatedReplicas
+          name: Updated
+          type: integer
+        - description: Total number of unavailable machines targeted by this control plane
+          jsonPath: .status.unavailableReplicas
+          name: Unavailable
+          type: integer
+        deprecated: true
+        name: v1alpha3
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                properties:
+                  infrastructureTemplate:
+                    description: |-
+                      InfrastructureTemplate is a required reference to a custom resource
+                      offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                          TODO: this design is not final and this field is subject to change in the future.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  kubeadmConfigSpec:
+                    description: |-
+                      KubeadmConfigSpec is a KubeadmConfigSpec
+                      to use for initializing and joining machines to the control plane.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API
+                              server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names
+                                  for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              CertificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for
+                              the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed
+                              in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              type:
+                                description: Type defines the DNS add-on to be used
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              Etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  External describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      CertFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for
+                                      ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      KeyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  Local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      DataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative
+                                      Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                              `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                              will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              KubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              Networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services.
+                                  Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  ServiceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler
+                              control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          useHyperKubeImage:
+                            description: UseHyperKubeImage controls if hyperkube should
+                              be used for Kubernetes components instead of their respective
+                              separate images
+                            type: boolean
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition
+                          tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add
+                                    to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to
+                                    be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    Overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use.
+                                    The valid options are: "auto|any", "auto", "any",
+                                    "none", and <NUM>, where NUM is the actual partition
+                                    number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    Layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    TableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file
+                                contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign
+                                to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token,
+                                stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    Description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    Expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    Groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    Token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    TTL defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    Usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for
+                          the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              CACertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                          controlPlane:
+                            description: |-
+                              ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - advertiseAddress
+                                - bindPort
+                                type: object
+                            type: object
+                          discovery:
+                            description: |-
+                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                              TODO: revisit when there is defaulting from k/k
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  BootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      CACertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      Token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      UnsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                - unsafeSkipCAVerification
+                                type: object
+                              file:
+                                description: |-
+                                  File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the
+                                      actual file path or URL to the kubeconfig file from
+                                      which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  TLSBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run
+                          after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run
+                          before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+
+                          This will add about 40KB to userdata
+
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in
+                            cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for
+                                the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use
+                                for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user
+                                as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should
+                                be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the
+                                user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for
+                                the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized
+                                keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          Verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeDrainTimeout:
+                    description: |-
+                      NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                    type: string
+                  replicas:
+                    description: |-
+                      Number of desired machines. Defaults to 1. When stacked etcd is used only
+                      odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                      This is a pointer to distinguish between explicit zero and not specified.
+                    format: int32
+                    type: integer
+                  rolloutStrategy:
+                    description: |-
+                      The RolloutStrategy to use to replace control plane machines with
+                      new ones.
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if
+                          RolloutStrategyType = RollingUpdate.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of control planes that can be scheduled above or under the
+                              desired number of control planes.
+                              Value can be an absolute number 1 or 0.
+                              Defaults to 1.
+                              Example: when this is set to 1, the control plane can be scaled
+                              up immediately when the rolling update starts.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: |-
+                          Type of rollout. Currently the only supported strategy is
+                          "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
+                  upgradeAfter:
+                    description: |-
+                      UpgradeAfter is a field to indicate an upgrade should be performed
+                      after the specified time even if no changes have been made to the
+                      KubeadmControlPlane
+                    format: date-time
+                    type: string
+                  version:
+                    description: Version defines the desired Kubernetes version.
+                    type: string
+                required:
+                - infrastructureTemplate
+                - kubeadmConfigSpec
+                - version
+                type: object
+              status:
+                description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmControlPlane.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  failureMessage:
+                    description: |-
+                      ErrorMessage indicates that there is a terminal problem reconciling the
+                      state, and will be set to a descriptive error message.
+                    type: string
+                  failureReason:
+                    description: |-
+                      FailureReason indicates that there is a terminal problem reconciling the
+                      state, and will be set to a token value suitable for
+                      programmatic interpretation.
+                    type: string
+                  initialized:
+                    description: |-
+                      Initialized denotes whether or not the control plane has the
+                      uploaded kubeadm-config configmap.
+                    type: boolean
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: |-
+                      Ready denotes that the KubeadmControlPlane API Server is ready to
+                      receive requests.
+                    type: boolean
+                  readyReplicas:
+                    description: Total number of fully running and ready control plane
+                      machines.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      (their labels match the selector).
+                    format: int32
+                    type: integer
+                  selector:
+                    description: |-
+                      Selector is the label selector in string format to avoid introspection
+                      by clients, and is used to provide the CRD-based integration for the
+                      scale subresource and additional integrations for things like kubectl
+                      describe.. The string will be in the same format as the query-param syntax.
+                      More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable machines targeted by this control plane.
+                      This is the total number of machines that are still required for
+                      the deployment to have 100% available capacity. They may either
+                      be machines that are running but not yet ready or machines
+                      that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          scale:
+            labelSelectorPath: .status.selector
+            specReplicasPath: .spec.replicas
+            statusReplicasPath: .status.replicas
+          status: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmControlPlane
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: This denotes whether or not the control plane has the uploaded
+            kubeadm-config configmap
+          jsonPath: .status.initialized
+          name: Initialized
+          type: boolean
+        - description: KubeadmControlPlane API Server is ready to receive requests
+          jsonPath: .status.ready
+          name: API Server Available
+          type: boolean
+        - description: Kubernetes version associated with this control plane
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        - description: Total number of non-terminated machines targeted by this control
+            plane
+          jsonPath: .status.replicas
+          name: Replicas
+          type: integer
+        - description: Total number of fully running and ready control plane machines
+          jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane that have the desired template spec
+          jsonPath: .status.updatedReplicas
+          name: Updated
+          type: integer
+        - description: Total number of unavailable machines targeted by this control plane
+          jsonPath: .status.unavailableReplicas
+          name: Unavailable
+          type: integer
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                properties:
+                  kubeadmConfigSpec:
+                    description: |-
+                      KubeadmConfigSpec is a KubeadmConfigSpec
+                      to use for initializing and joining machines to the control plane.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API
+                              server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names
+                                  for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              CertificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for
+                              the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed
+                              in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              Etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  External describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      CertFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for
+                                      ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      KeyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  Local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      DataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative
+                                      Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                              `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                              will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              KubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              Networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services.
+                                  Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  ServiceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler
+                              control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition
+                          tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add
+                                    to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to
+                                    be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    Overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use.
+                                    The valid options are: "auto|any", "auto", "any",
+                                    "none", and <NUM>, where NUM is the actual partition
+                                    number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    Layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    TableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file
+                                contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign
+                                to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token,
+                                stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    Description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    Expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    Groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    Token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    TTL defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    Usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for
+                          the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              CACertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                          controlPlane:
+                            description: |-
+                              ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: |-
+                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                              TODO: revisit when there is defaulting from k/k
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  BootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      CACertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      Token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      UnsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: |-
+                                  File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the
+                                      actual file path or URL to the kubeconfig file from
+                                      which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  TLSBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run
+                          after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run
+                          before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+
+                          This will add about 40KB to userdata
+
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in
+                            cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for
+                                the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use
+                                for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user
+                                as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should
+                                be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the
+                                user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for
+                                the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized
+                                keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          Verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                  machineTemplate:
+                    description: |-
+                      MachineTemplate contains information about how machines
+                      should be shaped when creating or updating a control plane.
+                    properties:
+                      infrastructureRef:
+                        description: |-
+                          InfrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                              TODO: this design is not final and this field is subject to change in the future.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      nodeDrainTimeout:
+                        description: |-
+                          NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                    required:
+                    - infrastructureRef
+                    type: object
+                  replicas:
+                    description: |-
+                      Number of desired machines. Defaults to 1. When stacked etcd is used only
+                      odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                      This is a pointer to distinguish between explicit zero and not specified.
+                    format: int32
+                    type: integer
+                  rolloutAfter:
+                    description: |-
+                      RolloutAfter is a field to indicate a rollout should be performed
+                      after the specified time even if no changes have been made to the
+                      KubeadmControlPlane.
+                    format: date-time
+                    type: string
+                  rolloutStrategy:
+                    default:
+                      rollingUpdate:
+                        maxSurge: 1
+                      type: RollingUpdate
+                    description: |-
+                      The RolloutStrategy to use to replace control plane machines with
+                      new ones.
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if
+                          RolloutStrategyType = RollingUpdate.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of control planes that can be scheduled above or under the
+                              desired number of control planes.
+                              Value can be an absolute number 1 or 0.
+                              Defaults to 1.
+                              Example: when this is set to 1, the control plane can be scaled
+                              up immediately when the rolling update starts.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: |-
+                          Type of rollout. Currently the only supported strategy is
+                          "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
+                  version:
+                    description: Version defines the desired Kubernetes version.
+                    type: string
+                required:
+                - kubeadmConfigSpec
+                - machineTemplate
+                - version
+                type: object
+              status:
+                description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmControlPlane.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  failureMessage:
+                    description: |-
+                      ErrorMessage indicates that there is a terminal problem reconciling the
+                      state, and will be set to a descriptive error message.
+                    type: string
+                  failureReason:
+                    description: |-
+                      FailureReason indicates that there is a terminal problem reconciling the
+                      state, and will be set to a token value suitable for
+                      programmatic interpretation.
+                    type: string
+                  initialized:
+                    description: |-
+                      Initialized denotes whether or not the control plane has the
+                      uploaded kubeadm-config configmap.
+                    type: boolean
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: |-
+                      Ready denotes that the KubeadmControlPlane API Server is ready to
+                      receive requests.
+                    type: boolean
+                  readyReplicas:
+                    description: Total number of fully running and ready control plane
+                      machines.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      (their labels match the selector).
+                    format: int32
+                    type: integer
+                  selector:
+                    description: |-
+                      Selector is the label selector in string format to avoid introspection
+                      by clients, and is used to provide the CRD-based integration for the
+                      scale subresource and additional integrations for things like kubectl
+                      describe.. The string will be in the same format as the query-param syntax.
+                      More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable machines targeted by this control plane.
+                      This is the total number of machines that are still required for
+                      the deployment to have 100% available capacity. They may either
+                      be machines that are running but not yet ready or machines
+                      that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      that have the desired template spec.
+                    format: int32
+                    type: integer
+                  version:
+                    description: |-
+                      Version represents the minimum Kubernetes version for the control plane machines
+                      in the cluster.
+                    type: string
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          scale:
+            labelSelectorPath: .status.selector
+            specReplicasPath: .spec.replicas
+            statusReplicasPath: .status.replicas
+          status: {}
+      - additionalPrinterColumns:
+        - description: Cluster
+          jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+          name: Cluster
+          type: string
+        - description: This denotes whether or not the control plane has the uploaded
+            kubeadm-config configmap
+          jsonPath: .status.initialized
+          name: Initialized
+          type: boolean
+        - description: KubeadmControlPlane API Server is ready to receive requests
+          jsonPath: .status.ready
+          name: API Server Available
+          type: boolean
+        - description: Total number of machines desired by this control plane
+          jsonPath: .spec.replicas
+          name: Desired
+          priority: 10
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane
+          jsonPath: .status.replicas
+          name: Replicas
+          type: integer
+        - description: Total number of fully running and ready control plane machines
+          jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane that have the desired template spec
+          jsonPath: .status.updatedReplicas
+          name: Updated
+          type: integer
+        - description: Total number of unavailable machines targeted by this control plane
+          jsonPath: .status.unavailableReplicas
+          name: Unavailable
+          type: integer
+        - description: Time duration since creation of KubeadmControlPlane
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Kubernetes version associated with this control plane
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
+              API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                properties:
+                  kubeadmConfigSpec:
+                    description: |-
+                      KubeadmConfigSpec is a KubeadmConfigSpec
+                      to use for initializing and joining machines to the control plane.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API
+                              server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names
+                                  for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              CertificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for
+                              the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed
+                              in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              Etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  External describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      CertFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for
+                                      ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      KeyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  Local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      DataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative
+                                      Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              * If not set, the default registry of kubeadm will be used, i.e.
+                                * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                * k8s.gcr.io (old registry): all older versions
+                                Please note that when imageRepository is not set we don't allow upgrades to
+                                versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                              * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                               `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              KubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              Networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services.
+                                  Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  ServiceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler
+                              control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition
+                          tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add
+                                    to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to
+                                    be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    Overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use.
+                                    The valid options are: "auto|any", "auto", "any",
+                                    "none", and <NUM>, where NUM is the actual partition
+                                    number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    Layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    TableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            append:
+                              description: Append specifies whether to append Content
+                                to existing file if Path exists.
+                              type: boolean
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file
+                                contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign
+                                to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        - ignition
+                        type: string
+                      ignition:
+                        description: Ignition contains Ignition specific configuration.
+                        properties:
+                          containerLinuxConfig:
+                            description: ContainerLinuxConfig contains CLC specific configuration.
+                            properties:
+                              additionalConfig:
+                                description: |-
+                                  AdditionalConfig contains additional configuration to be merged with the Ignition
+                                  configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                                  The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                type: string
+                              strict:
+                                description: Strict controls if AdditionalConfig should
+                                  be strictly parsed. If so, warnings are treated as errors.
+                                type: boolean
+                            type: object
+                        type: object
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token,
+                                stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    Description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    Expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    Groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    Token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    TTL defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    Usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              Patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              SkipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for
+                          the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              CACertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                          controlPlane:
+                            description: |-
+                              ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: |-
+                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                              TODO: revisit when there is defaulting from k/k
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  BootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      CACertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      Token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      UnsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: |-
+                                  File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfig:
+                                    description: |-
+                                      KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                      The file is generated at the path specified in KubeConfigPath.
+
+
+                                      Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                      Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                    properties:
+                                      cluster:
+                                        description: |-
+                                          Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                          By default the following fields are automatically populated:
+                                          - Server with the Cluster's ControlPlaneEndpoint.
+                                          - CertificateAuthorityData with the Cluster's CA certificate.
+                                        properties:
+                                          certificateAuthorityData:
+                                            description: |-
+                                              CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                              Defaults to the Cluster's CA certificate if empty.
+                                            format: byte
+                                            type: string
+                                          insecureSkipTLSVerify:
+                                            description: InsecureSkipTLSVerify skips the
+                                              validity check for the server's certificate.
+                                              This will make your HTTPS connections insecure.
+                                            type: boolean
+                                          proxyURL:
+                                            description: |-
+                                              ProxyURL is the URL to the proxy to be used for all requests made by this
+                                              client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                              this configuration is not provided or the empty string, the client
+                                              attempts to construct a proxy configuration from http_proxy and
+                                              https_proxy environment variables. If these environment variables are not
+                                              set, the client does not attempt to proxy requests.
+
+
+                                              socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                              attach, port forward).
+                                            type: string
+                                          server:
+                                            description: |-
+                                              Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                              Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                            type: string
+                                          tlsServerName:
+                                            description: TLSServerName is used to check
+                                              server certificate. If TLSServerName is
+                                              empty, the hostname used to contact the
+                                              server is used.
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: |-
+                                          User contains information that describes identity information.
+                                          This is used to tell the kubernetes cluster who you are.
+                                        properties:
+                                          authProvider:
+                                            description: AuthProvider specifies a custom
+                                              authentication plugin for the kubernetes
+                                              cluster.
+                                            properties:
+                                              config:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Config holds the parameters
+                                                  for the authentication plugin.
+                                                type: object
+                                              name:
+                                                description: Name is the name of the authentication
+                                                  plugin.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          exec:
+                                            description: Exec specifies a custom exec-based
+                                              authentication plugin for the kubernetes
+                                              cluster.
+                                            properties:
+                                              apiVersion:
+                                                description: |-
+                                                  Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                  the same encoding version as the input.
+                                                  Defaults to client.authentication.k8s.io/v1 if not set.
+                                                type: string
+                                              args:
+                                                description: Arguments to pass to the
+                                                  command when executing it.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                description: Command to execute.
+                                                type: string
+                                              env:
+                                                description: |-
+                                                  Env defines additional environment variables to expose to the process. These
+                                                  are unioned with the host's environment, as well as variables client-go uses
+                                                  to pass argument to the plugin.
+                                                items:
+                                                  description: |-
+                                                    KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                    credential plugin.
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              provideClusterInfo:
+                                                description: |-
+                                                  ProvideClusterInfo determines whether or not to provide cluster information,
+                                                  which could potentially contain very large CA data, to this exec plugin as a
+                                                  part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                  to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                  reading this environment variable.
+                                                type: boolean
+                                            required:
+                                            - command
+                                            type: object
+                                        type: object
+                                    required:
+                                    - user
+                                    type: object
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the
+                                      actual file path or URL to the kubeconfig file from
+                                      which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  TLSBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              Patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              SkipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run
+                          after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run
+                          before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+
+                          This will add about 40KB to userdata
+
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                          Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                          When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in
+                            cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for
+                                the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use
+                                for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user
+                                as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should
+                                be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the
+                                user
+                              type: string
+                            passwdFrom:
+                              description: PasswdFrom is a referenced source of passwd
+                                to populate the passwd.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this password.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for
+                                the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized
+                                keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          Verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                  machineTemplate:
+                    description: |-
+                      MachineTemplate contains information about how machines
+                      should be shaped when creating or updating a control plane.
+                    properties:
+                      infrastructureRef:
+                        description: |-
+                          InfrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                              TODO: this design is not final and this field is subject to change in the future.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      nodeDeletionTimeout:
+                        description: |-
+                          NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          If no value is provided, the default value for this property of the Machine resource will be used.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                    required:
+                    - infrastructureRef
+                    type: object
+                  remediationStrategy:
+                    description: The RemediationStrategy that controls how control plane
+                      machine remediation happens.
+                    properties:
+                      maxRetry:
+                        description: "MaxRetry is the Max number of retries while attempting
+                          to remediate an unhealthy machine.\nA retry happens when a machine
+                          that was created as a replacement for an unhealthy machine also
+                          fails.\nFor example, given a control plane with three machines
+                          M1, M2, M3:\n\n\n\tM1 become unhealthy; remediation happens,
+                          and M1-1 is created as a replacement.\n\tIf M1-1 (replacement
+                          of M1) has problems while bootstrapping it will become unhealthy,
+                          and then be\n\tremediated; such operation is considered a retry,
+                          remediation-retry #1.\n\tIf M1-2 (replacement of M1-1) becomes
+                          unhealthy, remediation-retry #2 will happen, etc.\n\n\nA retry
+                          could happen only after RetryPeriod from the previous retry.\nIf
+                          a machine is marked as unhealthy after MinHealthyPeriod from
+                          the previous remediation expired,\nthis is not considered a
+                          retry anymore because the new issue is assumed unrelated from
+                          the previous one.\n\n\nIf not set, the remedation will be retried
+                          infinitely."
+                        format: int32
+                        type: integer
+                      minHealthyPeriod:
+                        description: "MinHealthyPeriod defines the duration after which
+                          KCP will consider any failure to a machine unrelated\nfrom the
+                          previous one. In this case the remediation is not considered
+                          a retry anymore, and thus the retry\ncounter restarts from 0.
+                          For example, assuming MinHealthyPeriod is set to 1h (default)\n\n\n\tM1
+                          become unhealthy; remediation happens, and M1-1 is created as
+                          a replacement.\n\tIf M1-1 (replacement of M1) has problems within
+                          the 1hr after the creation, also\n\tthis machine will be remediated
+                          and this operation is considered a retry - a problem related\n\tto
+                          the original issue happened to M1 -.\n\n\n\tIf instead the problem
+                          on M1-1 is happening after MinHealthyPeriod expired, e.g. four
+                          days after\n\tm1-1 has been created as a remediation of M1,
+                          the problem on M1-1 is considered unrelated to\n\tthe original
+                          issue happened to M1.\n\n\nIf not set, this value is defaulted
+                          to 1h."
+                        type: string
+                      retryPeriod:
+                        description: |-
+                          RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                          for an unhealthy machine (a retry).
+
+
+                          If not set, a retry will happen immediately.
+                        type: string
+                    type: object
+                  replicas:
+                    description: |-
+                      Number of desired machines. Defaults to 1. When stacked etcd is used only
+                      odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                      This is a pointer to distinguish between explicit zero and not specified.
+                    format: int32
+                    type: integer
+                  rolloutAfter:
+                    description: |-
+                      RolloutAfter is a field to indicate a rollout should be performed
+                      after the specified time even if no changes have been made to the
+                      KubeadmControlPlane.
+                      Example: In the YAML the time can be specified in the RFC3339 format.
+                      To specify the rolloutAfter target as March 9, 2023, at 9 am UTC
+                      use "2023-03-09T09:00:00Z".
+                    format: date-time
+                    type: string
+                  rolloutBefore:
+                    description: |-
+                      RolloutBefore is a field to indicate a rollout should be performed
+                      if the specified criteria is met.
+                    properties:
+                      certificatesExpiryDays:
+                        description: |-
+                          CertificatesExpiryDays indicates a rollout needs to be performed if the
+                          certificates of the machine will expire within the specified days.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutStrategy:
+                    default:
+                      rollingUpdate:
+                        maxSurge: 1
+                      type: RollingUpdate
+                    description: |-
+                      The RolloutStrategy to use to replace control plane machines with
+                      new ones.
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if
+                          RolloutStrategyType = RollingUpdate.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of control planes that can be scheduled above or under the
+                              desired number of control planes.
+                              Value can be an absolute number 1 or 0.
+                              Defaults to 1.
+                              Example: when this is set to 1, the control plane can be scaled
+                              up immediately when the rolling update starts.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: |-
+                          Type of rollout. Currently the only supported strategy is
+                          "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
+                  version:
+                    description: |-
+                      Version defines the desired Kubernetes version.
+                      Please note that if kubeadmConfigSpec.ClusterConfiguration.imageRepository is not set
+                      we don't allow upgrades to versions >= v1.22.0 for which kubeadm uses the old registry (k8s.gcr.io).
+                      Please use a newer patch version with the new registry instead. The default registries of kubeadm are:
+                        * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                        * k8s.gcr.io (old registry): all older versions
+                    type: string
+                required:
+                - kubeadmConfigSpec
+                - machineTemplate
+                - version
+                type: object
+              status:
+                description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmControlPlane.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  failureMessage:
+                    description: |-
+                      ErrorMessage indicates that there is a terminal problem reconciling the
+                      state, and will be set to a descriptive error message.
+                    type: string
+                  failureReason:
+                    description: |-
+                      FailureReason indicates that there is a terminal problem reconciling the
+                      state, and will be set to a token value suitable for
+                      programmatic interpretation.
+                    type: string
+                  initialized:
+                    description: |-
+                      Initialized denotes whether or not the control plane has the
+                      uploaded kubeadm-config configmap.
+                    type: boolean
+                  lastRemediation:
+                    description: LastRemediation stores info about last remediation performed.
+                    properties:
+                      machine:
+                        description: Machine is the machine name of the latest machine
+                          being remediated.
+                        type: string
+                      retryCount:
+                        description: |-
+                          RetryCount used to keep track of remediation retry for the last remediated machine.
+                          A retry happens when a machine that was created as a replacement for an unhealthy machine also fails.
+                        format: int32
+                        type: integer
+                      timestamp:
+                        description: Timestamp is when last remediation happened. It is
+                          represented in RFC3339 form and is in UTC.
+                        format: date-time
+                        type: string
+                    required:
+                    - machine
+                    - retryCount
+                    - timestamp
+                    type: object
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: |-
+                      Ready denotes that the KubeadmControlPlane API Server is ready to
+                      receive requests.
+                    type: boolean
+                  readyReplicas:
+                    description: Total number of fully running and ready control plane
+                      machines.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      (their labels match the selector).
+                    format: int32
+                    type: integer
+                  selector:
+                    description: |-
+                      Selector is the label selector in string format to avoid introspection
+                      by clients, and is used to provide the CRD-based integration for the
+                      scale subresource and additional integrations for things like kubectl
+                      describe.. The string will be in the same format as the query-param syntax.
+                      More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable machines targeted by this control plane.
+                      This is the total number of machines that are still required for
+                      the deployment to have 100% available capacity. They may either
+                      be machines that are running but not yet ready or machines
+                      that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      that have the desired template spec.
+                    format: int32
+                    type: integer
+                  version:
+                    description: |-
+                      Version represents the minimum Kubernetes version for the control plane machines
+                      in the cluster.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          scale:
+            labelSelectorPath: .status.selector
+            specReplicasPath: .spec.replicas
+            statusReplicasPath: .status.replicas
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+        controller-gen.kubebuilder.io/version: v0.14.0
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-control-plane-webhook-service
+              namespace: capi-kubeadm-control-plane-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: controlplane.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmControlPlaneTemplate
+        listKind: KubeadmControlPlaneTemplateList
+        plural: kubeadmcontrolplanetemplates
+        singular: kubeadmcontrolplanetemplate
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmControlPlaneTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneTemplateSpec defines the desired state
+                  of KubeadmControlPlaneTemplate.
+                properties:
+                  template:
+                    description: KubeadmControlPlaneTemplateResource describes the data
+                      needed to create a KubeadmControlPlane from a template.
+                    properties:
+                      spec:
+                        description: KubeadmControlPlaneSpec defines the desired state
+                          of KubeadmControlPlane.
+                        properties:
+                          kubeadmConfigSpec:
+                            description: |-
+                              KubeadmConfigSpec is a KubeadmConfigSpec
+                              to use for initializing and joining machines to the control plane.
+                            properties:
+                              clusterConfiguration:
+                                description: ClusterConfiguration along with InitConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiServer:
+                                    description: APIServer contains extra settings for
+                                      the API server control plane component
+                                    properties:
+                                      certSANs:
+                                        description: CertSANs sets extra Subject Alternative
+                                          Names for the API Server signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                      timeoutForControlPlane:
+                                        description: TimeoutForControlPlane controls the
+                                          timeout that we use for API server to appear
+                                        type: string
+                                    type: object
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  certificatesDir:
+                                    description: |-
+                                      CertificatesDir specifies where to store or look for all required certificates.
+                                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                    type: string
+                                  clusterName:
+                                    description: The cluster name
+                                    type: string
+                                  controlPlaneEndpoint:
+                                    description: |-
+                                      ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                      the BindPort is used.
+                                      Possible usages are:
+                                      e.g. In a cluster with more than one control plane instances, this field should be
+                                      assigned the address of the external load balancer in front of the
+                                      control plane instances.
+                                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                      could be used for assigning a stable DNS to the control plane.
+                                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                    type: string
+                                  controllerManager:
+                                    description: ControllerManager contains extra settings
+                                      for the controller manager control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                  dns:
+                                    description: DNS defines the options for the DNS add-on
+                                      installed in the cluster.
+                                    properties:
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                    type: object
+                                  etcd:
+                                    description: |-
+                                      Etcd holds configuration for etcd.
+                                      NB: This value defaults to a Local (stacked) etcd
+                                    properties:
+                                      external:
+                                        description: |-
+                                          External describes how to connect to an external etcd cluster
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          caFile:
+                                            description: |-
+                                              CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          certFile:
+                                            description: |-
+                                              CertFile is an SSL certification file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          endpoints:
+                                            description: Endpoints of etcd members. Required
+                                              for ExternalEtcd.
+                                            items:
+                                              type: string
+                                            type: array
+                                          keyFile:
+                                            description: |-
+                                              KeyFile is an SSL key file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                        required:
+                                        - caFile
+                                        - certFile
+                                        - endpoints
+                                        - keyFile
+                                        type: object
+                                      local:
+                                        description: |-
+                                          Local provides configuration knobs for configuring the local etcd instance
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          dataDir:
+                                            description: |-
+                                              DataDir is the directory etcd will place its data.
+                                              Defaults to "/var/lib/etcd".
+                                            type: string
+                                          extraArgs:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              ExtraArgs are extra arguments provided to the etcd binary
+                                              when run inside a static pod.
+                                            type: object
+                                          imageRepository:
+                                            description: |-
+                                              ImageRepository sets the container registry to pull images from.
+                                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                            type: string
+                                          imageTag:
+                                            description: |-
+                                              ImageTag allows to specify a tag for the image.
+                                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                            type: string
+                                          peerCertSANs:
+                                            description: PeerCertSANs sets extra Subject
+                                              Alternative Names for the etcd peer signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                          serverCertSANs:
+                                            description: ServerCertSANs sets extra Subject
+                                              Alternative Names for the etcd server signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                    type: object
+                                  featureGates:
+                                    additionalProperties:
+                                      type: boolean
+                                    description: FeatureGates enabled by the user.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                      `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                                      will be used for all the other images.
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  kubernetesVersion:
+                                    description: |-
+                                      KubernetesVersion is the target version of the control plane.
+                                      NB: This value defaults to the Machine object spec.version
+                                    type: string
+                                  networking:
+                                    description: |-
+                                      Networking holds configuration for the networking topology of the cluster.
+                                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                    properties:
+                                      dnsDomain:
+                                        description: DNSDomain is the dns domain used
+                                          by k8s services. Defaults to "cluster.local".
+                                        type: string
+                                      podSubnet:
+                                        description: |-
+                                          PodSubnet is the subnet used by pods.
+                                          If unset, the API server will not allocate CIDR ranges for every node.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                        type: string
+                                      serviceSubnet:
+                                        description: |-
+                                          ServiceSubnet is the subnet used by k8s services.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                          to "10.96.0.0/12" if that's unset.
+                                        type: string
+                                    type: object
+                                  scheduler:
+                                    description: Scheduler contains extra settings for
+                                      the scheduler control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              diskSetup:
+                                description: DiskSetup specifies options for the creation
+                                  of partition tables and file systems on devices.
+                                properties:
+                                  filesystems:
+                                    description: Filesystems specifies the list of file
+                                      systems to setup.
+                                    items:
+                                      description: Filesystem defines the file systems
+                                        to be created.
+                                      properties:
+                                        device:
+                                          description: Device specifies the device name
+                                          type: string
+                                        extraOpts:
+                                          description: ExtraOpts defined extra options
+                                            to add to the command for creating the file
+                                            system.
+                                          items:
+                                            type: string
+                                          type: array
+                                        filesystem:
+                                          description: Filesystem specifies the file system
+                                            type.
+                                          type: string
+                                        label:
+                                          description: Label specifies the file system
+                                            label to be used. If set to None, no label
+                                            is used.
+                                          type: string
+                                        overwrite:
+                                          description: |-
+                                            Overwrite defines whether or not to overwrite any existing filesystem.
+                                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                                          type: boolean
+                                        partition:
+                                          description: 'Partition specifies the partition
+                                            to use. The valid options are: "auto|any",
+                                            "auto", "any", "none", and <NUM>, where NUM
+                                            is the actual partition number.'
+                                          type: string
+                                        replaceFS:
+                                          description: |-
+                                            ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                          type: string
+                                      required:
+                                      - device
+                                      - filesystem
+                                      - label
+                                      type: object
+                                    type: array
+                                  partitions:
+                                    description: Partitions specifies the list of the
+                                      partitions to setup.
+                                    items:
+                                      description: Partition defines how to create and
+                                        layout a partition.
+                                      properties:
+                                        device:
+                                          description: Device is the name of the device.
+                                          type: string
+                                        layout:
+                                          description: |-
+                                            Layout specifies the device layout.
+                                            If it is true, a single partition will be created for the entire device.
+                                            When layout is false, it means don't partition or ignore existing partitioning.
+                                          type: boolean
+                                        overwrite:
+                                          description: |-
+                                            Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                            Use with caution. Default is 'false'.
+                                          type: boolean
+                                        tableType:
+                                          description: |-
+                                            TableType specifies the tupe of partition table. The following are supported:
+                                            'mbr': default and setups a MS-DOS partition table
+                                            'gpt': setups a GPT partition table
+                                          type: string
+                                      required:
+                                      - device
+                                      - layout
+                                      type: object
+                                    type: array
+                                type: object
+                              files:
+                                description: Files specifies extra files to be passed
+                                  to user_data upon creation.
+                                items:
+                                  description: File defines the input for generating write_files
+                                    in cloud-init.
+                                  properties:
+                                    content:
+                                      description: Content is the actual content of the
+                                        file.
+                                      type: string
+                                    contentFrom:
+                                      description: ContentFrom is a referenced source
+                                        of content to populate the file.
+                                      properties:
+                                        secret:
+                                          description: Secret represents a secret that
+                                            should populate this file.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret's
+                                                data map for this value.
+                                              type: string
+                                            name:
+                                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                                namespace to use.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                      required:
+                                      - secret
+                                      type: object
+                                    encoding:
+                                      description: Encoding specifies the encoding of
+                                        the file contents.
+                                      enum:
+                                      - base64
+                                      - gzip
+                                      - gzip+base64
+                                      type: string
+                                    owner:
+                                      description: Owner specifies the ownership of the
+                                        file, e.g. "root:root".
+                                      type: string
+                                    path:
+                                      description: Path specifies the full path on disk
+                                        where to store the file.
+                                      type: string
+                                    permissions:
+                                      description: Permissions specifies the permissions
+                                        to assign to the file, e.g. "0640".
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                              format:
+                                description: Format specifies the output format of the
+                                  bootstrap data
+                                enum:
+                                - cloud-config
+                                type: string
+                              initConfiguration:
+                                description: InitConfiguration along with ClusterConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  bootstrapTokens:
+                                    description: |-
+                                      BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                    items:
+                                      description: BootstrapToken describes one bootstrap
+                                        token, stored as a Secret in the cluster.
+                                      properties:
+                                        description:
+                                          description: |-
+                                            Description sets a human-friendly message why this token exists and what it's used
+                                            for, so other administrators can know its purpose.
+                                          type: string
+                                        expires:
+                                          description: |-
+                                            Expires specifies the timestamp when this token expires. Defaults to being set
+                                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                          format: date-time
+                                          type: string
+                                        groups:
+                                          description: |-
+                                            Groups specifies the extra groups that this token will authenticate as when/if
+                                            used for authentication
+                                          items:
+                                            type: string
+                                          type: array
+                                        token:
+                                          description: |-
+                                            Token is used for establishing bidirectional trust between nodes and control-planes.
+                                            Used for joining nodes in the cluster.
+                                          type: string
+                                        ttl:
+                                          description: |-
+                                            TTL defines the time to live for this token. Defaults to 24h.
+                                            Expires and TTL are mutually exclusive.
+                                          type: string
+                                        usages:
+                                          description: |-
+                                            Usages describes the ways in which this token can be used. Can by default be used
+                                            for establishing bidirectional trust, but that can be changed here.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - token
+                                      type: object
+                                    type: array
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  localAPIEndpoint:
+                                    description: |-
+                                      LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                      fails you may set the desired value here.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              joinConfiguration:
+                                description: JoinConfiguration is the kubeadm configuration
+                                  for the join command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  caCertPath:
+                                    description: |-
+                                      CACertPath is the path to the SSL certificate authority used to
+                                      secure comunications between node and control-plane.
+                                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                                      TODO: revisit when there is defaulting from k/k
+                                    type: string
+                                  controlPlane:
+                                    description: |-
+                                      ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                      If nil, no additional control plane instance will be deployed.
+                                    properties:
+                                      localAPIEndpoint:
+                                        description: LocalAPIEndpoint represents the endpoint
+                                          of the API server instance to be deployed on
+                                          this node.
+                                        properties:
+                                          advertiseAddress:
+                                            description: AdvertiseAddress sets the IP
+                                              address for the API server to advertise.
+                                            type: string
+                                          bindPort:
+                                            description: |-
+                                              BindPort sets the secure port for the API Server to bind to.
+                                              Defaults to 6443.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  discovery:
+                                    description: |-
+                                      Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                      TODO: revisit when there is defaulting from k/k
+                                    properties:
+                                      bootstrapToken:
+                                        description: |-
+                                          BootstrapToken is used to set the options for bootstrap token based discovery
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          apiServerEndpoint:
+                                            description: APIServerEndpoint is an IP or
+                                              domain name to the API server from which
+                                              info will be fetched.
+                                            type: string
+                                          caCertHashes:
+                                            description: |-
+                                              CACertHashes specifies a set of public key pins to verify
+                                              when token-based discovery is used. The root CA found during discovery
+                                              must match one of these values. Specifying an empty set disables root CA
+                                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                              where the only currently supported type is "sha256". This is a hex-encoded
+                                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                            items:
+                                              type: string
+                                            type: array
+                                          token:
+                                            description: |-
+                                              Token is a token used to validate cluster information
+                                              fetched from the control-plane.
+                                            type: string
+                                          unsafeSkipCAVerification:
+                                            description: |-
+                                              UnsafeSkipCAVerification allows token-based discovery
+                                              without CA verification via CACertHashes. This can weaken
+                                              the security of kubeadm since other nodes can impersonate the control-plane.
+                                            type: boolean
+                                        required:
+                                        - token
+                                        type: object
+                                      file:
+                                        description: |-
+                                          File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          kubeConfigPath:
+                                            description: KubeConfigPath is used to specify
+                                              the actual file path or URL to the kubeconfig
+                                              file from which to load cluster information
+                                            type: string
+                                        required:
+                                        - kubeConfigPath
+                                        type: object
+                                      timeout:
+                                        description: Timeout modifies the discovery timeout
+                                        type: string
+                                      tlsBootstrapToken:
+                                        description: |-
+                                          TLSBootstrapToken is a token used for TLS bootstrapping.
+                                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                        type: string
+                                    type: object
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              mounts:
+                                description: Mounts specifies a list of mount points to
+                                  be setup.
+                                items:
+                                  description: MountPoints defines input for generated
+                                    mounts in cloud-init.
+                                  items:
+                                    type: string
+                                  type: array
+                                type: array
+                              ntp:
+                                description: NTP specifies NTP configuration
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether NTP should
+                                      be enabled
+                                    type: boolean
+                                  servers:
+                                    description: Servers specifies which NTP servers to
+                                      use
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              postKubeadmCommands:
+                                description: PostKubeadmCommands specifies extra commands
+                                  to run after kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              preKubeadmCommands:
+                                description: PreKubeadmCommands specifies extra commands
+                                  to run before kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              useExperimentalRetryJoin:
+                                description: |-
+                                  UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                                  script with retries for joins.
+
+
+                                  This is meant to be an experimental temporary workaround on some environments
+                                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                                  kubeadm proper and use that functionality.
+
+
+                                  This will add about 40KB to userdata
+
+
+                                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                                type: boolean
+                              users:
+                                description: Users specifies extra users to add
+                                items:
+                                  description: User defines the input for a generated
+                                    user in cloud-init.
+                                  properties:
+                                    gecos:
+                                      description: Gecos specifies the gecos to use for
+                                        the user
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the additional groups
+                                        for the user
+                                      type: string
+                                    homeDir:
+                                      description: HomeDir specifies the home directory
+                                        to use for the user
+                                      type: string
+                                    inactive:
+                                      description: Inactive specifies whether to mark
+                                        the user as inactive
+                                      type: boolean
+                                    lockPassword:
+                                      description: LockPassword specifies if password
+                                        login should be disabled
+                                      type: boolean
+                                    name:
+                                      description: Name specifies the user name
+                                      type: string
+                                    passwd:
+                                      description: Passwd specifies a hashed password
+                                        for the user
+                                      type: string
+                                    primaryGroup:
+                                      description: PrimaryGroup specifies the primary
+                                        group for the user
+                                      type: string
+                                    shell:
+                                      description: Shell specifies the user's shell
+                                      type: string
+                                    sshAuthorizedKeys:
+                                      description: SSHAuthorizedKeys specifies a list
+                                        of ssh authorized keys for the user
+                                      items:
+                                        type: string
+                                      type: array
+                                    sudo:
+                                      description: Sudo specifies a sudo role for the
+                                        user
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              verbosity:
+                                description: |-
+                                  Verbosity is the number for the kubeadm log level verbosity.
+                                  It overrides the `--v` flag in kubeadm commands.
+                                format: int32
+                                type: integer
+                            type: object
+                          machineTemplate:
+                            description: |-
+                              MachineTemplate contains information about how machines
+                              should be shaped when creating or updating a control plane.
+                            properties:
+                              infrastructureRef:
+                                description: |-
+                                  InfrastructureRef is a required reference to a custom resource
+                                  offered by an infrastructure provider.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: |-
+                                      If referring to a piece of an object instead of an entire object, this string
+                                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                      the event) or if no container name is specified "spec.containers[2]" (container with
+                                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                      referencing a part of an object.
+                                      TODO: this design is not final and this field is subject to change in the future.
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the referent.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                    type: string
+                                  resourceVersion:
+                                    description: |-
+                                      Specific resourceVersion to which this reference is made, if any.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                    type: string
+                                  uid:
+                                    description: |-
+                                      UID of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              metadata:
+                                description: |-
+                                  Standard object's metadata.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata. They are not
+                                      queryable and should be preserved when modifying objects.
+                                      More info: http://kubernetes.io/docs/user-guide/annotations
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects. May match selectors of replication controllers
+                                      and services.
+                                      More info: http://kubernetes.io/docs/user-guide/labels
+                                    type: object
+                                type: object
+                              nodeDrainTimeout:
+                                description: |-
+                                  NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                                  The default value is 0, meaning that the node can be drained without any time limitations.
+                                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                                type: string
+                            required:
+                            - infrastructureRef
+                            type: object
+                          replicas:
+                            description: |-
+                              Number of desired machines. Defaults to 1. When stacked etcd is used only
+                              odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                              This is a pointer to distinguish between explicit zero and not specified.
+                            format: int32
+                            type: integer
+                          rolloutAfter:
+                            description: |-
+                              RolloutAfter is a field to indicate a rollout should be performed
+                              after the specified time even if no changes have been made to the
+                              KubeadmControlPlane.
+                            format: date-time
+                            type: string
+                          rolloutStrategy:
+                            default:
+                              rollingUpdate:
+                                maxSurge: 1
+                              type: RollingUpdate
+                            description: |-
+                              The RolloutStrategy to use to replace control plane machines with
+                              new ones.
+                            properties:
+                              rollingUpdate:
+                                description: |-
+                                  Rolling update config params. Present only if
+                                  RolloutStrategyType = RollingUpdate.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of control planes that can be scheduled above or under the
+                                      desired number of control planes.
+                                      Value can be an absolute number 1 or 0.
+                                      Defaults to 1.
+                                      Example: when this is set to 1, the control plane can be scaled
+                                      up immediately when the rolling update starts.
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  Type of rollout. Currently the only supported strategy is
+                                  "RollingUpdate".
+                                  Default is RollingUpdate.
+                                type: string
+                            type: object
+                          version:
+                            description: Version defines the desired Kubernetes version.
+                            type: string
+                        required:
+                        - kubeadmConfigSpec
+                        - machineTemplate
+                        - version
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmControlPlaneTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates
+              API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneTemplateSpec defines the desired state
+                  of KubeadmControlPlaneTemplate.
+                properties:
+                  template:
+                    description: KubeadmControlPlaneTemplateResource describes the data
+                      needed to create a KubeadmControlPlane from a template.
+                    properties:
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      spec:
+                        description: |-
+                          KubeadmControlPlaneTemplateResourceSpec defines the desired state of KubeadmControlPlane.
+                          NOTE: KubeadmControlPlaneTemplateResourceSpec is similar to KubeadmControlPlaneSpec but
+                          omits Replicas and Version fields. These fields do not make sense on the KubeadmControlPlaneTemplate,
+                          because they are calculated by the Cluster topology reconciler during reconciliation and thus cannot
+                          be configured on the KubeadmControlPlaneTemplate.
+                        properties:
+                          kubeadmConfigSpec:
+                            description: |-
+                              KubeadmConfigSpec is a KubeadmConfigSpec
+                              to use for initializing and joining machines to the control plane.
+                            properties:
+                              clusterConfiguration:
+                                description: ClusterConfiguration along with InitConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiServer:
+                                    description: APIServer contains extra settings for
+                                      the API server control plane component
+                                    properties:
+                                      certSANs:
+                                        description: CertSANs sets extra Subject Alternative
+                                          Names for the API Server signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                      timeoutForControlPlane:
+                                        description: TimeoutForControlPlane controls the
+                                          timeout that we use for API server to appear
+                                        type: string
+                                    type: object
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  certificatesDir:
+                                    description: |-
+                                      CertificatesDir specifies where to store or look for all required certificates.
+                                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                    type: string
+                                  clusterName:
+                                    description: The cluster name
+                                    type: string
+                                  controlPlaneEndpoint:
+                                    description: |-
+                                      ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                      the BindPort is used.
+                                      Possible usages are:
+                                      e.g. In a cluster with more than one control plane instances, this field should be
+                                      assigned the address of the external load balancer in front of the
+                                      control plane instances.
+                                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                      could be used for assigning a stable DNS to the control plane.
+                                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                    type: string
+                                  controllerManager:
+                                    description: ControllerManager contains extra settings
+                                      for the controller manager control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                  dns:
+                                    description: DNS defines the options for the DNS add-on
+                                      installed in the cluster.
+                                    properties:
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                    type: object
+                                  etcd:
+                                    description: |-
+                                      Etcd holds configuration for etcd.
+                                      NB: This value defaults to a Local (stacked) etcd
+                                    properties:
+                                      external:
+                                        description: |-
+                                          External describes how to connect to an external etcd cluster
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          caFile:
+                                            description: |-
+                                              CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          certFile:
+                                            description: |-
+                                              CertFile is an SSL certification file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          endpoints:
+                                            description: Endpoints of etcd members. Required
+                                              for ExternalEtcd.
+                                            items:
+                                              type: string
+                                            type: array
+                                          keyFile:
+                                            description: |-
+                                              KeyFile is an SSL key file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                        required:
+                                        - caFile
+                                        - certFile
+                                        - endpoints
+                                        - keyFile
+                                        type: object
+                                      local:
+                                        description: |-
+                                          Local provides configuration knobs for configuring the local etcd instance
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          dataDir:
+                                            description: |-
+                                              DataDir is the directory etcd will place its data.
+                                              Defaults to "/var/lib/etcd".
+                                            type: string
+                                          extraArgs:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              ExtraArgs are extra arguments provided to the etcd binary
+                                              when run inside a static pod.
+                                            type: object
+                                          imageRepository:
+                                            description: |-
+                                              ImageRepository sets the container registry to pull images from.
+                                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                            type: string
+                                          imageTag:
+                                            description: |-
+                                              ImageTag allows to specify a tag for the image.
+                                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                            type: string
+                                          peerCertSANs:
+                                            description: PeerCertSANs sets extra Subject
+                                              Alternative Names for the etcd peer signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                          serverCertSANs:
+                                            description: ServerCertSANs sets extra Subject
+                                              Alternative Names for the etcd server signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                    type: object
+                                  featureGates:
+                                    additionalProperties:
+                                      type: boolean
+                                    description: FeatureGates enabled by the user.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      * If not set, the default registry of kubeadm will be used, i.e.
+                                        * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                        * k8s.gcr.io (old registry): all older versions
+                                        Please note that when imageRepository is not set we don't allow upgrades to
+                                        versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                        a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                        >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                                      * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                       `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                        and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  kubernetesVersion:
+                                    description: |-
+                                      KubernetesVersion is the target version of the control plane.
+                                      NB: This value defaults to the Machine object spec.version
+                                    type: string
+                                  networking:
+                                    description: |-
+                                      Networking holds configuration for the networking topology of the cluster.
+                                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                    properties:
+                                      dnsDomain:
+                                        description: DNSDomain is the dns domain used
+                                          by k8s services. Defaults to "cluster.local".
+                                        type: string
+                                      podSubnet:
+                                        description: |-
+                                          PodSubnet is the subnet used by pods.
+                                          If unset, the API server will not allocate CIDR ranges for every node.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                        type: string
+                                      serviceSubnet:
+                                        description: |-
+                                          ServiceSubnet is the subnet used by k8s services.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                          to "10.96.0.0/12" if that's unset.
+                                        type: string
+                                    type: object
+                                  scheduler:
+                                    description: Scheduler contains extra settings for
+                                      the scheduler control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              diskSetup:
+                                description: DiskSetup specifies options for the creation
+                                  of partition tables and file systems on devices.
+                                properties:
+                                  filesystems:
+                                    description: Filesystems specifies the list of file
+                                      systems to setup.
+                                    items:
+                                      description: Filesystem defines the file systems
+                                        to be created.
+                                      properties:
+                                        device:
+                                          description: Device specifies the device name
+                                          type: string
+                                        extraOpts:
+                                          description: ExtraOpts defined extra options
+                                            to add to the command for creating the file
+                                            system.
+                                          items:
+                                            type: string
+                                          type: array
+                                        filesystem:
+                                          description: Filesystem specifies the file system
+                                            type.
+                                          type: string
+                                        label:
+                                          description: Label specifies the file system
+                                            label to be used. If set to None, no label
+                                            is used.
+                                          type: string
+                                        overwrite:
+                                          description: |-
+                                            Overwrite defines whether or not to overwrite any existing filesystem.
+                                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                                          type: boolean
+                                        partition:
+                                          description: 'Partition specifies the partition
+                                            to use. The valid options are: "auto|any",
+                                            "auto", "any", "none", and <NUM>, where NUM
+                                            is the actual partition number.'
+                                          type: string
+                                        replaceFS:
+                                          description: |-
+                                            ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                          type: string
+                                      required:
+                                      - device
+                                      - filesystem
+                                      - label
+                                      type: object
+                                    type: array
+                                  partitions:
+                                    description: Partitions specifies the list of the
+                                      partitions to setup.
+                                    items:
+                                      description: Partition defines how to create and
+                                        layout a partition.
+                                      properties:
+                                        device:
+                                          description: Device is the name of the device.
+                                          type: string
+                                        layout:
+                                          description: |-
+                                            Layout specifies the device layout.
+                                            If it is true, a single partition will be created for the entire device.
+                                            When layout is false, it means don't partition or ignore existing partitioning.
+                                          type: boolean
+                                        overwrite:
+                                          description: |-
+                                            Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                            Use with caution. Default is 'false'.
+                                          type: boolean
+                                        tableType:
+                                          description: |-
+                                            TableType specifies the tupe of partition table. The following are supported:
+                                            'mbr': default and setups a MS-DOS partition table
+                                            'gpt': setups a GPT partition table
+                                          type: string
+                                      required:
+                                      - device
+                                      - layout
+                                      type: object
+                                    type: array
+                                type: object
+                              files:
+                                description: Files specifies extra files to be passed
+                                  to user_data upon creation.
+                                items:
+                                  description: File defines the input for generating write_files
+                                    in cloud-init.
+                                  properties:
+                                    append:
+                                      description: Append specifies whether to append
+                                        Content to existing file if Path exists.
+                                      type: boolean
+                                    content:
+                                      description: Content is the actual content of the
+                                        file.
+                                      type: string
+                                    contentFrom:
+                                      description: ContentFrom is a referenced source
+                                        of content to populate the file.
+                                      properties:
+                                        secret:
+                                          description: Secret represents a secret that
+                                            should populate this file.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret's
+                                                data map for this value.
+                                              type: string
+                                            name:
+                                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                                namespace to use.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                      required:
+                                      - secret
+                                      type: object
+                                    encoding:
+                                      description: Encoding specifies the encoding of
+                                        the file contents.
+                                      enum:
+                                      - base64
+                                      - gzip
+                                      - gzip+base64
+                                      type: string
+                                    owner:
+                                      description: Owner specifies the ownership of the
+                                        file, e.g. "root:root".
+                                      type: string
+                                    path:
+                                      description: Path specifies the full path on disk
+                                        where to store the file.
+                                      type: string
+                                    permissions:
+                                      description: Permissions specifies the permissions
+                                        to assign to the file, e.g. "0640".
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                              format:
+                                description: Format specifies the output format of the
+                                  bootstrap data
+                                enum:
+                                - cloud-config
+                                - ignition
+                                type: string
+                              ignition:
+                                description: Ignition contains Ignition specific configuration.
+                                properties:
+                                  containerLinuxConfig:
+                                    description: ContainerLinuxConfig contains CLC specific
+                                      configuration.
+                                    properties:
+                                      additionalConfig:
+                                        description: |-
+                                          AdditionalConfig contains additional configuration to be merged with the Ignition
+                                          configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                                          The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                        type: string
+                                      strict:
+                                        description: Strict controls if AdditionalConfig
+                                          should be strictly parsed. If so, warnings are
+                                          treated as errors.
+                                        type: boolean
+                                    type: object
+                                type: object
+                              initConfiguration:
+                                description: InitConfiguration along with ClusterConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  bootstrapTokens:
+                                    description: |-
+                                      BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                    items:
+                                      description: BootstrapToken describes one bootstrap
+                                        token, stored as a Secret in the cluster.
+                                      properties:
+                                        description:
+                                          description: |-
+                                            Description sets a human-friendly message why this token exists and what it's used
+                                            for, so other administrators can know its purpose.
+                                          type: string
+                                        expires:
+                                          description: |-
+                                            Expires specifies the timestamp when this token expires. Defaults to being set
+                                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                          format: date-time
+                                          type: string
+                                        groups:
+                                          description: |-
+                                            Groups specifies the extra groups that this token will authenticate as when/if
+                                            used for authentication
+                                          items:
+                                            type: string
+                                          type: array
+                                        token:
+                                          description: |-
+                                            Token is used for establishing bidirectional trust between nodes and control-planes.
+                                            Used for joining nodes in the cluster.
+                                          type: string
+                                        ttl:
+                                          description: |-
+                                            TTL defines the time to live for this token. Defaults to 24h.
+                                            Expires and TTL are mutually exclusive.
+                                          type: string
+                                        usages:
+                                          description: |-
+                                            Usages describes the ways in which this token can be used. Can by default be used
+                                            for establishing bidirectional trust, but that can be changed here.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - token
+                                      type: object
+                                    type: array
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  localAPIEndpoint:
+                                    description: |-
+                                      LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                      fails you may set the desired value here.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      imagePullPolicy:
+                                        description: |-
+                                          ImagePullPolicy specifies the policy for image pulling
+                                          during kubeadm "init" and "join" operations. The value of
+                                          this field must be one of "Always", "IfNotPresent" or
+                                          "Never". Defaults to "IfNotPresent". This can be used only
+                                          with Kubernetes version equal to 1.22 and later.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        - Never
+                                        type: string
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                  patches:
+                                    description: |-
+                                      Patches contains options related to applying patches to components deployed by kubeadm during
+                                      "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                                    properties:
+                                      directory:
+                                        description: |-
+                                          Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                          "suffix" is an optional string that can be used to determine which patches are applied
+                                          first alpha-numerically.
+                                          These files can be written into the target directory via KubeadmConfig.Files which
+                                          specifies additional files to be created on the machine, either with content inline or
+                                          by referencing a secret.
+                                        type: string
+                                    type: object
+                                  skipPhases:
+                                    description: |-
+                                      SkipPhases is a list of phases to skip during command execution.
+                                      The list of phases can be obtained with the "kubeadm init --help" command.
+                                      This option takes effect only on Kubernetes >=1.22.0.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              joinConfiguration:
+                                description: JoinConfiguration is the kubeadm configuration
+                                  for the join command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  caCertPath:
+                                    description: |-
+                                      CACertPath is the path to the SSL certificate authority used to
+                                      secure comunications between node and control-plane.
+                                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                                      TODO: revisit when there is defaulting from k/k
+                                    type: string
+                                  controlPlane:
+                                    description: |-
+                                      ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                      If nil, no additional control plane instance will be deployed.
+                                    properties:
+                                      localAPIEndpoint:
+                                        description: LocalAPIEndpoint represents the endpoint
+                                          of the API server instance to be deployed on
+                                          this node.
+                                        properties:
+                                          advertiseAddress:
+                                            description: AdvertiseAddress sets the IP
+                                              address for the API server to advertise.
+                                            type: string
+                                          bindPort:
+                                            description: |-
+                                              BindPort sets the secure port for the API Server to bind to.
+                                              Defaults to 6443.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  discovery:
+                                    description: |-
+                                      Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                      TODO: revisit when there is defaulting from k/k
+                                    properties:
+                                      bootstrapToken:
+                                        description: |-
+                                          BootstrapToken is used to set the options for bootstrap token based discovery
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          apiServerEndpoint:
+                                            description: APIServerEndpoint is an IP or
+                                              domain name to the API server from which
+                                              info will be fetched.
+                                            type: string
+                                          caCertHashes:
+                                            description: |-
+                                              CACertHashes specifies a set of public key pins to verify
+                                              when token-based discovery is used. The root CA found during discovery
+                                              must match one of these values. Specifying an empty set disables root CA
+                                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                              where the only currently supported type is "sha256". This is a hex-encoded
+                                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                            items:
+                                              type: string
+                                            type: array
+                                          token:
+                                            description: |-
+                                              Token is a token used to validate cluster information
+                                              fetched from the control-plane.
+                                            type: string
+                                          unsafeSkipCAVerification:
+                                            description: |-
+                                              UnsafeSkipCAVerification allows token-based discovery
+                                              without CA verification via CACertHashes. This can weaken
+                                              the security of kubeadm since other nodes can impersonate the control-plane.
+                                            type: boolean
+                                        required:
+                                        - token
+                                        type: object
+                                      file:
+                                        description: |-
+                                          File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          kubeConfig:
+                                            description: |-
+                                              KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                              The file is generated at the path specified in KubeConfigPath.
+
+
+                                              Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                              Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                            properties:
+                                              cluster:
+                                                description: |-
+                                                  Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                                  By default the following fields are automatically populated:
+                                                  - Server with the Cluster's ControlPlaneEndpoint.
+                                                  - CertificateAuthorityData with the Cluster's CA certificate.
+                                                properties:
+                                                  certificateAuthorityData:
+                                                    description: |-
+                                                      CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                                      Defaults to the Cluster's CA certificate if empty.
+                                                    format: byte
+                                                    type: string
+                                                  insecureSkipTLSVerify:
+                                                    description: InsecureSkipTLSVerify
+                                                      skips the validity check for the
+                                                      server's certificate. This will
+                                                      make your HTTPS connections insecure.
+                                                    type: boolean
+                                                  proxyURL:
+                                                    description: |-
+                                                      ProxyURL is the URL to the proxy to be used for all requests made by this
+                                                      client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                                      this configuration is not provided or the empty string, the client
+                                                      attempts to construct a proxy configuration from http_proxy and
+                                                      https_proxy environment variables. If these environment variables are not
+                                                      set, the client does not attempt to proxy requests.
+
+
+                                                      socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                                      attach, port forward).
+                                                    type: string
+                                                  server:
+                                                    description: |-
+                                                      Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                                      Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                                    type: string
+                                                  tlsServerName:
+                                                    description: TLSServerName is used
+                                                      to check server certificate. If
+                                                      TLSServerName is empty, the hostname
+                                                      used to contact the server is used.
+                                                    type: string
+                                                type: object
+                                              user:
+                                                description: |-
+                                                  User contains information that describes identity information.
+                                                  This is used to tell the kubernetes cluster who you are.
+                                                properties:
+                                                  authProvider:
+                                                    description: AuthProvider specifies
+                                                      a custom authentication plugin for
+                                                      the kubernetes cluster.
+                                                    properties:
+                                                      config:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: Config holds the
+                                                          parameters for the authentication
+                                                          plugin.
+                                                        type: object
+                                                      name:
+                                                        description: Name is the name
+                                                          of the authentication plugin.
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  exec:
+                                                    description: Exec specifies a custom
+                                                      exec-based authentication plugin
+                                                      for the kubernetes cluster.
+                                                    properties:
+                                                      apiVersion:
+                                                        description: |-
+                                                          Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                          the same encoding version as the input.
+                                                          Defaults to client.authentication.k8s.io/v1 if not set.
+                                                        type: string
+                                                      args:
+                                                        description: Arguments to pass
+                                                          to the command when executing
+                                                          it.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      command:
+                                                        description: Command to execute.
+                                                        type: string
+                                                      env:
+                                                        description: |-
+                                                          Env defines additional environment variables to expose to the process. These
+                                                          are unioned with the host's environment, as well as variables client-go uses
+                                                          to pass argument to the plugin.
+                                                        items:
+                                                          description: |-
+                                                            KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                            credential plugin.
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      provideClusterInfo:
+                                                        description: |-
+                                                          ProvideClusterInfo determines whether or not to provide cluster information,
+                                                          which could potentially contain very large CA data, to this exec plugin as a
+                                                          part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                          to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                          reading this environment variable.
+                                                        type: boolean
+                                                    required:
+                                                    - command
+                                                    type: object
+                                                type: object
+                                            required:
+                                            - user
+                                            type: object
+                                          kubeConfigPath:
+                                            description: KubeConfigPath is used to specify
+                                              the actual file path or URL to the kubeconfig
+                                              file from which to load cluster information
+                                            type: string
+                                        required:
+                                        - kubeConfigPath
+                                        type: object
+                                      timeout:
+                                        description: Timeout modifies the discovery timeout
+                                        type: string
+                                      tlsBootstrapToken:
+                                        description: |-
+                                          TLSBootstrapToken is a token used for TLS bootstrapping.
+                                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                        type: string
+                                    type: object
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      imagePullPolicy:
+                                        description: |-
+                                          ImagePullPolicy specifies the policy for image pulling
+                                          during kubeadm "init" and "join" operations. The value of
+                                          this field must be one of "Always", "IfNotPresent" or
+                                          "Never". Defaults to "IfNotPresent". This can be used only
+                                          with Kubernetes version equal to 1.22 and later.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        - Never
+                                        type: string
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                  patches:
+                                    description: |-
+                                      Patches contains options related to applying patches to components deployed by kubeadm during
+                                      "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                                    properties:
+                                      directory:
+                                        description: |-
+                                          Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                          "suffix" is an optional string that can be used to determine which patches are applied
+                                          first alpha-numerically.
+                                          These files can be written into the target directory via KubeadmConfig.Files which
+                                          specifies additional files to be created on the machine, either with content inline or
+                                          by referencing a secret.
+                                        type: string
+                                    type: object
+                                  skipPhases:
+                                    description: |-
+                                      SkipPhases is a list of phases to skip during command execution.
+                                      The list of phases can be obtained with the "kubeadm init --help" command.
+                                      This option takes effect only on Kubernetes >=1.22.0.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              mounts:
+                                description: Mounts specifies a list of mount points to
+                                  be setup.
+                                items:
+                                  description: MountPoints defines input for generated
+                                    mounts in cloud-init.
+                                  items:
+                                    type: string
+                                  type: array
+                                type: array
+                              ntp:
+                                description: NTP specifies NTP configuration
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether NTP should
+                                      be enabled
+                                    type: boolean
+                                  servers:
+                                    description: Servers specifies which NTP servers to
+                                      use
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              postKubeadmCommands:
+                                description: PostKubeadmCommands specifies extra commands
+                                  to run after kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              preKubeadmCommands:
+                                description: PreKubeadmCommands specifies extra commands
+                                  to run before kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              useExperimentalRetryJoin:
+                                description: |-
+                                  UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                                  script with retries for joins.
+
+
+                                  This is meant to be an experimental temporary workaround on some environments
+                                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                                  kubeadm proper and use that functionality.
+
+
+                                  This will add about 40KB to userdata
+
+
+                                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                                  Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                                  When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                                type: boolean
+                              users:
+                                description: Users specifies extra users to add
+                                items:
+                                  description: User defines the input for a generated
+                                    user in cloud-init.
+                                  properties:
+                                    gecos:
+                                      description: Gecos specifies the gecos to use for
+                                        the user
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the additional groups
+                                        for the user
+                                      type: string
+                                    homeDir:
+                                      description: HomeDir specifies the home directory
+                                        to use for the user
+                                      type: string
+                                    inactive:
+                                      description: Inactive specifies whether to mark
+                                        the user as inactive
+                                      type: boolean
+                                    lockPassword:
+                                      description: LockPassword specifies if password
+                                        login should be disabled
+                                      type: boolean
+                                    name:
+                                      description: Name specifies the user name
+                                      type: string
+                                    passwd:
+                                      description: Passwd specifies a hashed password
+                                        for the user
+                                      type: string
+                                    passwdFrom:
+                                      description: PasswdFrom is a referenced source of
+                                        passwd to populate the passwd.
+                                      properties:
+                                        secret:
+                                          description: Secret represents a secret that
+                                            should populate this password.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret's
+                                                data map for this value.
+                                              type: string
+                                            name:
+                                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                                namespace to use.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                      required:
+                                      - secret
+                                      type: object
+                                    primaryGroup:
+                                      description: PrimaryGroup specifies the primary
+                                        group for the user
+                                      type: string
+                                    shell:
+                                      description: Shell specifies the user's shell
+                                      type: string
+                                    sshAuthorizedKeys:
+                                      description: SSHAuthorizedKeys specifies a list
+                                        of ssh authorized keys for the user
+                                      items:
+                                        type: string
+                                      type: array
+                                    sudo:
+                                      description: Sudo specifies a sudo role for the
+                                        user
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              verbosity:
+                                description: |-
+                                  Verbosity is the number for the kubeadm log level verbosity.
+                                  It overrides the `--v` flag in kubeadm commands.
+                                format: int32
+                                type: integer
+                            type: object
+                          machineTemplate:
+                            description: |-
+                              MachineTemplate contains information about how machines
+                              should be shaped when creating or updating a control plane.
+                            properties:
+                              metadata:
+                                description: |-
+                                  Standard object's metadata.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata. They are not
+                                      queryable and should be preserved when modifying objects.
+                                      More info: http://kubernetes.io/docs/user-guide/annotations
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects. May match selectors of replication controllers
+                                      and services.
+                                      More info: http://kubernetes.io/docs/user-guide/labels
+                                    type: object
+                                type: object
+                              nodeDeletionTimeout:
+                                description: |-
+                                  NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                                  hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                  If no value is provided, the default value for this property of the Machine resource will be used.
+                                type: string
+                              nodeDrainTimeout:
+                                description: |-
+                                  NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                                  The default value is 0, meaning that the node can be drained without any time limitations.
+                                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                                type: string
+                              nodeVolumeDetachTimeout:
+                                description: |-
+                                  NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                  to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                                type: string
+                            type: object
+                          remediationStrategy:
+                            description: The RemediationStrategy that controls how control
+                              plane machine remediation happens.
+                            properties:
+                              maxRetry:
+                                description: "MaxRetry is the Max number of retries while
+                                  attempting to remediate an unhealthy machine.\nA retry
+                                  happens when a machine that was created as a replacement
+                                  for an unhealthy machine also fails.\nFor example, given
+                                  a control plane with three machines M1, M2, M3:\n\n\n\tM1
+                                  become unhealthy; remediation happens, and M1-1 is created
+                                  as a replacement.\n\tIf M1-1 (replacement of M1) has
+                                  problems while bootstrapping it will become unhealthy,
+                                  and then be\n\tremediated; such operation is considered
+                                  a retry, remediation-retry #1.\n\tIf M1-2 (replacement
+                                  of M1-1) becomes unhealthy, remediation-retry #2 will
+                                  happen, etc.\n\n\nA retry could happen only after RetryPeriod
+                                  from the previous retry.\nIf a machine is marked as
+                                  unhealthy after MinHealthyPeriod from the previous remediation
+                                  expired,\nthis is not considered a retry anymore because
+                                  the new issue is assumed unrelated from the previous
+                                  one.\n\n\nIf not set, the remedation will be retried
+                                  infinitely."
+                                format: int32
+                                type: integer
+                              minHealthyPeriod:
+                                description: "MinHealthyPeriod defines the duration after
+                                  which KCP will consider any failure to a machine unrelated\nfrom
+                                  the previous one. In this case the remediation is not
+                                  considered a retry anymore, and thus the retry\ncounter
+                                  restarts from 0. For example, assuming MinHealthyPeriod
+                                  is set to 1h (default)\n\n\n\tM1 become unhealthy; remediation
+                                  happens, and M1-1 is created as a replacement.\n\tIf
+                                  M1-1 (replacement of M1) has problems within the 1hr
+                                  after the creation, also\n\tthis machine will be remediated
+                                  and this operation is considered a retry - a problem
+                                  related\n\tto the original issue happened to M1 -.\n\n\n\tIf
+                                  instead the problem on M1-1 is happening after MinHealthyPeriod
+                                  expired, e.g. four days after\n\tm1-1 has been created
+                                  as a remediation of M1, the problem on M1-1 is considered
+                                  unrelated to\n\tthe original issue happened to M1.\n\n\nIf
+                                  not set, this value is defaulted to 1h."
+                                type: string
+                              retryPeriod:
+                                description: |-
+                                  RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                                  for an unhealthy machine (a retry).
+
+
+                                  If not set, a retry will happen immediately.
+                                type: string
+                            type: object
+                          rolloutAfter:
+                            description: |-
+                              RolloutAfter is a field to indicate a rollout should be performed
+                              after the specified time even if no changes have been made to the
+                              KubeadmControlPlane.
+                            format: date-time
+                            type: string
+                          rolloutBefore:
+                            description: |-
+                              RolloutBefore is a field to indicate a rollout should be performed
+                              if the specified criteria is met.
+                            properties:
+                              certificatesExpiryDays:
+                                description: |-
+                                  CertificatesExpiryDays indicates a rollout needs to be performed if the
+                                  certificates of the machine will expire within the specified days.
+                                format: int32
+                                type: integer
+                            type: object
+                          rolloutStrategy:
+                            default:
+                              rollingUpdate:
+                                maxSurge: 1
+                              type: RollingUpdate
+                            description: |-
+                              The RolloutStrategy to use to replace control plane machines with
+                              new ones.
+                            properties:
+                              rollingUpdate:
+                                description: |-
+                                  Rolling update config params. Present only if
+                                  RolloutStrategyType = RollingUpdate.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of control planes that can be scheduled above or under the
+                                      desired number of control planes.
+                                      Value can be an absolute number 1 or 0.
+                                      Defaults to 1.
+                                      Example: when this is set to 1, the control plane can be scaled
+                                      up immediately when the rolling update starts.
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  Type of rollout. Currently the only supported strategy is
+                                  "RollingUpdate".
+                                  Default is RollingUpdate.
+                                type: string
+                            type: object
+                        required:
+                        - kubeadmConfigSpec
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources: {}
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-manager
+      namespace: capi-kubeadm-control-plane-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-leader-election-role
+      namespace: capi-kubeadm-control-plane-system
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-aggregated-manager-role
+    rules: []
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+      name: capi-kubeadm-control-plane-manager-role
+    rules:
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - bootstrap.cluster.x-k8s.io
+      - controlplane.cluster.x-k8s.io
+      - infrastructure.cluster.x-k8s.io
+      resources:
+      - '*'
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - clusters
+      - clusters/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - machinepools
+      verbs:
+      - list
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - machines
+      - machines/status
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-leader-election-rolebinding
+      namespace: capi-kubeadm-control-plane-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: capi-kubeadm-control-plane-leader-election-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-control-plane-manager
+      namespace: capi-kubeadm-control-plane-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: capi-kubeadm-control-plane-aggregated-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-control-plane-manager
+      namespace: capi-kubeadm-control-plane-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      ports:
+      - port: 443
+        targetPort: webhook-server
+      selector:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        control-plane: controller-manager
+      name: capi-kubeadm-control-plane-controller-manager
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          cluster.x-k8s.io/provider: control-plane-kubeadm
+          control-plane: controller-manager
+      template:
+        metadata:
+          labels:
+            cluster.x-k8s.io/provider: control-plane-kubeadm
+            control-plane: controller-manager
+        spec:
+          containers:
+          - args:
+            - --leader-elect
+            - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+            - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+            - --use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}
+            - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+            command:
+            - /manager
+            env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.7
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              runAsGroup: 65532
+              runAsUser: 65532
+            volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: capi-kubeadm-control-plane-manager
+          terminationGracePeriodSeconds: 10
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+          volumes:
+          - name: cert
+            secret:
+              secretName: capi-kubeadm-control-plane-webhook-service-cert
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-serving-cert
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      dnsNames:
+      - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc
+      - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc.cluster.local
+      issuerRef:
+        kind: Issuer
+        name: capi-kubeadm-control-plane-selfsigned-issuer
+      secretName: capi-kubeadm-control-plane-webhook-service-cert
+      subject:
+        organizations:
+        - k8s-sig-cluster-lifecycle
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-selfsigned-issuer
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      selfSigned: {}
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-mutating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanes
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+      failurePolicy: Fail
+      name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanetemplates
+      sideEffects: None
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-validating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /validate-scale-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation-scale.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanes/scale
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanes
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+      failurePolicy: Fail
+      name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanetemplates
+      sideEffects: None
+  metadata: |
+    # maps release series of major.minor to cluster-api contract version
+    # the contract version may change between minor or major versions, but *not*
+    # between patch versions.
+    #
+    # update this file only when a new major or minor version is released
+    apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+    kind: Metadata
+    releaseSeries:
+      - major: 1
+        minor: 7
+        contract: v1beta1
+      - major: 1
+        minor: 6
+        contract: v1beta1
+      - major: 1
+        minor: 5
+        contract: v1beta1
+      - major: 1
+        minor: 4
+        contract: v1beta1
+      - major: 1
+        minor: 3
+        contract: v1beta1
+      - major: 1
+        minor: 2
+        contract: v1beta1
+      - major: 1
+        minor: 1
+        contract: v1beta1
+      - major: 1
+        minor: 0
+        contract: v1beta1
+kind: ConfigMap
+metadata:
+  labels:
+    provider.cluster.x-k8s.io/name: kubeadm
+    provider.cluster.x-k8s.io/type: controlplane
+    provider.cluster.x-k8s.io/version: v1.7.7
+  name: controlplane-kubeadm-v1.7.7
+  namespace: capi-kubeadm-control-plane-system

--- a/test/e2e/resources/controlplane-kubeadm-v1.8.0.yaml
+++ b/test/e2e/resources/controlplane-kubeadm-v1.8.0.yaml
@@ -1,0 +1,8265 @@
+apiVersion: v1
+data:
+  components: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+        controller-gen.kubebuilder.io/version: v0.15.0
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-control-plane-webhook-service
+              namespace: capi-kubeadm-control-plane-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: controlplane.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmControlPlane
+        listKind: KubeadmControlPlaneList
+        plural: kubeadmcontrolplanes
+        shortNames:
+        - kcp
+        singular: kubeadmcontrolplane
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: This denotes whether or not the control plane has the uploaded
+            kubeadm-config configmap
+          jsonPath: .status.initialized
+          name: Initialized
+          type: boolean
+        - description: KubeadmControlPlane API Server is ready to receive requests
+          jsonPath: .status.ready
+          name: API Server Available
+          type: boolean
+        - description: Kubernetes version associated with this control plane
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        - description: Total number of non-terminated machines targeted by this control
+            plane
+          jsonPath: .status.replicas
+          name: Replicas
+          type: integer
+        - description: Total number of fully running and ready control plane machines
+          jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane that have the desired template spec
+          jsonPath: .status.updatedReplicas
+          name: Updated
+          type: integer
+        - description: Total number of unavailable machines targeted by this control plane
+          jsonPath: .status.unavailableReplicas
+          name: Unavailable
+          type: integer
+        deprecated: true
+        name: v1alpha3
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                properties:
+                  infrastructureTemplate:
+                    description: |-
+                      InfrastructureTemplate is a required reference to a custom resource
+                      offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                          TODO: this design is not final and this field is subject to change in the future.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  kubeadmConfigSpec:
+                    description: |-
+                      KubeadmConfigSpec is a KubeadmConfigSpec
+                      to use for initializing and joining machines to the control plane.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API
+                              server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names
+                                  for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              CertificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for
+                              the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed
+                              in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              type:
+                                description: Type defines the DNS add-on to be used
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              Etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  External describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      CertFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for
+                                      ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      KeyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  Local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      DataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative
+                                      Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                              `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+                              will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              KubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              Networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services.
+                                  Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  ServiceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler
+                              control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          useHyperKubeImage:
+                            description: UseHyperKubeImage controls if hyperkube should
+                              be used for Kubernetes components instead of their respective
+                              separate images
+                            type: boolean
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition
+                          tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add
+                                    to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to
+                                    be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    Overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use.
+                                    The valid options are: "auto|any", "auto", "any",
+                                    "none", and <NUM>, where NUM is the actual partition
+                                    number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    Layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    TableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file
+                                contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign
+                                to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token,
+                                stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    Description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    Expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    Groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    Token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    TTL defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    Usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for
+                          the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              CACertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                          controlPlane:
+                            description: |-
+                              ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - advertiseAddress
+                                - bindPort
+                                type: object
+                            type: object
+                          discovery:
+                            description: |-
+                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                              TODO: revisit when there is defaulting from k/k
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  BootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      CACertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      Token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      UnsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                - unsafeSkipCAVerification
+                                type: object
+                              file:
+                                description: |-
+                                  File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the
+                                      actual file path or URL to the kubeconfig file from
+                                      which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  TLSBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                  TODO: revisit when there is defaulting from k/k
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run
+                          after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run
+                          before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+
+                          This will add about 40KB to userdata
+
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in
+                            cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for
+                                the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use
+                                for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user
+                                as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should
+                                be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the
+                                user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for
+                                the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized
+                                keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          Verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeDrainTimeout:
+                    description: |-
+                      NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                    type: string
+                  replicas:
+                    description: |-
+                      Number of desired machines. Defaults to 1. When stacked etcd is used only
+                      odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                      This is a pointer to distinguish between explicit zero and not specified.
+                    format: int32
+                    type: integer
+                  rolloutStrategy:
+                    description: |-
+                      The RolloutStrategy to use to replace control plane machines with
+                      new ones.
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if
+                          RolloutStrategyType = RollingUpdate.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of control planes that can be scheduled above or under the
+                              desired number of control planes.
+                              Value can be an absolute number 1 or 0.
+                              Defaults to 1.
+                              Example: when this is set to 1, the control plane can be scaled
+                              up immediately when the rolling update starts.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: |-
+                          Type of rollout. Currently the only supported strategy is
+                          "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
+                  upgradeAfter:
+                    description: |-
+                      UpgradeAfter is a field to indicate an upgrade should be performed
+                      after the specified time even if no changes have been made to the
+                      KubeadmControlPlane
+                    format: date-time
+                    type: string
+                  version:
+                    description: Version defines the desired Kubernetes version.
+                    type: string
+                required:
+                - infrastructureTemplate
+                - kubeadmConfigSpec
+                - version
+                type: object
+              status:
+                description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmControlPlane.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  failureMessage:
+                    description: |-
+                      ErrorMessage indicates that there is a terminal problem reconciling the
+                      state, and will be set to a descriptive error message.
+                    type: string
+                  failureReason:
+                    description: |-
+                      FailureReason indicates that there is a terminal problem reconciling the
+                      state, and will be set to a token value suitable for
+                      programmatic interpretation.
+                    type: string
+                  initialized:
+                    description: |-
+                      Initialized denotes whether or not the control plane has the
+                      uploaded kubeadm-config configmap.
+                    type: boolean
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: |-
+                      Ready denotes that the KubeadmControlPlane API Server is ready to
+                      receive requests.
+                    type: boolean
+                  readyReplicas:
+                    description: Total number of fully running and ready control plane
+                      machines.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      (their labels match the selector).
+                    format: int32
+                    type: integer
+                  selector:
+                    description: |-
+                      Selector is the label selector in string format to avoid introspection
+                      by clients, and is used to provide the CRD-based integration for the
+                      scale subresource and additional integrations for things like kubectl
+                      describe.. The string will be in the same format as the query-param syntax.
+                      More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable machines targeted by this control plane.
+                      This is the total number of machines that are still required for
+                      the deployment to have 100% available capacity. They may either
+                      be machines that are running but not yet ready or machines
+                      that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          scale:
+            labelSelectorPath: .status.selector
+            specReplicasPath: .spec.replicas
+            statusReplicasPath: .status.replicas
+          status: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmControlPlane
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: This denotes whether or not the control plane has the uploaded
+            kubeadm-config configmap
+          jsonPath: .status.initialized
+          name: Initialized
+          type: boolean
+        - description: KubeadmControlPlane API Server is ready to receive requests
+          jsonPath: .status.ready
+          name: API Server Available
+          type: boolean
+        - description: Kubernetes version associated with this control plane
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        - description: Total number of non-terminated machines targeted by this control
+            plane
+          jsonPath: .status.replicas
+          name: Replicas
+          type: integer
+        - description: Total number of fully running and ready control plane machines
+          jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane that have the desired template spec
+          jsonPath: .status.updatedReplicas
+          name: Updated
+          type: integer
+        - description: Total number of unavailable machines targeted by this control plane
+          jsonPath: .status.unavailableReplicas
+          name: Unavailable
+          type: integer
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                properties:
+                  kubeadmConfigSpec:
+                    description: |-
+                      KubeadmConfigSpec is a KubeadmConfigSpec
+                      to use for initializing and joining machines to the control plane.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API
+                              server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names
+                                  for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              CertificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for
+                              the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed
+                              in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              Etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  External describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      CertFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for
+                                      ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      KeyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  Local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      DataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative
+                                      Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                              `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                              will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              KubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              Networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services.
+                                  Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  ServiceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler
+                              control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition
+                          tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add
+                                    to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to
+                                    be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    Overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use.
+                                    The valid options are: "auto|any", "auto", "any",
+                                    "none", and <NUM>, where NUM is the actual partition
+                                    number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    Layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    TableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file
+                                contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign
+                                to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token,
+                                stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    Description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    Expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    Groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    Token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    TTL defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    Usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for
+                          the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              CACertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                          controlPlane:
+                            description: |-
+                              ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: |-
+                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                              TODO: revisit when there is defaulting from k/k
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  BootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      CACertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      Token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      UnsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: |-
+                                  File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the
+                                      actual file path or URL to the kubeconfig file from
+                                      which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  TLSBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run
+                          after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run
+                          before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+
+                          This will add about 40KB to userdata
+
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in
+                            cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for
+                                the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use
+                                for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user
+                                as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should
+                                be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the
+                                user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for
+                                the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized
+                                keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          Verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                  machineTemplate:
+                    description: |-
+                      MachineTemplate contains information about how machines
+                      should be shaped when creating or updating a control plane.
+                    properties:
+                      infrastructureRef:
+                        description: |-
+                          InfrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                              TODO: this design is not final and this field is subject to change in the future.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      nodeDrainTimeout:
+                        description: |-
+                          NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                    required:
+                    - infrastructureRef
+                    type: object
+                  replicas:
+                    description: |-
+                      Number of desired machines. Defaults to 1. When stacked etcd is used only
+                      odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                      This is a pointer to distinguish between explicit zero and not specified.
+                    format: int32
+                    type: integer
+                  rolloutAfter:
+                    description: |-
+                      RolloutAfter is a field to indicate a rollout should be performed
+                      after the specified time even if no changes have been made to the
+                      KubeadmControlPlane.
+                    format: date-time
+                    type: string
+                  rolloutStrategy:
+                    default:
+                      rollingUpdate:
+                        maxSurge: 1
+                      type: RollingUpdate
+                    description: |-
+                      The RolloutStrategy to use to replace control plane machines with
+                      new ones.
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if
+                          RolloutStrategyType = RollingUpdate.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of control planes that can be scheduled above or under the
+                              desired number of control planes.
+                              Value can be an absolute number 1 or 0.
+                              Defaults to 1.
+                              Example: when this is set to 1, the control plane can be scaled
+                              up immediately when the rolling update starts.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: |-
+                          Type of rollout. Currently the only supported strategy is
+                          "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
+                  version:
+                    description: Version defines the desired Kubernetes version.
+                    type: string
+                required:
+                - kubeadmConfigSpec
+                - machineTemplate
+                - version
+                type: object
+              status:
+                description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmControlPlane.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  failureMessage:
+                    description: |-
+                      ErrorMessage indicates that there is a terminal problem reconciling the
+                      state, and will be set to a descriptive error message.
+                    type: string
+                  failureReason:
+                    description: |-
+                      FailureReason indicates that there is a terminal problem reconciling the
+                      state, and will be set to a token value suitable for
+                      programmatic interpretation.
+                    type: string
+                  initialized:
+                    description: |-
+                      Initialized denotes whether or not the control plane has the
+                      uploaded kubeadm-config configmap.
+                    type: boolean
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: |-
+                      Ready denotes that the KubeadmControlPlane API Server is ready to
+                      receive requests.
+                    type: boolean
+                  readyReplicas:
+                    description: Total number of fully running and ready control plane
+                      machines.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      (their labels match the selector).
+                    format: int32
+                    type: integer
+                  selector:
+                    description: |-
+                      Selector is the label selector in string format to avoid introspection
+                      by clients, and is used to provide the CRD-based integration for the
+                      scale subresource and additional integrations for things like kubectl
+                      describe.. The string will be in the same format as the query-param syntax.
+                      More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable machines targeted by this control plane.
+                      This is the total number of machines that are still required for
+                      the deployment to have 100% available capacity. They may either
+                      be machines that are running but not yet ready or machines
+                      that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      that have the desired template spec.
+                    format: int32
+                    type: integer
+                  version:
+                    description: |-
+                      Version represents the minimum Kubernetes version for the control plane machines
+                      in the cluster.
+                    type: string
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources:
+          scale:
+            labelSelectorPath: .status.selector
+            specReplicasPath: .spec.replicas
+            statusReplicasPath: .status.replicas
+          status: {}
+      - additionalPrinterColumns:
+        - description: Cluster
+          jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+          name: Cluster
+          type: string
+        - description: This denotes whether or not the control plane has the uploaded
+            kubeadm-config configmap
+          jsonPath: .status.initialized
+          name: Initialized
+          type: boolean
+        - description: KubeadmControlPlane API Server is ready to receive requests
+          jsonPath: .status.ready
+          name: API Server Available
+          type: boolean
+        - description: Total number of machines desired by this control plane
+          jsonPath: .spec.replicas
+          name: Desired
+          priority: 10
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane
+          jsonPath: .status.replicas
+          name: Replicas
+          type: integer
+        - description: Total number of fully running and ready control plane machines
+          jsonPath: .status.readyReplicas
+          name: Ready
+          type: integer
+        - description: Total number of non-terminated machines targeted by this control
+            plane that have the desired template spec
+          jsonPath: .status.updatedReplicas
+          name: Updated
+          type: integer
+        - description: Total number of unavailable machines targeted by this control plane
+          jsonPath: .status.unavailableReplicas
+          name: Unavailable
+          type: integer
+        - description: Time duration since creation of KubeadmControlPlane
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Kubernetes version associated with this control plane
+          jsonPath: .spec.version
+          name: Version
+          type: string
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
+              API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                properties:
+                  kubeadmConfigSpec:
+                    description: |-
+                      KubeadmConfigSpec is a KubeadmConfigSpec
+                      to use for initializing and joining machines to the control plane.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API
+                              server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names
+                                  for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must
+                                        be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath
+                                                is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for
+                                                volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults to
+                                                "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the
+                                            pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select
+                                                from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              CertificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for
+                              the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must
+                                        be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath
+                                                is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for
+                                                volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults to
+                                                "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the
+                                            pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select
+                                                from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed
+                              in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              Etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  External describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      CertFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for
+                                      ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      KeyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  Local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      DataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      ExtraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment variable
+                                        present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment variable's
+                                            value. Cannot be used if value is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the
+                                                    FieldPath is written in terms of,
+                                                    defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select
+                                                    in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format
+                                                    of the exposed resources, defaults
+                                                    to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to
+                                                    select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret in
+                                                the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret to
+                                                    select from.  Must be a valid secret
+                                                    key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret
+                                                    or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      ImageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative
+                                      Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              ImageRepository sets the container registry to pull images from.
+                              * If not set, the default registry of kubeadm will be used, i.e.
+                                * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                * k8s.gcr.io (old registry): all older versions
+                                Please note that when imageRepository is not set we don't allow upgrades to
+                                versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                              * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                               `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              KubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            type: string
+                          networking:
+                            description: |-
+                              Networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services.
+                                  Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  ServiceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler
+                              control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ExtraArgs is an extra set of flags to pass to the control plane component.
+                                  TODO: This is temporary and ideally we would like to switch all components to
+                                  use ComponentConfig + ConfigMaps.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must
+                                        be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath
+                                                is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for
+                                                volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults to
+                                                "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the
+                                            pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select
+                                                from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes,
+                                  mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        HostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod
+                                        where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the
+                                        volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition
+                          tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add
+                                    to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to
+                                    be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    Overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use.
+                                    The valid options are: "auto|any", "auto", "any",
+                                    "none", and <NUM>, where NUM is the actual partition
+                                    number.'
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    Layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    TableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            append:
+                              description: Append specifies whether to append Content
+                                to existing file if Path exists.
+                              type: boolean
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file
+                                contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign
+                                to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        - ignition
+                        type: string
+                      ignition:
+                        description: Ignition contains Ignition specific configuration.
+                        properties:
+                          containerLinuxConfig:
+                            description: ContainerLinuxConfig contains CLC specific configuration.
+                            properties:
+                              additionalConfig:
+                                description: |-
+                                  AdditionalConfig contains additional configuration to be merged with the Ignition
+                                  configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                                  The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                type: string
+                              strict:
+                                description: Strict controls if AdditionalConfig should
+                                  be strictly parsed. If so, warnings are treated as errors.
+                                type: boolean
+                            type: object
+                        type: object
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token,
+                                stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    Description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: |-
+                                    Expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    Groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: |-
+                                    Token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    TTL defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    Usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for
+                                  the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: |-
+                                  BindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              imagePullSerial:
+                                description: |-
+                                  ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                  Default: true (defaulted in kubeadm)
+                                type: boolean
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              Patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              SkipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for
+                          the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              CACertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                              TODO: revisit when there is defaulting from k/k
+                            type: string
+                          controlPlane:
+                            description: |-
+                              ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      BindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: |-
+                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                              TODO: revisit when there is defaulting from k/k
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  BootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain
+                                      name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      CACertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: |-
+                                      Token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      UnsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: |-
+                                  File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfig:
+                                    description: |-
+                                      KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                      The file is generated at the path specified in KubeConfigPath.
+
+
+                                      Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                      Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                    properties:
+                                      cluster:
+                                        description: |-
+                                          Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                          By default the following fields are automatically populated:
+                                          - Server with the Cluster's ControlPlaneEndpoint.
+                                          - CertificateAuthorityData with the Cluster's CA certificate.
+                                        properties:
+                                          certificateAuthorityData:
+                                            description: |-
+                                              CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                              Defaults to the Cluster's CA certificate if empty.
+                                            format: byte
+                                            type: string
+                                          insecureSkipTLSVerify:
+                                            description: InsecureSkipTLSVerify skips the
+                                              validity check for the server's certificate.
+                                              This will make your HTTPS connections insecure.
+                                            type: boolean
+                                          proxyURL:
+                                            description: |-
+                                              ProxyURL is the URL to the proxy to be used for all requests made by this
+                                              client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                              this configuration is not provided or the empty string, the client
+                                              attempts to construct a proxy configuration from http_proxy and
+                                              https_proxy environment variables. If these environment variables are not
+                                              set, the client does not attempt to proxy requests.
+
+
+                                              socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                              attach, port forward).
+                                            type: string
+                                          server:
+                                            description: |-
+                                              Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                              Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                            type: string
+                                          tlsServerName:
+                                            description: TLSServerName is used to check
+                                              server certificate. If TLSServerName is
+                                              empty, the hostname used to contact the
+                                              server is used.
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: |-
+                                          User contains information that describes identity information.
+                                          This is used to tell the kubernetes cluster who you are.
+                                        properties:
+                                          authProvider:
+                                            description: AuthProvider specifies a custom
+                                              authentication plugin for the kubernetes
+                                              cluster.
+                                            properties:
+                                              config:
+                                                additionalProperties:
+                                                  type: string
+                                                description: Config holds the parameters
+                                                  for the authentication plugin.
+                                                type: object
+                                              name:
+                                                description: Name is the name of the authentication
+                                                  plugin.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          exec:
+                                            description: Exec specifies a custom exec-based
+                                              authentication plugin for the kubernetes
+                                              cluster.
+                                            properties:
+                                              apiVersion:
+                                                description: |-
+                                                  Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                  the same encoding version as the input.
+                                                  Defaults to client.authentication.k8s.io/v1 if not set.
+                                                type: string
+                                              args:
+                                                description: Arguments to pass to the
+                                                  command when executing it.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              command:
+                                                description: Command to execute.
+                                                type: string
+                                              env:
+                                                description: |-
+                                                  Env defines additional environment variables to expose to the process. These
+                                                  are unioned with the host's environment, as well as variables client-go uses
+                                                  to pass argument to the plugin.
+                                                items:
+                                                  description: |-
+                                                    KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                    credential plugin.
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              provideClusterInfo:
+                                                description: |-
+                                                  ProvideClusterInfo determines whether or not to provide cluster information,
+                                                  which could potentially contain very large CA data, to this exec plugin as a
+                                                  part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                  to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                  reading this environment variable.
+                                                type: boolean
+                                            required:
+                                            - command
+                                            type: object
+                                        type: object
+                                    required:
+                                    - user
+                                    type: object
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the
+                                      actual file path or URL to the kubeconfig file from
+                                      which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  TLSBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime
+                                  info. This information will be annotated to the Node
+                                  API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of
+                                  pre-flight errors to be ignored when the current node
+                                  is registered.
+                                items:
+                                  type: string
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  ImagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              imagePullSerial:
+                                description: |-
+                                  ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                  Default: true (defaulted in kubeadm)
+                                type: boolean
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: |-
+                                  Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the
+                                        taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              Patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              SkipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run
+                          after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run
+                          before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+
+                          This will add about 40KB to userdata
+
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                          Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                          When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in
+                            cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for
+                                the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use
+                                for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user
+                                as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should
+                                be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the
+                                user
+                              type: string
+                            passwdFrom:
+                              description: PasswdFrom is a referenced source of passwd
+                                to populate the passwd.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this password.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data
+                                        map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for
+                                the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized
+                                keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: |-
+                          Verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                  machineTemplate:
+                    description: |-
+                      MachineTemplate contains information about how machines
+                      should be shaped when creating or updating a control plane.
+                    properties:
+                      infrastructureRef:
+                        description: |-
+                          InfrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                              TODO: this design is not final and this field is subject to change in the future.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      nodeDeletionTimeout:
+                        description: |-
+                          NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          If no value is provided, the default value for this property of the Machine resource will be used.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                    required:
+                    - infrastructureRef
+                    type: object
+                  remediationStrategy:
+                    description: The RemediationStrategy that controls how control plane
+                      machine remediation happens.
+                    properties:
+                      maxRetry:
+                        description: "MaxRetry is the Max number of retries while attempting
+                          to remediate an unhealthy machine.\nA retry happens when a machine
+                          that was created as a replacement for an unhealthy machine also
+                          fails.\nFor example, given a control plane with three machines
+                          M1, M2, M3:\n\n\n\tM1 become unhealthy; remediation happens,
+                          and M1-1 is created as a replacement.\n\tIf M1-1 (replacement
+                          of M1) has problems while bootstrapping it will become unhealthy,
+                          and then be\n\tremediated; such operation is considered a retry,
+                          remediation-retry #1.\n\tIf M1-2 (replacement of M1-1) becomes
+                          unhealthy, remediation-retry #2 will happen, etc.\n\n\nA retry
+                          could happen only after RetryPeriod from the previous retry.\nIf
+                          a machine is marked as unhealthy after MinHealthyPeriod from
+                          the previous remediation expired,\nthis is not considered a
+                          retry anymore because the new issue is assumed unrelated from
+                          the previous one.\n\n\nIf not set, the remedation will be retried
+                          infinitely."
+                        format: int32
+                        type: integer
+                      minHealthyPeriod:
+                        description: "MinHealthyPeriod defines the duration after which
+                          KCP will consider any failure to a machine unrelated\nfrom the
+                          previous one. In this case the remediation is not considered
+                          a retry anymore, and thus the retry\ncounter restarts from 0.
+                          For example, assuming MinHealthyPeriod is set to 1h (default)\n\n\n\tM1
+                          become unhealthy; remediation happens, and M1-1 is created as
+                          a replacement.\n\tIf M1-1 (replacement of M1) has problems within
+                          the 1hr after the creation, also\n\tthis machine will be remediated
+                          and this operation is considered a retry - a problem related\n\tto
+                          the original issue happened to M1 -.\n\n\n\tIf instead the problem
+                          on M1-1 is happening after MinHealthyPeriod expired, e.g. four
+                          days after\n\tm1-1 has been created as a remediation of M1,
+                          the problem on M1-1 is considered unrelated to\n\tthe original
+                          issue happened to M1.\n\n\nIf not set, this value is defaulted
+                          to 1h."
+                        type: string
+                      retryPeriod:
+                        description: |-
+                          RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                          for an unhealthy machine (a retry).
+
+
+                          If not set, a retry will happen immediately.
+                        type: string
+                    type: object
+                  replicas:
+                    description: |-
+                      Number of desired machines. Defaults to 1. When stacked etcd is used only
+                      odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                      This is a pointer to distinguish between explicit zero and not specified.
+                    format: int32
+                    type: integer
+                  rolloutAfter:
+                    description: |-
+                      RolloutAfter is a field to indicate a rollout should be performed
+                      after the specified time even if no changes have been made to the
+                      KubeadmControlPlane.
+                      Example: In the YAML the time can be specified in the RFC3339 format.
+                      To specify the rolloutAfter target as March 9, 2023, at 9 am UTC
+                      use "2023-03-09T09:00:00Z".
+                    format: date-time
+                    type: string
+                  rolloutBefore:
+                    description: |-
+                      RolloutBefore is a field to indicate a rollout should be performed
+                      if the specified criteria is met.
+                    properties:
+                      certificatesExpiryDays:
+                        description: |-
+                          CertificatesExpiryDays indicates a rollout needs to be performed if the
+                          certificates of the machine will expire within the specified days.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutStrategy:
+                    default:
+                      rollingUpdate:
+                        maxSurge: 1
+                      type: RollingUpdate
+                    description: |-
+                      The RolloutStrategy to use to replace control plane machines with
+                      new ones.
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if
+                          RolloutStrategyType = RollingUpdate.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of control planes that can be scheduled above or under the
+                              desired number of control planes.
+                              Value can be an absolute number 1 or 0.
+                              Defaults to 1.
+                              Example: when this is set to 1, the control plane can be scaled
+                              up immediately when the rolling update starts.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: |-
+                          Type of rollout. Currently the only supported strategy is
+                          "RollingUpdate".
+                          Default is RollingUpdate.
+                        type: string
+                    type: object
+                  version:
+                    description: |-
+                      Version defines the desired Kubernetes version.
+                      Please note that if kubeadmConfigSpec.ClusterConfiguration.imageRepository is not set
+                      we don't allow upgrades to versions >= v1.22.0 for which kubeadm uses the old registry (k8s.gcr.io).
+                      Please use a newer patch version with the new registry instead. The default registries of kubeadm are:
+                        * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                        * k8s.gcr.io (old registry): all older versions
+                    type: string
+                required:
+                - kubeadmConfigSpec
+                - machineTemplate
+                - version
+                type: object
+              status:
+                description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+                properties:
+                  conditions:
+                    description: Conditions defines current service state of the KubeadmControlPlane.
+                    items:
+                      description: Condition defines an observation of a Cluster API resource
+                        operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            Last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed. If that is not known, then using the time when
+                            the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            A human readable message indicating details about the transition.
+                            This field may be empty.
+                          type: string
+                        reason:
+                          description: |-
+                            The reason for the condition's last transition in CamelCase.
+                            The specific API may choose whether or not this field is considered a guaranteed API.
+                            This field may not be empty.
+                          type: string
+                        severity:
+                          description: |-
+                            Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                            understand the current situation and act accordingly.
+                            The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: |-
+                            Type of condition in CamelCase or in foo.example.com/CamelCase.
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  failureMessage:
+                    description: |-
+                      ErrorMessage indicates that there is a terminal problem reconciling the
+                      state, and will be set to a descriptive error message.
+                    type: string
+                  failureReason:
+                    description: |-
+                      FailureReason indicates that there is a terminal problem reconciling the
+                      state, and will be set to a token value suitable for
+                      programmatic interpretation.
+                    type: string
+                  initialized:
+                    description: |-
+                      Initialized denotes whether or not the control plane has the
+                      uploaded kubeadm-config configmap.
+                    type: boolean
+                  lastRemediation:
+                    description: LastRemediation stores info about last remediation performed.
+                    properties:
+                      machine:
+                        description: Machine is the machine name of the latest machine
+                          being remediated.
+                        type: string
+                      retryCount:
+                        description: |-
+                          RetryCount used to keep track of remediation retry for the last remediated machine.
+                          A retry happens when a machine that was created as a replacement for an unhealthy machine also fails.
+                        format: int32
+                        type: integer
+                      timestamp:
+                        description: Timestamp is when last remediation happened. It is
+                          represented in RFC3339 form and is in UTC.
+                        format: date-time
+                        type: string
+                    required:
+                    - machine
+                    - retryCount
+                    - timestamp
+                    type: object
+                  observedGeneration:
+                    description: ObservedGeneration is the latest generation observed
+                      by the controller.
+                    format: int64
+                    type: integer
+                  ready:
+                    description: |-
+                      Ready denotes that the KubeadmControlPlane API Server became ready during initial provisioning
+                      to receive requests.
+                      NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                      The value of this field is never updated after provisioning is completed. Please use conditions
+                      to check the operational state of the control plane.
+                    type: boolean
+                  readyReplicas:
+                    description: Total number of fully running and ready control plane
+                      machines.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      (their labels match the selector).
+                    format: int32
+                    type: integer
+                  selector:
+                    description: |-
+                      Selector is the label selector in string format to avoid introspection
+                      by clients, and is used to provide the CRD-based integration for the
+                      scale subresource and additional integrations for things like kubectl
+                      describe.. The string will be in the same format as the query-param syntax.
+                      More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable machines targeted by this control plane.
+                      This is the total number of machines that are still required for
+                      the deployment to have 100% available capacity. They may either
+                      be machines that are running but not yet ready or machines
+                      that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: |-
+                      Total number of non-terminated machines targeted by this control plane
+                      that have the desired template spec.
+                    format: int32
+                    type: integer
+                  version:
+                    description: |-
+                      Version represents the minimum Kubernetes version for the control plane machines
+                      in the cluster.
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          scale:
+            labelSelectorPath: .status.selector
+            specReplicasPath: .spec.replicas
+            statusReplicasPath: .status.replicas
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+        controller-gen.kubebuilder.io/version: v0.15.0
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        cluster.x-k8s.io/v1beta1: v1beta1
+      name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: capi-kubeadm-control-plane-webhook-service
+              namespace: capi-kubeadm-control-plane-system
+              path: /convert
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: controlplane.cluster.x-k8s.io
+      names:
+        categories:
+        - cluster-api
+        kind: KubeadmControlPlaneTemplate
+        listKind: KubeadmControlPlaneTemplateList
+        plural: kubeadmcontrolplanetemplates
+        singular: kubeadmcontrolplanetemplate
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmControlPlaneTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        deprecated: true
+        name: v1alpha4
+        schema:
+          openAPIV3Schema:
+            description: |-
+              KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
+
+
+              Deprecated: This type will be removed in one of the next releases.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneTemplateSpec defines the desired state
+                  of KubeadmControlPlaneTemplate.
+                properties:
+                  template:
+                    description: KubeadmControlPlaneTemplateResource describes the data
+                      needed to create a KubeadmControlPlane from a template.
+                    properties:
+                      spec:
+                        description: KubeadmControlPlaneSpec defines the desired state
+                          of KubeadmControlPlane.
+                        properties:
+                          kubeadmConfigSpec:
+                            description: |-
+                              KubeadmConfigSpec is a KubeadmConfigSpec
+                              to use for initializing and joining machines to the control plane.
+                            properties:
+                              clusterConfiguration:
+                                description: ClusterConfiguration along with InitConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiServer:
+                                    description: APIServer contains extra settings for
+                                      the API server control plane component
+                                    properties:
+                                      certSANs:
+                                        description: CertSANs sets extra Subject Alternative
+                                          Names for the API Server signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                      timeoutForControlPlane:
+                                        description: TimeoutForControlPlane controls the
+                                          timeout that we use for API server to appear
+                                        type: string
+                                    type: object
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  certificatesDir:
+                                    description: |-
+                                      CertificatesDir specifies where to store or look for all required certificates.
+                                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                    type: string
+                                  clusterName:
+                                    description: The cluster name
+                                    type: string
+                                  controlPlaneEndpoint:
+                                    description: |-
+                                      ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                      the BindPort is used.
+                                      Possible usages are:
+                                      e.g. In a cluster with more than one control plane instances, this field should be
+                                      assigned the address of the external load balancer in front of the
+                                      control plane instances.
+                                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                      could be used for assigning a stable DNS to the control plane.
+                                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                    type: string
+                                  controllerManager:
+                                    description: ControllerManager contains extra settings
+                                      for the controller manager control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                  dns:
+                                    description: DNS defines the options for the DNS add-on
+                                      installed in the cluster.
+                                    properties:
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                    type: object
+                                  etcd:
+                                    description: |-
+                                      Etcd holds configuration for etcd.
+                                      NB: This value defaults to a Local (stacked) etcd
+                                    properties:
+                                      external:
+                                        description: |-
+                                          External describes how to connect to an external etcd cluster
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          caFile:
+                                            description: |-
+                                              CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          certFile:
+                                            description: |-
+                                              CertFile is an SSL certification file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          endpoints:
+                                            description: Endpoints of etcd members. Required
+                                              for ExternalEtcd.
+                                            items:
+                                              type: string
+                                            type: array
+                                          keyFile:
+                                            description: |-
+                                              KeyFile is an SSL key file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                        required:
+                                        - caFile
+                                        - certFile
+                                        - endpoints
+                                        - keyFile
+                                        type: object
+                                      local:
+                                        description: |-
+                                          Local provides configuration knobs for configuring the local etcd instance
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          dataDir:
+                                            description: |-
+                                              DataDir is the directory etcd will place its data.
+                                              Defaults to "/var/lib/etcd".
+                                            type: string
+                                          extraArgs:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              ExtraArgs are extra arguments provided to the etcd binary
+                                              when run inside a static pod.
+                                            type: object
+                                          imageRepository:
+                                            description: |-
+                                              ImageRepository sets the container registry to pull images from.
+                                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                            type: string
+                                          imageTag:
+                                            description: |-
+                                              ImageTag allows to specify a tag for the image.
+                                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                            type: string
+                                          peerCertSANs:
+                                            description: PeerCertSANs sets extra Subject
+                                              Alternative Names for the etcd peer signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                          serverCertSANs:
+                                            description: ServerCertSANs sets extra Subject
+                                              Alternative Names for the etcd server signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                    type: object
+                                  featureGates:
+                                    additionalProperties:
+                                      type: boolean
+                                    description: FeatureGates enabled by the user.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                      `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
+                                      will be used for all the other images.
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  kubernetesVersion:
+                                    description: |-
+                                      KubernetesVersion is the target version of the control plane.
+                                      NB: This value defaults to the Machine object spec.version
+                                    type: string
+                                  networking:
+                                    description: |-
+                                      Networking holds configuration for the networking topology of the cluster.
+                                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                    properties:
+                                      dnsDomain:
+                                        description: DNSDomain is the dns domain used
+                                          by k8s services. Defaults to "cluster.local".
+                                        type: string
+                                      podSubnet:
+                                        description: |-
+                                          PodSubnet is the subnet used by pods.
+                                          If unset, the API server will not allocate CIDR ranges for every node.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                        type: string
+                                      serviceSubnet:
+                                        description: |-
+                                          ServiceSubnet is the subnet used by k8s services.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                          to "10.96.0.0/12" if that's unset.
+                                        type: string
+                                    type: object
+                                  scheduler:
+                                    description: Scheduler contains extra settings for
+                                      the scheduler control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              diskSetup:
+                                description: DiskSetup specifies options for the creation
+                                  of partition tables and file systems on devices.
+                                properties:
+                                  filesystems:
+                                    description: Filesystems specifies the list of file
+                                      systems to setup.
+                                    items:
+                                      description: Filesystem defines the file systems
+                                        to be created.
+                                      properties:
+                                        device:
+                                          description: Device specifies the device name
+                                          type: string
+                                        extraOpts:
+                                          description: ExtraOpts defined extra options
+                                            to add to the command for creating the file
+                                            system.
+                                          items:
+                                            type: string
+                                          type: array
+                                        filesystem:
+                                          description: Filesystem specifies the file system
+                                            type.
+                                          type: string
+                                        label:
+                                          description: Label specifies the file system
+                                            label to be used. If set to None, no label
+                                            is used.
+                                          type: string
+                                        overwrite:
+                                          description: |-
+                                            Overwrite defines whether or not to overwrite any existing filesystem.
+                                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                                          type: boolean
+                                        partition:
+                                          description: 'Partition specifies the partition
+                                            to use. The valid options are: "auto|any",
+                                            "auto", "any", "none", and <NUM>, where NUM
+                                            is the actual partition number.'
+                                          type: string
+                                        replaceFS:
+                                          description: |-
+                                            ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                          type: string
+                                      required:
+                                      - device
+                                      - filesystem
+                                      - label
+                                      type: object
+                                    type: array
+                                  partitions:
+                                    description: Partitions specifies the list of the
+                                      partitions to setup.
+                                    items:
+                                      description: Partition defines how to create and
+                                        layout a partition.
+                                      properties:
+                                        device:
+                                          description: Device is the name of the device.
+                                          type: string
+                                        layout:
+                                          description: |-
+                                            Layout specifies the device layout.
+                                            If it is true, a single partition will be created for the entire device.
+                                            When layout is false, it means don't partition or ignore existing partitioning.
+                                          type: boolean
+                                        overwrite:
+                                          description: |-
+                                            Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                            Use with caution. Default is 'false'.
+                                          type: boolean
+                                        tableType:
+                                          description: |-
+                                            TableType specifies the tupe of partition table. The following are supported:
+                                            'mbr': default and setups a MS-DOS partition table
+                                            'gpt': setups a GPT partition table
+                                          type: string
+                                      required:
+                                      - device
+                                      - layout
+                                      type: object
+                                    type: array
+                                type: object
+                              files:
+                                description: Files specifies extra files to be passed
+                                  to user_data upon creation.
+                                items:
+                                  description: File defines the input for generating write_files
+                                    in cloud-init.
+                                  properties:
+                                    content:
+                                      description: Content is the actual content of the
+                                        file.
+                                      type: string
+                                    contentFrom:
+                                      description: ContentFrom is a referenced source
+                                        of content to populate the file.
+                                      properties:
+                                        secret:
+                                          description: Secret represents a secret that
+                                            should populate this file.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret's
+                                                data map for this value.
+                                              type: string
+                                            name:
+                                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                                namespace to use.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                      required:
+                                      - secret
+                                      type: object
+                                    encoding:
+                                      description: Encoding specifies the encoding of
+                                        the file contents.
+                                      enum:
+                                      - base64
+                                      - gzip
+                                      - gzip+base64
+                                      type: string
+                                    owner:
+                                      description: Owner specifies the ownership of the
+                                        file, e.g. "root:root".
+                                      type: string
+                                    path:
+                                      description: Path specifies the full path on disk
+                                        where to store the file.
+                                      type: string
+                                    permissions:
+                                      description: Permissions specifies the permissions
+                                        to assign to the file, e.g. "0640".
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                              format:
+                                description: Format specifies the output format of the
+                                  bootstrap data
+                                enum:
+                                - cloud-config
+                                type: string
+                              initConfiguration:
+                                description: InitConfiguration along with ClusterConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  bootstrapTokens:
+                                    description: |-
+                                      BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                    items:
+                                      description: BootstrapToken describes one bootstrap
+                                        token, stored as a Secret in the cluster.
+                                      properties:
+                                        description:
+                                          description: |-
+                                            Description sets a human-friendly message why this token exists and what it's used
+                                            for, so other administrators can know its purpose.
+                                          type: string
+                                        expires:
+                                          description: |-
+                                            Expires specifies the timestamp when this token expires. Defaults to being set
+                                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                          format: date-time
+                                          type: string
+                                        groups:
+                                          description: |-
+                                            Groups specifies the extra groups that this token will authenticate as when/if
+                                            used for authentication
+                                          items:
+                                            type: string
+                                          type: array
+                                        token:
+                                          description: |-
+                                            Token is used for establishing bidirectional trust between nodes and control-planes.
+                                            Used for joining nodes in the cluster.
+                                          type: string
+                                        ttl:
+                                          description: |-
+                                            TTL defines the time to live for this token. Defaults to 24h.
+                                            Expires and TTL are mutually exclusive.
+                                          type: string
+                                        usages:
+                                          description: |-
+                                            Usages describes the ways in which this token can be used. Can by default be used
+                                            for establishing bidirectional trust, but that can be changed here.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - token
+                                      type: object
+                                    type: array
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  localAPIEndpoint:
+                                    description: |-
+                                      LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                      fails you may set the desired value here.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              joinConfiguration:
+                                description: JoinConfiguration is the kubeadm configuration
+                                  for the join command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  caCertPath:
+                                    description: |-
+                                      CACertPath is the path to the SSL certificate authority used to
+                                      secure comunications between node and control-plane.
+                                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                                      TODO: revisit when there is defaulting from k/k
+                                    type: string
+                                  controlPlane:
+                                    description: |-
+                                      ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                      If nil, no additional control plane instance will be deployed.
+                                    properties:
+                                      localAPIEndpoint:
+                                        description: LocalAPIEndpoint represents the endpoint
+                                          of the API server instance to be deployed on
+                                          this node.
+                                        properties:
+                                          advertiseAddress:
+                                            description: AdvertiseAddress sets the IP
+                                              address for the API server to advertise.
+                                            type: string
+                                          bindPort:
+                                            description: |-
+                                              BindPort sets the secure port for the API Server to bind to.
+                                              Defaults to 6443.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  discovery:
+                                    description: |-
+                                      Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                      TODO: revisit when there is defaulting from k/k
+                                    properties:
+                                      bootstrapToken:
+                                        description: |-
+                                          BootstrapToken is used to set the options for bootstrap token based discovery
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          apiServerEndpoint:
+                                            description: APIServerEndpoint is an IP or
+                                              domain name to the API server from which
+                                              info will be fetched.
+                                            type: string
+                                          caCertHashes:
+                                            description: |-
+                                              CACertHashes specifies a set of public key pins to verify
+                                              when token-based discovery is used. The root CA found during discovery
+                                              must match one of these values. Specifying an empty set disables root CA
+                                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                              where the only currently supported type is "sha256". This is a hex-encoded
+                                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                            items:
+                                              type: string
+                                            type: array
+                                          token:
+                                            description: |-
+                                              Token is a token used to validate cluster information
+                                              fetched from the control-plane.
+                                            type: string
+                                          unsafeSkipCAVerification:
+                                            description: |-
+                                              UnsafeSkipCAVerification allows token-based discovery
+                                              without CA verification via CACertHashes. This can weaken
+                                              the security of kubeadm since other nodes can impersonate the control-plane.
+                                            type: boolean
+                                        required:
+                                        - token
+                                        type: object
+                                      file:
+                                        description: |-
+                                          File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          kubeConfigPath:
+                                            description: KubeConfigPath is used to specify
+                                              the actual file path or URL to the kubeconfig
+                                              file from which to load cluster information
+                                            type: string
+                                        required:
+                                        - kubeConfigPath
+                                        type: object
+                                      timeout:
+                                        description: Timeout modifies the discovery timeout
+                                        type: string
+                                      tlsBootstrapToken:
+                                        description: |-
+                                          TLSBootstrapToken is a token used for TLS bootstrapping.
+                                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                        type: string
+                                    type: object
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              mounts:
+                                description: Mounts specifies a list of mount points to
+                                  be setup.
+                                items:
+                                  description: MountPoints defines input for generated
+                                    mounts in cloud-init.
+                                  items:
+                                    type: string
+                                  type: array
+                                type: array
+                              ntp:
+                                description: NTP specifies NTP configuration
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether NTP should
+                                      be enabled
+                                    type: boolean
+                                  servers:
+                                    description: Servers specifies which NTP servers to
+                                      use
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              postKubeadmCommands:
+                                description: PostKubeadmCommands specifies extra commands
+                                  to run after kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              preKubeadmCommands:
+                                description: PreKubeadmCommands specifies extra commands
+                                  to run before kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              useExperimentalRetryJoin:
+                                description: |-
+                                  UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                                  script with retries for joins.
+
+
+                                  This is meant to be an experimental temporary workaround on some environments
+                                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                                  kubeadm proper and use that functionality.
+
+
+                                  This will add about 40KB to userdata
+
+
+                                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+                                type: boolean
+                              users:
+                                description: Users specifies extra users to add
+                                items:
+                                  description: User defines the input for a generated
+                                    user in cloud-init.
+                                  properties:
+                                    gecos:
+                                      description: Gecos specifies the gecos to use for
+                                        the user
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the additional groups
+                                        for the user
+                                      type: string
+                                    homeDir:
+                                      description: HomeDir specifies the home directory
+                                        to use for the user
+                                      type: string
+                                    inactive:
+                                      description: Inactive specifies whether to mark
+                                        the user as inactive
+                                      type: boolean
+                                    lockPassword:
+                                      description: LockPassword specifies if password
+                                        login should be disabled
+                                      type: boolean
+                                    name:
+                                      description: Name specifies the user name
+                                      type: string
+                                    passwd:
+                                      description: Passwd specifies a hashed password
+                                        for the user
+                                      type: string
+                                    primaryGroup:
+                                      description: PrimaryGroup specifies the primary
+                                        group for the user
+                                      type: string
+                                    shell:
+                                      description: Shell specifies the user's shell
+                                      type: string
+                                    sshAuthorizedKeys:
+                                      description: SSHAuthorizedKeys specifies a list
+                                        of ssh authorized keys for the user
+                                      items:
+                                        type: string
+                                      type: array
+                                    sudo:
+                                      description: Sudo specifies a sudo role for the
+                                        user
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              verbosity:
+                                description: |-
+                                  Verbosity is the number for the kubeadm log level verbosity.
+                                  It overrides the `--v` flag in kubeadm commands.
+                                format: int32
+                                type: integer
+                            type: object
+                          machineTemplate:
+                            description: |-
+                              MachineTemplate contains information about how machines
+                              should be shaped when creating or updating a control plane.
+                            properties:
+                              infrastructureRef:
+                                description: |-
+                                  InfrastructureRef is a required reference to a custom resource
+                                  offered by an infrastructure provider.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: |-
+                                      If referring to a piece of an object instead of an entire object, this string
+                                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                      the event) or if no container name is specified "spec.containers[2]" (container with
+                                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                      referencing a part of an object.
+                                      TODO: this design is not final and this field is subject to change in the future.
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the referent.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                    type: string
+                                  resourceVersion:
+                                    description: |-
+                                      Specific resourceVersion to which this reference is made, if any.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                    type: string
+                                  uid:
+                                    description: |-
+                                      UID of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              metadata:
+                                description: |-
+                                  Standard object's metadata.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata. They are not
+                                      queryable and should be preserved when modifying objects.
+                                      More info: http://kubernetes.io/docs/user-guide/annotations
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects. May match selectors of replication controllers
+                                      and services.
+                                      More info: http://kubernetes.io/docs/user-guide/labels
+                                    type: object
+                                type: object
+                              nodeDrainTimeout:
+                                description: |-
+                                  NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                                  The default value is 0, meaning that the node can be drained without any time limitations.
+                                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                                type: string
+                            required:
+                            - infrastructureRef
+                            type: object
+                          replicas:
+                            description: |-
+                              Number of desired machines. Defaults to 1. When stacked etcd is used only
+                              odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                              This is a pointer to distinguish between explicit zero and not specified.
+                            format: int32
+                            type: integer
+                          rolloutAfter:
+                            description: |-
+                              RolloutAfter is a field to indicate a rollout should be performed
+                              after the specified time even if no changes have been made to the
+                              KubeadmControlPlane.
+                            format: date-time
+                            type: string
+                          rolloutStrategy:
+                            default:
+                              rollingUpdate:
+                                maxSurge: 1
+                              type: RollingUpdate
+                            description: |-
+                              The RolloutStrategy to use to replace control plane machines with
+                              new ones.
+                            properties:
+                              rollingUpdate:
+                                description: |-
+                                  Rolling update config params. Present only if
+                                  RolloutStrategyType = RollingUpdate.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of control planes that can be scheduled above or under the
+                                      desired number of control planes.
+                                      Value can be an absolute number 1 or 0.
+                                      Defaults to 1.
+                                      Example: when this is set to 1, the control plane can be scaled
+                                      up immediately when the rolling update starts.
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  Type of rollout. Currently the only supported strategy is
+                                  "RollingUpdate".
+                                  Default is RollingUpdate.
+                                type: string
+                            type: object
+                          version:
+                            description: Version defines the desired Kubernetes version.
+                            type: string
+                        required:
+                        - kubeadmConfigSpec
+                        - machineTemplate
+                        - version
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: false
+        storage: false
+        subresources: {}
+      - additionalPrinterColumns:
+        - description: Time duration since creation of KubeadmControlPlaneTemplate
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1beta1
+        schema:
+          openAPIV3Schema:
+            description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates
+              API.
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: KubeadmControlPlaneTemplateSpec defines the desired state
+                  of KubeadmControlPlaneTemplate.
+                properties:
+                  template:
+                    description: KubeadmControlPlaneTemplateResource describes the data
+                      needed to create a KubeadmControlPlane from a template.
+                    properties:
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      spec:
+                        description: |-
+                          KubeadmControlPlaneTemplateResourceSpec defines the desired state of KubeadmControlPlane.
+                          NOTE: KubeadmControlPlaneTemplateResourceSpec is similar to KubeadmControlPlaneSpec but
+                          omits Replicas and Version fields. These fields do not make sense on the KubeadmControlPlaneTemplate,
+                          because they are calculated by the Cluster topology reconciler during reconciliation and thus cannot
+                          be configured on the KubeadmControlPlaneTemplate.
+                        properties:
+                          kubeadmConfigSpec:
+                            description: |-
+                              KubeadmConfigSpec is a KubeadmConfigSpec
+                              to use for initializing and joining machines to the control plane.
+                            properties:
+                              clusterConfiguration:
+                                description: ClusterConfiguration along with InitConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiServer:
+                                    description: APIServer contains extra settings for
+                                      the API server control plane component
+                                    properties:
+                                      certSANs:
+                                        description: CertSANs sets extra Subject Alternative
+                                          Names for the API Server signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraEnvs:
+                                        description: |-
+                                          ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment variable.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: |-
+                                                Variable references $(VAR_NAME) are expanded
+                                                using the previously defined environment variables in the container and
+                                                any service environment variables. If a variable cannot be resolved,
+                                                the reference in the input string will be unchanged. Double $$ are reduced
+                                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                Escaped references will never be expanded, regardless of whether the variable
+                                                exists or not.
+                                                Defaults to "".
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if value
+                                                is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        ConfigMap or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: |-
+                                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema
+                                                        the FieldPath is written in terms
+                                                        of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to
+                                                        select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name: required
+                                                        for volumes, optional for env
+                                                        vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret
+                                                    in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret
+                                                        to select from.  Must be a valid
+                                                        secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        Secret or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                      timeoutForControlPlane:
+                                        description: TimeoutForControlPlane controls the
+                                          timeout that we use for API server to appear
+                                        type: string
+                                    type: object
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  certificatesDir:
+                                    description: |-
+                                      CertificatesDir specifies where to store or look for all required certificates.
+                                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                    type: string
+                                  clusterName:
+                                    description: The cluster name
+                                    type: string
+                                  controlPlaneEndpoint:
+                                    description: |-
+                                      ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                      the BindPort is used.
+                                      Possible usages are:
+                                      e.g. In a cluster with more than one control plane instances, this field should be
+                                      assigned the address of the external load balancer in front of the
+                                      control plane instances.
+                                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                      could be used for assigning a stable DNS to the control plane.
+                                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                    type: string
+                                  controllerManager:
+                                    description: ControllerManager contains extra settings
+                                      for the controller manager control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraEnvs:
+                                        description: |-
+                                          ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment variable.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: |-
+                                                Variable references $(VAR_NAME) are expanded
+                                                using the previously defined environment variables in the container and
+                                                any service environment variables. If a variable cannot be resolved,
+                                                the reference in the input string will be unchanged. Double $$ are reduced
+                                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                Escaped references will never be expanded, regardless of whether the variable
+                                                exists or not.
+                                                Defaults to "".
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if value
+                                                is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        ConfigMap or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: |-
+                                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema
+                                                        the FieldPath is written in terms
+                                                        of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to
+                                                        select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name: required
+                                                        for volumes, optional for env
+                                                        vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret
+                                                    in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret
+                                                        to select from.  Must be a valid
+                                                        secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        Secret or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                  dns:
+                                    description: DNS defines the options for the DNS add-on
+                                      installed in the cluster.
+                                    properties:
+                                      imageRepository:
+                                        description: |-
+                                          ImageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          ImageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                    type: object
+                                  etcd:
+                                    description: |-
+                                      Etcd holds configuration for etcd.
+                                      NB: This value defaults to a Local (stacked) etcd
+                                    properties:
+                                      external:
+                                        description: |-
+                                          External describes how to connect to an external etcd cluster
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          caFile:
+                                            description: |-
+                                              CAFile is an SSL Certificate Authority file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          certFile:
+                                            description: |-
+                                              CertFile is an SSL certification file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                          endpoints:
+                                            description: Endpoints of etcd members. Required
+                                              for ExternalEtcd.
+                                            items:
+                                              type: string
+                                            type: array
+                                          keyFile:
+                                            description: |-
+                                              KeyFile is an SSL key file used to secure etcd communication.
+                                              Required if using a TLS connection.
+                                            type: string
+                                        required:
+                                        - caFile
+                                        - certFile
+                                        - endpoints
+                                        - keyFile
+                                        type: object
+                                      local:
+                                        description: |-
+                                          Local provides configuration knobs for configuring the local etcd instance
+                                          Local and External are mutually exclusive
+                                        properties:
+                                          dataDir:
+                                            description: |-
+                                              DataDir is the directory etcd will place its data.
+                                              Defaults to "/var/lib/etcd".
+                                            type: string
+                                          extraArgs:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              ExtraArgs are extra arguments provided to the etcd binary
+                                              when run inside a static pod.
+                                            type: object
+                                          extraEnvs:
+                                            description: |-
+                                              ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                              This option takes effect only on Kubernetes >=1.31.0.
+                                            items:
+                                              description: EnvVar represents an environment
+                                                variable present in a Container.
+                                              properties:
+                                                name:
+                                                  description: Name of the environment
+                                                    variable. Must be a C_IDENTIFIER.
+                                                  type: string
+                                                value:
+                                                  description: |-
+                                                    Variable references $(VAR_NAME) are expanded
+                                                    using the previously defined environment variables in the container and
+                                                    any service environment variables. If a variable cannot be resolved,
+                                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                    Escaped references will never be expanded, regardless of whether the variable
+                                                    exists or not.
+                                                    Defaults to "".
+                                                  type: string
+                                                valueFrom:
+                                                  description: Source for the environment
+                                                    variable's value. Cannot be used if
+                                                    value is not empty.
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      description: Selects a key of a
+                                                        ConfigMap.
+                                                      properties:
+                                                        key:
+                                                          description: The key to select.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the ConfigMap or its key must
+                                                            be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      description: |-
+                                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the
+                                                            schema the FieldPath is written
+                                                            in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field
+                                                            to select in the specified
+                                                            API version.
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name:
+                                                            required for volumes, optional
+                                                            for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          description: Specifies the output
+                                                            format of the exposed resources,
+                                                            defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource
+                                                            to select'
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      description: Selects a key of a
+                                                        secret in the pod's namespace
+                                                      properties:
+                                                        key:
+                                                          description: The key of the
+                                                            secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key must
+                                                            be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          imageRepository:
+                                            description: |-
+                                              ImageRepository sets the container registry to pull images from.
+                                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                            type: string
+                                          imageTag:
+                                            description: |-
+                                              ImageTag allows to specify a tag for the image.
+                                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                            type: string
+                                          peerCertSANs:
+                                            description: PeerCertSANs sets extra Subject
+                                              Alternative Names for the etcd peer signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                          serverCertSANs:
+                                            description: ServerCertSANs sets extra Subject
+                                              Alternative Names for the etcd server signing
+                                              cert.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                    type: object
+                                  featureGates:
+                                    additionalProperties:
+                                      type: boolean
+                                    description: FeatureGates enabled by the user.
+                                    type: object
+                                  imageRepository:
+                                    description: |-
+                                      ImageRepository sets the container registry to pull images from.
+                                      * If not set, the default registry of kubeadm will be used, i.e.
+                                        * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                        * k8s.gcr.io (old registry): all older versions
+                                        Please note that when imageRepository is not set we don't allow upgrades to
+                                        versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                        a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                        >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                                      * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                       `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                        and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  kubernetesVersion:
+                                    description: |-
+                                      KubernetesVersion is the target version of the control plane.
+                                      NB: This value defaults to the Machine object spec.version
+                                    type: string
+                                  networking:
+                                    description: |-
+                                      Networking holds configuration for the networking topology of the cluster.
+                                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                    properties:
+                                      dnsDomain:
+                                        description: DNSDomain is the dns domain used
+                                          by k8s services. Defaults to "cluster.local".
+                                        type: string
+                                      podSubnet:
+                                        description: |-
+                                          PodSubnet is the subnet used by pods.
+                                          If unset, the API server will not allocate CIDR ranges for every node.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                        type: string
+                                      serviceSubnet:
+                                        description: |-
+                                          ServiceSubnet is the subnet used by k8s services.
+                                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                          to "10.96.0.0/12" if that's unset.
+                                        type: string
+                                    type: object
+                                  scheduler:
+                                    description: Scheduler contains extra settings for
+                                      the scheduler control plane component
+                                    properties:
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ExtraArgs is an extra set of flags to pass to the control plane component.
+                                          TODO: This is temporary and ideally we would like to switch all components to
+                                          use ComponentConfig + ConfigMaps.
+                                        type: object
+                                      extraEnvs:
+                                        description: |-
+                                          ExtraEnvs is an extra set of environment variables to pass to the control plane component.
+                                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment variable.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: |-
+                                                Variable references $(VAR_NAME) are expanded
+                                                using the previously defined environment variables in the container and
+                                                any service environment variables. If a variable cannot be resolved,
+                                                the reference in the input string will be unchanged. Double $$ are reduced
+                                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                Escaped references will never be expanded, regardless of whether the variable
+                                                exists or not.
+                                                Defaults to "".
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if value
+                                                is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        ConfigMap or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: |-
+                                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema
+                                                        the FieldPath is written in terms
+                                                        of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to
+                                                        select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name: required
+                                                        for volumes, optional for env
+                                                        vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret
+                                                    in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret
+                                                        to select from.  Must be a valid
+                                                        secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the
+                                                        Secret or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      extraVolumes:
+                                        description: ExtraVolumes is an extra set of host
+                                          volumes, mounted to the control plane component.
+                                        items:
+                                          description: |-
+                                            HostPathMount contains elements describing volumes that are mounted from the
+                                            host.
+                                          properties:
+                                            hostPath:
+                                              description: |-
+                                                HostPath is the path in the host that will be mounted inside
+                                                the pod.
+                                              type: string
+                                            mountPath:
+                                              description: MountPath is the path inside
+                                                the pod where hostPath will be mounted.
+                                              type: string
+                                            name:
+                                              description: Name of the volume inside the
+                                                pod template.
+                                              type: string
+                                            pathType:
+                                              description: PathType is the type of the
+                                                HostPath.
+                                              type: string
+                                            readOnly:
+                                              description: ReadOnly controls write access
+                                                to the volume
+                                              type: boolean
+                                          required:
+                                          - hostPath
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              diskSetup:
+                                description: DiskSetup specifies options for the creation
+                                  of partition tables and file systems on devices.
+                                properties:
+                                  filesystems:
+                                    description: Filesystems specifies the list of file
+                                      systems to setup.
+                                    items:
+                                      description: Filesystem defines the file systems
+                                        to be created.
+                                      properties:
+                                        device:
+                                          description: Device specifies the device name
+                                          type: string
+                                        extraOpts:
+                                          description: ExtraOpts defined extra options
+                                            to add to the command for creating the file
+                                            system.
+                                          items:
+                                            type: string
+                                          type: array
+                                        filesystem:
+                                          description: Filesystem specifies the file system
+                                            type.
+                                          type: string
+                                        label:
+                                          description: Label specifies the file system
+                                            label to be used. If set to None, no label
+                                            is used.
+                                          type: string
+                                        overwrite:
+                                          description: |-
+                                            Overwrite defines whether or not to overwrite any existing filesystem.
+                                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                                          type: boolean
+                                        partition:
+                                          description: 'Partition specifies the partition
+                                            to use. The valid options are: "auto|any",
+                                            "auto", "any", "none", and <NUM>, where NUM
+                                            is the actual partition number.'
+                                          type: string
+                                        replaceFS:
+                                          description: |-
+                                            ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                          type: string
+                                      required:
+                                      - device
+                                      - filesystem
+                                      - label
+                                      type: object
+                                    type: array
+                                  partitions:
+                                    description: Partitions specifies the list of the
+                                      partitions to setup.
+                                    items:
+                                      description: Partition defines how to create and
+                                        layout a partition.
+                                      properties:
+                                        device:
+                                          description: Device is the name of the device.
+                                          type: string
+                                        layout:
+                                          description: |-
+                                            Layout specifies the device layout.
+                                            If it is true, a single partition will be created for the entire device.
+                                            When layout is false, it means don't partition or ignore existing partitioning.
+                                          type: boolean
+                                        overwrite:
+                                          description: |-
+                                            Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                            Use with caution. Default is 'false'.
+                                          type: boolean
+                                        tableType:
+                                          description: |-
+                                            TableType specifies the tupe of partition table. The following are supported:
+                                            'mbr': default and setups a MS-DOS partition table
+                                            'gpt': setups a GPT partition table
+                                          type: string
+                                      required:
+                                      - device
+                                      - layout
+                                      type: object
+                                    type: array
+                                type: object
+                              files:
+                                description: Files specifies extra files to be passed
+                                  to user_data upon creation.
+                                items:
+                                  description: File defines the input for generating write_files
+                                    in cloud-init.
+                                  properties:
+                                    append:
+                                      description: Append specifies whether to append
+                                        Content to existing file if Path exists.
+                                      type: boolean
+                                    content:
+                                      description: Content is the actual content of the
+                                        file.
+                                      type: string
+                                    contentFrom:
+                                      description: ContentFrom is a referenced source
+                                        of content to populate the file.
+                                      properties:
+                                        secret:
+                                          description: Secret represents a secret that
+                                            should populate this file.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret's
+                                                data map for this value.
+                                              type: string
+                                            name:
+                                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                                namespace to use.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                      required:
+                                      - secret
+                                      type: object
+                                    encoding:
+                                      description: Encoding specifies the encoding of
+                                        the file contents.
+                                      enum:
+                                      - base64
+                                      - gzip
+                                      - gzip+base64
+                                      type: string
+                                    owner:
+                                      description: Owner specifies the ownership of the
+                                        file, e.g. "root:root".
+                                      type: string
+                                    path:
+                                      description: Path specifies the full path on disk
+                                        where to store the file.
+                                      type: string
+                                    permissions:
+                                      description: Permissions specifies the permissions
+                                        to assign to the file, e.g. "0640".
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                              format:
+                                description: Format specifies the output format of the
+                                  bootstrap data
+                                enum:
+                                - cloud-config
+                                - ignition
+                                type: string
+                              ignition:
+                                description: Ignition contains Ignition specific configuration.
+                                properties:
+                                  containerLinuxConfig:
+                                    description: ContainerLinuxConfig contains CLC specific
+                                      configuration.
+                                    properties:
+                                      additionalConfig:
+                                        description: |-
+                                          AdditionalConfig contains additional configuration to be merged with the Ignition
+                                          configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+
+                                          The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                        type: string
+                                      strict:
+                                        description: Strict controls if AdditionalConfig
+                                          should be strictly parsed. If so, warnings are
+                                          treated as errors.
+                                        type: boolean
+                                    type: object
+                                type: object
+                              initConfiguration:
+                                description: InitConfiguration along with ClusterConfiguration
+                                  are the configurations necessary for the init command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  bootstrapTokens:
+                                    description: |-
+                                      BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                    items:
+                                      description: BootstrapToken describes one bootstrap
+                                        token, stored as a Secret in the cluster.
+                                      properties:
+                                        description:
+                                          description: |-
+                                            Description sets a human-friendly message why this token exists and what it's used
+                                            for, so other administrators can know its purpose.
+                                          type: string
+                                        expires:
+                                          description: |-
+                                            Expires specifies the timestamp when this token expires. Defaults to being set
+                                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                          format: date-time
+                                          type: string
+                                        groups:
+                                          description: |-
+                                            Groups specifies the extra groups that this token will authenticate as when/if
+                                            used for authentication
+                                          items:
+                                            type: string
+                                          type: array
+                                        token:
+                                          description: |-
+                                            Token is used for establishing bidirectional trust between nodes and control-planes.
+                                            Used for joining nodes in the cluster.
+                                          type: string
+                                        ttl:
+                                          description: |-
+                                            TTL defines the time to live for this token. Defaults to 24h.
+                                            Expires and TTL are mutually exclusive.
+                                          type: string
+                                        usages:
+                                          description: |-
+                                            Usages describes the ways in which this token can be used. Can by default be used
+                                            for establishing bidirectional trust, but that can be changed here.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - token
+                                      type: object
+                                    type: array
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  localAPIEndpoint:
+                                    description: |-
+                                      LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                      fails you may set the desired value here.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address
+                                          for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          BindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      imagePullPolicy:
+                                        description: |-
+                                          ImagePullPolicy specifies the policy for image pulling
+                                          during kubeadm "init" and "join" operations. The value of
+                                          this field must be one of "Always", "IfNotPresent" or
+                                          "Never". Defaults to "IfNotPresent". This can be used only
+                                          with Kubernetes version equal to 1.22 and later.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        - Never
+                                        type: string
+                                      imagePullSerial:
+                                        description: |-
+                                          ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                          Default: true (defaulted in kubeadm)
+                                        type: boolean
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                  patches:
+                                    description: |-
+                                      Patches contains options related to applying patches to components deployed by kubeadm during
+                                      "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                                    properties:
+                                      directory:
+                                        description: |-
+                                          Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                          "suffix" is an optional string that can be used to determine which patches are applied
+                                          first alpha-numerically.
+                                          These files can be written into the target directory via KubeadmConfig.Files which
+                                          specifies additional files to be created on the machine, either with content inline or
+                                          by referencing a secret.
+                                        type: string
+                                    type: object
+                                  skipPhases:
+                                    description: |-
+                                      SkipPhases is a list of phases to skip during command execution.
+                                      The list of phases can be obtained with the "kubeadm init --help" command.
+                                      This option takes effect only on Kubernetes >=1.22.0.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              joinConfiguration:
+                                description: JoinConfiguration is the kubeadm configuration
+                                  for the join command
+                                properties:
+                                  apiVersion:
+                                    description: |-
+                                      APIVersion defines the versioned schema of this representation of an object.
+                                      Servers should convert recognized schemas to the latest internal value, and
+                                      may reject unrecognized values.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                    type: string
+                                  caCertPath:
+                                    description: |-
+                                      CACertPath is the path to the SSL certificate authority used to
+                                      secure comunications between node and control-plane.
+                                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                                      TODO: revisit when there is defaulting from k/k
+                                    type: string
+                                  controlPlane:
+                                    description: |-
+                                      ControlPlane defines the additional control plane instance to be deployed on the joining node.
+                                      If nil, no additional control plane instance will be deployed.
+                                    properties:
+                                      localAPIEndpoint:
+                                        description: LocalAPIEndpoint represents the endpoint
+                                          of the API server instance to be deployed on
+                                          this node.
+                                        properties:
+                                          advertiseAddress:
+                                            description: AdvertiseAddress sets the IP
+                                              address for the API server to advertise.
+                                            type: string
+                                          bindPort:
+                                            description: |-
+                                              BindPort sets the secure port for the API Server to bind to.
+                                              Defaults to 6443.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  discovery:
+                                    description: |-
+                                      Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
+                                      TODO: revisit when there is defaulting from k/k
+                                    properties:
+                                      bootstrapToken:
+                                        description: |-
+                                          BootstrapToken is used to set the options for bootstrap token based discovery
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          apiServerEndpoint:
+                                            description: APIServerEndpoint is an IP or
+                                              domain name to the API server from which
+                                              info will be fetched.
+                                            type: string
+                                          caCertHashes:
+                                            description: |-
+                                              CACertHashes specifies a set of public key pins to verify
+                                              when token-based discovery is used. The root CA found during discovery
+                                              must match one of these values. Specifying an empty set disables root CA
+                                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                              where the only currently supported type is "sha256". This is a hex-encoded
+                                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                            items:
+                                              type: string
+                                            type: array
+                                          token:
+                                            description: |-
+                                              Token is a token used to validate cluster information
+                                              fetched from the control-plane.
+                                            type: string
+                                          unsafeSkipCAVerification:
+                                            description: |-
+                                              UnsafeSkipCAVerification allows token-based discovery
+                                              without CA verification via CACertHashes. This can weaken
+                                              the security of kubeadm since other nodes can impersonate the control-plane.
+                                            type: boolean
+                                        required:
+                                        - token
+                                        type: object
+                                      file:
+                                        description: |-
+                                          File is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                          BootstrapToken and File are mutually exclusive
+                                        properties:
+                                          kubeConfig:
+                                            description: |-
+                                              KubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                              The file is generated at the path specified in KubeConfigPath.
+
+
+                                              Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                              Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                            properties:
+                                              cluster:
+                                                description: |-
+                                                  Cluster contains information about how to communicate with the kubernetes cluster.
+
+
+                                                  By default the following fields are automatically populated:
+                                                  - Server with the Cluster's ControlPlaneEndpoint.
+                                                  - CertificateAuthorityData with the Cluster's CA certificate.
+                                                properties:
+                                                  certificateAuthorityData:
+                                                    description: |-
+                                                      CertificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+
+                                                      Defaults to the Cluster's CA certificate if empty.
+                                                    format: byte
+                                                    type: string
+                                                  insecureSkipTLSVerify:
+                                                    description: InsecureSkipTLSVerify
+                                                      skips the validity check for the
+                                                      server's certificate. This will
+                                                      make your HTTPS connections insecure.
+                                                    type: boolean
+                                                  proxyURL:
+                                                    description: |-
+                                                      ProxyURL is the URL to the proxy to be used for all requests made by this
+                                                      client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                                      this configuration is not provided or the empty string, the client
+                                                      attempts to construct a proxy configuration from http_proxy and
+                                                      https_proxy environment variables. If these environment variables are not
+                                                      set, the client does not attempt to proxy requests.
+
+
+                                                      socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                                      attach, port forward).
+                                                    type: string
+                                                  server:
+                                                    description: |-
+                                                      Server is the address of the kubernetes cluster (https://hostname:port).
+
+
+                                                      Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                                    type: string
+                                                  tlsServerName:
+                                                    description: TLSServerName is used
+                                                      to check server certificate. If
+                                                      TLSServerName is empty, the hostname
+                                                      used to contact the server is used.
+                                                    type: string
+                                                type: object
+                                              user:
+                                                description: |-
+                                                  User contains information that describes identity information.
+                                                  This is used to tell the kubernetes cluster who you are.
+                                                properties:
+                                                  authProvider:
+                                                    description: AuthProvider specifies
+                                                      a custom authentication plugin for
+                                                      the kubernetes cluster.
+                                                    properties:
+                                                      config:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: Config holds the
+                                                          parameters for the authentication
+                                                          plugin.
+                                                        type: object
+                                                      name:
+                                                        description: Name is the name
+                                                          of the authentication plugin.
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    type: object
+                                                  exec:
+                                                    description: Exec specifies a custom
+                                                      exec-based authentication plugin
+                                                      for the kubernetes cluster.
+                                                    properties:
+                                                      apiVersion:
+                                                        description: |-
+                                                          Preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                          the same encoding version as the input.
+                                                          Defaults to client.authentication.k8s.io/v1 if not set.
+                                                        type: string
+                                                      args:
+                                                        description: Arguments to pass
+                                                          to the command when executing
+                                                          it.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      command:
+                                                        description: Command to execute.
+                                                        type: string
+                                                      env:
+                                                        description: |-
+                                                          Env defines additional environment variables to expose to the process. These
+                                                          are unioned with the host's environment, as well as variables client-go uses
+                                                          to pass argument to the plugin.
+                                                        items:
+                                                          description: |-
+                                                            KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                            credential plugin.
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      provideClusterInfo:
+                                                        description: |-
+                                                          ProvideClusterInfo determines whether or not to provide cluster information,
+                                                          which could potentially contain very large CA data, to this exec plugin as a
+                                                          part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                          to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                          reading this environment variable.
+                                                        type: boolean
+                                                    required:
+                                                    - command
+                                                    type: object
+                                                type: object
+                                            required:
+                                            - user
+                                            type: object
+                                          kubeConfigPath:
+                                            description: KubeConfigPath is used to specify
+                                              the actual file path or URL to the kubeconfig
+                                              file from which to load cluster information
+                                            type: string
+                                        required:
+                                        - kubeConfigPath
+                                        type: object
+                                      timeout:
+                                        description: Timeout modifies the discovery timeout
+                                        type: string
+                                      tlsBootstrapToken:
+                                        description: |-
+                                          TLSBootstrapToken is a token used for TLS bootstrapping.
+                                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                        type: string
+                                    type: object
+                                  kind:
+                                    description: |-
+                                      Kind is a string value representing the REST resource this object represents.
+                                      Servers may infer this from the endpoint the client submits requests to.
+                                      Cannot be updated.
+                                      In CamelCase.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                    type: string
+                                  nodeRegistration:
+                                    description: |-
+                                      NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                      across both InitConfiguration and JoinConfiguration
+                                    properties:
+                                      criSocket:
+                                        description: CRISocket is used to retrieve container
+                                          runtime info. This information will be annotated
+                                          to the Node API object, for later re-use
+                                        type: string
+                                      ignorePreflightErrors:
+                                        description: IgnorePreflightErrors provides a
+                                          slice of pre-flight errors to be ignored when
+                                          the current node is registered.
+                                        items:
+                                          type: string
+                                        type: array
+                                      imagePullPolicy:
+                                        description: |-
+                                          ImagePullPolicy specifies the policy for image pulling
+                                          during kubeadm "init" and "join" operations. The value of
+                                          this field must be one of "Always", "IfNotPresent" or
+                                          "Never". Defaults to "IfNotPresent". This can be used only
+                                          with Kubernetes version equal to 1.22 and later.
+                                        enum:
+                                        - Always
+                                        - IfNotPresent
+                                        - Never
+                                        type: string
+                                      imagePullSerial:
+                                        description: |-
+                                          ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                          Default: true (defaulted in kubeadm)
+                                        type: boolean
+                                      kubeletExtraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                        type: object
+                                      name:
+                                        description: |-
+                                          Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                          Defaults to the hostname of the node if not provided.
+                                        type: string
+                                      taints:
+                                        description: |-
+                                          Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                        items:
+                                          description: |-
+                                            The node this Taint is attached to has the "effect" on
+                                            any pod that does not tolerate the Taint.
+                                          properties:
+                                            effect:
+                                              description: |-
+                                                Required. The effect of the taint on pods
+                                                that do not tolerate the taint.
+                                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Required. The taint key to
+                                                be applied to a node.
+                                              type: string
+                                            timeAdded:
+                                              description: |-
+                                                TimeAdded represents the time at which the taint was added.
+                                                It is only written for NoExecute taints.
+                                              format: date-time
+                                              type: string
+                                            value:
+                                              description: The taint value corresponding
+                                                to the taint key.
+                                              type: string
+                                          required:
+                                          - effect
+                                          - key
+                                          type: object
+                                        type: array
+                                    type: object
+                                  patches:
+                                    description: |-
+                                      Patches contains options related to applying patches to components deployed by kubeadm during
+                                      "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                                    properties:
+                                      directory:
+                                        description: |-
+                                          Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                          "suffix" is an optional string that can be used to determine which patches are applied
+                                          first alpha-numerically.
+                                          These files can be written into the target directory via KubeadmConfig.Files which
+                                          specifies additional files to be created on the machine, either with content inline or
+                                          by referencing a secret.
+                                        type: string
+                                    type: object
+                                  skipPhases:
+                                    description: |-
+                                      SkipPhases is a list of phases to skip during command execution.
+                                      The list of phases can be obtained with the "kubeadm init --help" command.
+                                      This option takes effect only on Kubernetes >=1.22.0.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              mounts:
+                                description: Mounts specifies a list of mount points to
+                                  be setup.
+                                items:
+                                  description: MountPoints defines input for generated
+                                    mounts in cloud-init.
+                                  items:
+                                    type: string
+                                  type: array
+                                type: array
+                              ntp:
+                                description: NTP specifies NTP configuration
+                                properties:
+                                  enabled:
+                                    description: Enabled specifies whether NTP should
+                                      be enabled
+                                    type: boolean
+                                  servers:
+                                    description: Servers specifies which NTP servers to
+                                      use
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              postKubeadmCommands:
+                                description: PostKubeadmCommands specifies extra commands
+                                  to run after kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              preKubeadmCommands:
+                                description: PreKubeadmCommands specifies extra commands
+                                  to run before kubeadm runs
+                                items:
+                                  type: string
+                                type: array
+                              useExperimentalRetryJoin:
+                                description: |-
+                                  UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                                  script with retries for joins.
+
+
+                                  This is meant to be an experimental temporary workaround on some environments
+                                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                                  kubeadm proper and use that functionality.
+
+
+                                  This will add about 40KB to userdata
+
+
+                                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+
+                                  Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                                  When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                                type: boolean
+                              users:
+                                description: Users specifies extra users to add
+                                items:
+                                  description: User defines the input for a generated
+                                    user in cloud-init.
+                                  properties:
+                                    gecos:
+                                      description: Gecos specifies the gecos to use for
+                                        the user
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the additional groups
+                                        for the user
+                                      type: string
+                                    homeDir:
+                                      description: HomeDir specifies the home directory
+                                        to use for the user
+                                      type: string
+                                    inactive:
+                                      description: Inactive specifies whether to mark
+                                        the user as inactive
+                                      type: boolean
+                                    lockPassword:
+                                      description: LockPassword specifies if password
+                                        login should be disabled
+                                      type: boolean
+                                    name:
+                                      description: Name specifies the user name
+                                      type: string
+                                    passwd:
+                                      description: Passwd specifies a hashed password
+                                        for the user
+                                      type: string
+                                    passwdFrom:
+                                      description: PasswdFrom is a referenced source of
+                                        passwd to populate the passwd.
+                                      properties:
+                                        secret:
+                                          description: Secret represents a secret that
+                                            should populate this password.
+                                          properties:
+                                            key:
+                                              description: Key is the key in the secret's
+                                                data map for this value.
+                                              type: string
+                                            name:
+                                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                                namespace to use.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                      required:
+                                      - secret
+                                      type: object
+                                    primaryGroup:
+                                      description: PrimaryGroup specifies the primary
+                                        group for the user
+                                      type: string
+                                    shell:
+                                      description: Shell specifies the user's shell
+                                      type: string
+                                    sshAuthorizedKeys:
+                                      description: SSHAuthorizedKeys specifies a list
+                                        of ssh authorized keys for the user
+                                      items:
+                                        type: string
+                                      type: array
+                                    sudo:
+                                      description: Sudo specifies a sudo role for the
+                                        user
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              verbosity:
+                                description: |-
+                                  Verbosity is the number for the kubeadm log level verbosity.
+                                  It overrides the `--v` flag in kubeadm commands.
+                                format: int32
+                                type: integer
+                            type: object
+                          machineTemplate:
+                            description: |-
+                              MachineTemplate contains information about how machines
+                              should be shaped when creating or updating a control plane.
+                            properties:
+                              metadata:
+                                description: |-
+                                  Standard object's metadata.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata. They are not
+                                      queryable and should be preserved when modifying objects.
+                                      More info: http://kubernetes.io/docs/user-guide/annotations
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects. May match selectors of replication controllers
+                                      and services.
+                                      More info: http://kubernetes.io/docs/user-guide/labels
+                                    type: object
+                                type: object
+                              nodeDeletionTimeout:
+                                description: |-
+                                  NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                                  hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                  If no value is provided, the default value for this property of the Machine resource will be used.
+                                type: string
+                              nodeDrainTimeout:
+                                description: |-
+                                  NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                                  The default value is 0, meaning that the node can be drained without any time limitations.
+                                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                                type: string
+                              nodeVolumeDetachTimeout:
+                                description: |-
+                                  NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                  to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                                type: string
+                            type: object
+                          remediationStrategy:
+                            description: The RemediationStrategy that controls how control
+                              plane machine remediation happens.
+                            properties:
+                              maxRetry:
+                                description: "MaxRetry is the Max number of retries while
+                                  attempting to remediate an unhealthy machine.\nA retry
+                                  happens when a machine that was created as a replacement
+                                  for an unhealthy machine also fails.\nFor example, given
+                                  a control plane with three machines M1, M2, M3:\n\n\n\tM1
+                                  become unhealthy; remediation happens, and M1-1 is created
+                                  as a replacement.\n\tIf M1-1 (replacement of M1) has
+                                  problems while bootstrapping it will become unhealthy,
+                                  and then be\n\tremediated; such operation is considered
+                                  a retry, remediation-retry #1.\n\tIf M1-2 (replacement
+                                  of M1-1) becomes unhealthy, remediation-retry #2 will
+                                  happen, etc.\n\n\nA retry could happen only after RetryPeriod
+                                  from the previous retry.\nIf a machine is marked as
+                                  unhealthy after MinHealthyPeriod from the previous remediation
+                                  expired,\nthis is not considered a retry anymore because
+                                  the new issue is assumed unrelated from the previous
+                                  one.\n\n\nIf not set, the remedation will be retried
+                                  infinitely."
+                                format: int32
+                                type: integer
+                              minHealthyPeriod:
+                                description: "MinHealthyPeriod defines the duration after
+                                  which KCP will consider any failure to a machine unrelated\nfrom
+                                  the previous one. In this case the remediation is not
+                                  considered a retry anymore, and thus the retry\ncounter
+                                  restarts from 0. For example, assuming MinHealthyPeriod
+                                  is set to 1h (default)\n\n\n\tM1 become unhealthy; remediation
+                                  happens, and M1-1 is created as a replacement.\n\tIf
+                                  M1-1 (replacement of M1) has problems within the 1hr
+                                  after the creation, also\n\tthis machine will be remediated
+                                  and this operation is considered a retry - a problem
+                                  related\n\tto the original issue happened to M1 -.\n\n\n\tIf
+                                  instead the problem on M1-1 is happening after MinHealthyPeriod
+                                  expired, e.g. four days after\n\tm1-1 has been created
+                                  as a remediation of M1, the problem on M1-1 is considered
+                                  unrelated to\n\tthe original issue happened to M1.\n\n\nIf
+                                  not set, this value is defaulted to 1h."
+                                type: string
+                              retryPeriod:
+                                description: |-
+                                  RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                                  for an unhealthy machine (a retry).
+
+
+                                  If not set, a retry will happen immediately.
+                                type: string
+                            type: object
+                          rolloutAfter:
+                            description: |-
+                              RolloutAfter is a field to indicate a rollout should be performed
+                              after the specified time even if no changes have been made to the
+                              KubeadmControlPlane.
+                            format: date-time
+                            type: string
+                          rolloutBefore:
+                            description: |-
+                              RolloutBefore is a field to indicate a rollout should be performed
+                              if the specified criteria is met.
+                            properties:
+                              certificatesExpiryDays:
+                                description: |-
+                                  CertificatesExpiryDays indicates a rollout needs to be performed if the
+                                  certificates of the machine will expire within the specified days.
+                                format: int32
+                                type: integer
+                            type: object
+                          rolloutStrategy:
+                            default:
+                              rollingUpdate:
+                                maxSurge: 1
+                              type: RollingUpdate
+                            description: |-
+                              The RolloutStrategy to use to replace control plane machines with
+                              new ones.
+                            properties:
+                              rollingUpdate:
+                                description: |-
+                                  Rolling update config params. Present only if
+                                  RolloutStrategyType = RollingUpdate.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of control planes that can be scheduled above or under the
+                                      desired number of control planes.
+                                      Value can be an absolute number 1 or 0.
+                                      Defaults to 1.
+                                      Example: when this is set to 1, the control plane can be scaled
+                                      up immediately when the rolling update starts.
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  Type of rollout. Currently the only supported strategy is
+                                  "RollingUpdate".
+                                  Default is RollingUpdate.
+                                type: string
+                            type: object
+                        required:
+                        - kubeadmConfigSpec
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                required:
+                - template
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources: {}
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-manager
+      namespace: capi-kubeadm-control-plane-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-leader-election-role
+      namespace: capi-kubeadm-control-plane-system
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-aggregated-manager-role
+    rules: []
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+      name: capi-kubeadm-control-plane-manager-role
+    rules:
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - bootstrap.cluster.x-k8s.io
+      - controlplane.cluster.x-k8s.io
+      - infrastructure.cluster.x-k8s.io
+      resources:
+      - '*'
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - clusters
+      - clusters/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - machinepools
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - machines
+      - machines/status
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-leader-election-rolebinding
+      namespace: capi-kubeadm-control-plane-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: capi-kubeadm-control-plane-leader-election-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-control-plane-manager
+      namespace: capi-kubeadm-control-plane-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: capi-kubeadm-control-plane-aggregated-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: capi-kubeadm-control-plane-manager
+      namespace: capi-kubeadm-control-plane-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      ports:
+      - port: 443
+        targetPort: webhook-server
+      selector:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        control-plane: controller-manager
+      name: capi-kubeadm-control-plane-controller-manager
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          cluster.x-k8s.io/provider: control-plane-kubeadm
+          control-plane: controller-manager
+      template:
+        metadata:
+          labels:
+            cluster.x-k8s.io/provider: control-plane-kubeadm
+            control-plane: controller-manager
+        spec:
+          containers:
+          - args:
+            - --leader-elect
+            - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+            - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+            - --use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}
+            - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
+            command:
+            - /manager
+            env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            image: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.8.0
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              runAsGroup: 65532
+              runAsUser: 65532
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: capi-kubeadm-control-plane-manager
+          terminationGracePeriodSeconds: 10
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+          volumes:
+          - name: cert
+            secret:
+              secretName: capi-kubeadm-control-plane-webhook-service-cert
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-serving-cert
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      dnsNames:
+      - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc
+      - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc.cluster.local
+      issuerRef:
+        kind: Issuer
+        name: capi-kubeadm-control-plane-selfsigned-issuer
+      secretName: capi-kubeadm-control-plane-webhook-service-cert
+      subject:
+        organizations:
+        - k8s-sig-cluster-lifecycle
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-selfsigned-issuer
+      namespace: capi-kubeadm-control-plane-system
+    spec:
+      selfSigned: {}
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-mutating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanes
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+      failurePolicy: Fail
+      name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanetemplates
+      sideEffects: None
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      annotations:
+        cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+      name: capi-kubeadm-control-plane-validating-webhook-configuration
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /validate-scale-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation-scale.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanes/scale
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanes
+      sideEffects: None
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+      failurePolicy: Fail
+      name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+      rules:
+      - apiGroups:
+        - controlplane.cluster.x-k8s.io
+        apiVersions:
+        - v1beta1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - kubeadmcontrolplanetemplates
+      sideEffects: None
+  metadata: |
+    # maps release series of major.minor to cluster-api contract version
+    # the contract version may change between minor or major versions, but *not*
+    # between patch versions.
+    #
+    # update this file only when a new major or minor version is released
+    apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+    kind: Metadata
+    releaseSeries:
+      - major: 1
+        minor: 8
+        contract: v1beta1
+      - major: 1
+        minor: 7
+        contract: v1beta1
+      - major: 1
+        minor: 6
+        contract: v1beta1
+      - major: 1
+        minor: 5
+        contract: v1beta1
+      - major: 1
+        minor: 4
+        contract: v1beta1
+      - major: 1
+        minor: 3
+        contract: v1beta1
+      - major: 1
+        minor: 2
+        contract: v1beta1
+      - major: 1
+        minor: 1
+        contract: v1beta1
+      - major: 1
+        minor: 0
+        contract: v1beta1
+kind: ConfigMap
+metadata:
+  labels:
+    provider.cluster.x-k8s.io/name: kubeadm
+    provider.cluster.x-k8s.io/type: controlplane
+    provider.cluster.x-k8s.io/version: v1.8.0
+  name: controlplane-kubeadm-v1.8.0
+  namespace: capi-kubeadm-control-plane-system

--- a/util/util.go
+++ b/util/util.go
@@ -77,22 +77,22 @@ func GetCustomProviders(ctx context.Context, cl ctrlclient.Client, currProvider 
 	currProviderType := currProvider.GetType()
 
 	for _, providerList := range operatorv1.ProviderLists {
-		genericProviderList, ok := providerList.(genericProviderList)
+		genProviderList, ok := providerList.(genericProviderList)
 		if !ok {
 			return nil, fmt.Errorf("cannot cast providers list to genericProviderList")
 		}
 
-		if err := cl.List(ctx, genericProviderList); err != nil {
+		if err := cl.List(ctx, genProviderList); err != nil {
 			return nil, fmt.Errorf("cannot get a list of providers from the server: %w", err)
 		}
 
-		genericProviderListItems := genericProviderList.GetItems()
-		for i, provider := range genericProviderListItems {
+		genProviderListItems := genProviderList.GetItems()
+		for i, provider := range genProviderListItems {
 			if provider.GetName() == currProviderName && provider.GetType() == currProviderType || provider.GetSpec().FetchConfig == nil {
 				continue
 			}
 
-			customProviders = append(customProviders, genericProviderListItems[i])
+			customProviders = append(customProviders, genProviderListItems[i])
 		}
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -77,18 +77,13 @@ func GetCustomProviders(ctx context.Context, cl ctrlclient.Client, currProvider 
 	currProviderType := currProvider.GetType()
 
 	for _, providerList := range operatorv1.ProviderLists {
-		providerList, ok := providerList.(ctrlclient.ObjectList)
+		genericProviderList, ok := providerList.(genericProviderList)
 		if !ok {
-			return nil, fmt.Errorf("cannot cast providers list to ObjectList")
+			return nil, fmt.Errorf("cannot cast providers list to genericProviderList")
 		}
 
-		if err := cl.List(ctx, providerList); err != nil {
+		if err := cl.List(ctx, genericProviderList); err != nil {
 			return nil, fmt.Errorf("cannot get a list of providers from the server: %w", err)
-		}
-
-		genericProviderList, ok := providerList.(operatorv1.GenericProviderList)
-		if !ok {
-			return nil, fmt.Errorf("cannot cast providers list to GenericProviderList")
 		}
 
 		genericProviderListItems := genericProviderList.GetItems()


### PR DESCRIPTION
**What this PR does / why we need it**:
When using `fetchConfig` in the [provider spec](https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/05_provider-spec-configuration.html?highlight=fetchconfig#provider-spec) for multiple providers, the operator does not properly pass information about other "custom" providers to the [clusterctl configuration](https://cluster-api.sigs.k8s.io/clusterctl/configuration#provider-repositories). Currently, the operator passes repository information about the current provider only, and the default list from `clusterctl`. This causes `clusterctl` to fail it's lagging provider check, which is intended to keep providers within a valid version skew to avoid a broken cluster, and prevents upgrading providers when using `fetchConfig` in multiple places.

This PR adds information about other providers that are using `fetchConfig` to the MemoryReader, so that clusterctl can properly pass this check.

**Which issue(s) this PR fixes**:
Fixes #570
