### PR TITLE
🌱 Add e2e tests for IPAM provider to Cluster API Operator Helm chart

### DIFF
--- a/hack/charts/cluster-api-operator/templates/core-conditions.yaml
+++ b/hack/charts/cluster-api-operator/templates/core-conditions.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.addon .Values.bootstrap .Values.controlPlane .Values.infrastructure }}
+{{- if or .Values.addon .Values.bootstrap .Values.controlPlane .Values.infrastructure .Values.ipam }}
 # Deploy core components if not specified
 {{- if not .Values.core }}
 ---

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -154,6 +154,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"controlPlane":           "kubeadm-control-plane-custom-ns:kubeadm:v1.7.7",
 			"bootstrap":              "kubeadm-bootstrap-custom-ns:kubeadm:v1.7.7",
 			"infrastructure":         "capd-custom-ns:docker:v1.7.7",
+			"ipam":                   "in-cluster-custom-ns:in-cluster:v1.0.0",
 			"addon":                  "helm-custom-ns:helm:v0.2.6",
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -171,6 +172,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"controlPlane":           "kubeadm:v1.7.7",
 			"bootstrap":              "kubeadm:v1.7.7",
 			"infrastructure":         "docker:v1.7.7",
+			"ipam":                   "in-cluster:v1.0.0",
 			"addon":                  "helm:v0.2.6",
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -188,6 +190,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"controlPlane":           "kubeadm",
 			"bootstrap":              "kubeadm",
 			"infrastructure":         "docker",
+			"ipam":                   "in-cluster",
 			"addon":                  "helm",
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -232,6 +235,33 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())
 		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-control-plane.yaml"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).To(Equal(string(expectedManifests)))
+	})
+
+	It("should deploy core when only ipam is specified", func() {
+		manifests, err := helmChart.Run(map[string]string{
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"ipam":                   "in-cluster",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).ToNot(BeEmpty())
+		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-ipam.yaml"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).To(Equal(string(expectedManifests)))
+	})
+
+	It("should deploy core, bootstrap, control plane when only infra and ipam is specified", func() {
+		manifests, err := helmChart.Run(map[string]string{
+			"configSecret.name":      "test-secret-name",
+			"configSecret.namespace": "test-secret-namespace",
+			"infrastructure":         "docker",
+			"ipam":                   "in-cluster",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).ToNot(BeEmpty())
+		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "only-infra-and-ipam.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
@@ -306,6 +336,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"configSecret.name":        "aws-variables",
 			"configSecret.namespace":   "default",
 			"infrastructure":           "aws:v2.4.0",
+			"ipam":                     "in-cluster:",
 			"addon":                    "helm:",
 			"image.manager.tag":        "v0.9.1",
 			"cert-manager.enabled":     "false",
@@ -330,6 +361,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"configSecret.namespace":           "test-secret-namespace",
 			"core":                             "cluster-api",
 			"infrastructure":                   "azure",
+			"ipam":                             "in-cluster",
 			"addon":                            "helm",
 			"manager.cert-manager.enabled":     "false",
 			"manager.cert-manager.installCRDs": "false",
@@ -346,6 +378,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"controlPlane":   "kubeadm",
 			"bootstrap":      "kubeadm",
 			"infrastructure": "docker",
+			"ipam":           "in-cluster",
 			"addon":          "helm",
 			"manager.featureGates.core.ClusterTopology": "true",
 			"manager.featureGates.core.MachinePool":     "true",
@@ -362,6 +395,7 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"controlPlane":   "kubeadm",
 			"bootstrap":      "kubeadm",
 			"infrastructure": "docker",
+			"ipam":           "in-cluster",
 			"addon":          "helm",
 			"manager.featureGates.kubeadm.ClusterTopology": "true",
 			"manager.featureGates.kubeadm.MachinePool":     "true",

--- a/test/e2e/resources/all-providers-custom-ns-versions.yaml
+++ b/test/e2e/resources/all-providers-custom-ns-versions.yaml
@@ -46,6 +46,16 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: capd-custom-ns
 ---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-custom-ns
+---
 # Source: cluster-api-operator/templates/addon.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: AddonProvider
@@ -101,6 +111,22 @@ metadata:
     "argocd.argoproj.io/sync-wave": "2"
 spec:
   version: v1.7.7
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-custom-ns
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  version: v1.0.0
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace

--- a/test/e2e/resources/all-providers-latest-versions.yaml
+++ b/test/e2e/resources/all-providers-latest-versions.yaml
@@ -46,6 +46,16 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: docker-infrastructure-system
 ---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-ipam-system
+---
 # Source: cluster-api-operator/templates/addon.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: AddonProvider
@@ -91,6 +101,21 @@ kind: CoreProvider
 metadata:
   name: cluster-api
   namespace: capi-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-ipam-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"

--- a/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
+++ b/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
@@ -48,6 +48,16 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: azure-infrastructure-system
 ---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-ipam-system
+---
 # Source: cluster-api-operator/templates/addon.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: AddonProvider
@@ -96,6 +106,22 @@ kind: CoreProvider
 metadata:
   name: cluster-api
   namespace: capi-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  manager:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-ipam-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"

--- a/test/e2e/resources/feature-gates.yaml
+++ b/test/e2e/resources/feature-gates.yaml
@@ -48,6 +48,16 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: aws-infrastructure-system
 ---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-ipam-system
+---
 # Source: cluster-api-operator/templates/addon.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: AddonProvider
@@ -106,6 +116,22 @@ spec:
     featureGates:
       ClusterTopology: true
       MachinePool: true
+  configSecret:
+    name: aws-variables
+    namespace: default
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-ipam-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  manager:
   configSecret:
     name: aws-variables
     namespace: default

--- a/test/e2e/resources/kubeadm-manager-defined.yaml
+++ b/test/e2e/resources/kubeadm-manager-defined.yaml
@@ -46,6 +46,16 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: docker-infrastructure-system
 ---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-ipam-system
+---
 # Source: cluster-api-operator/templates/addon.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: AddonProvider
@@ -88,6 +98,19 @@ kind: CoreProvider
 metadata:
   name: cluster-api
   namespace: capi-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  manager:
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-ipam-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"

--- a/test/e2e/resources/manager-defined-missing-other-infra-spec.yaml
+++ b/test/e2e/resources/manager-defined-missing-other-infra-spec.yaml
@@ -46,6 +46,16 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: docker-infrastructure-system
 ---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-ipam-system
+---
 # Source: cluster-api-operator/templates/addon.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: AddonProvider
@@ -93,6 +103,19 @@ spec:
     featureGates:
       ClusterTopology: true
       MachinePool: true
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-ipam-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  manager:
 ---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/only-infra-and-ipam.yaml
+++ b/test/e2e/resources/only-infra-and-ipam.yaml
@@ -1,33 +1,5 @@
 ---
-# Source: cluster-api-operator/templates/addon.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "1"
-    "argocd.argoproj.io/sync-wave": "1"
-  name: helm-addon-system
----
-# Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "1"
-  name: kubeadm-bootstrap-system
----
-# Source: cluster-api-operator/templates/control-plane.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "1"
-  name: kubeadm-control-plane-system
----
-# Source: cluster-api-operator/templates/core.yaml
+# Source: cluster-api-operator/templates/core-conditions.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -35,6 +7,26 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "1"
   name: capi-system
+---
+# Source: cluster-api-operator/templates/infra-conditions.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: capi-kubeadm-bootstrap-system
+---
+# Source: cluster-api-operator/templates/infra-conditions.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: capi-kubeadm-control-plane-system
 ---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: v1
@@ -56,50 +48,37 @@ metadata:
     "argocd.argoproj.io/sync-wave": "1"
   name: in-cluster-ipam-system
 ---
-# Source: cluster-api-operator/templates/addon.yaml
+# Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
-kind: AddonProvider
+kind: BootstrapProvider
 metadata:
-  name: helm
-  namespace: helm-addon-system
+  name: kubeadm
+  namespace: capi-kubeadm-bootstrap-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  version: v0.2.6
----
-# Source: cluster-api-operator/templates/bootstrap.yaml
-apiVersion: operator.cluster.x-k8s.io/v1alpha2
-kind: BootstrapProvider
-metadata:
-  name: kubeadm
-  namespace: kubeadm-bootstrap-system
-  annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-weight": "2"
-spec:
-  version: v1.7.7
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace
 ---
-# Source: cluster-api-operator/templates/control-plane.yaml
+# Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
 metadata:
   name: kubeadm
-  namespace: kubeadm-control-plane-system
+  namespace: capi-kubeadm-control-plane-system
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
 spec:
-  version: v1.7.7
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace
 ---
-# Source: cluster-api-operator/templates/core.yaml
+# Source: cluster-api-operator/templates/core-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
@@ -108,9 +87,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
-    "argocd.argoproj.io/sync-wave": "2"
 spec:
-  version: v1.7.7
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace
@@ -126,7 +103,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  version: v1.0.0
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace
@@ -142,7 +118,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  version: v1.7.7
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace

--- a/test/e2e/resources/only-ipam.yaml
+++ b/test/e2e/resources/only-ipam.yaml
@@ -1,0 +1,48 @@
+---
+# Source: cluster-api-operator/templates/core-conditions.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+  name: capi-system
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-ipam-system
+---
+# Source: cluster-api-operator/templates/core-conditions.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-ipam-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR brings e2e tests for the IPAM provider into the Cluster API Operator Helm chart, on top of what was done in PR #688.

- Update core-conditions.yaml to include IPAM provider in deployment conditions
- Add IPAM provider test cases in helm_test.go
- Create new / update test resource files for IPAM provider scenarios

