### PR TITLE
🐛 avoid empty manager field in ControlPlaneProvider when no controlPlane and no features gates provided

### DIFF
--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -45,8 +45,8 @@ spec:
   version: {{ $coreVersion }}
 {{- end }}
 {{- if $.Values.manager }}
-  manager:
 {{- if and $.Values.manager.featureGates $.Values.manager.featureGates.core }}
+  manager:
     featureGates:
     {{- range $key, $value := $.Values.manager.featureGates.core }}
       {{ $key }}: {{ $value }}

--- a/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
@@ -54,8 +54,8 @@ metadata:
 {{- with .Values.configSecret }}
 spec:
 {{- if $.Values.manager }}
-  manager:
 {{- if and $.Values.manager.featureGates $.Values.manager.featureGates.kubeadm }}
+  manager:
     featureGates:
     {{- range $key, $value := $.Values.manager.featureGates.kubeadm }}
       {{ $key }}: {{ $value }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -47,8 +47,8 @@ spec:
   version: {{ $infrastructureVersion }}
 {{- end }}
 {{- if $.Values.manager }}
-  manager:
 {{- if and (kindIs "map" $.Values.manager.featureGates) (hasKey $.Values.manager.featureGates $infrastructureName) }}
+  manager:
 {{- range $key, $value := $.Values.manager.featureGates }}
   {{- if eq $key $infrastructureName }}
     featureGates:

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -47,8 +47,8 @@ spec:
   version: {{ $ipamVersion }}
 {{- end }}
 {{- if $.Values.manager }}
-  manager:
 {{- if and (kindIs "map" $.Values.manager.featureGates) (hasKey $.Values.manager.featureGates $ipamName) }}
+  manager:
 {{- range $key, $value := $.Values.manager.featureGates }}
   {{- if eq $key $ipamName }}
     featureGates:

--- a/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
+++ b/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
@@ -95,7 +95,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace
@@ -111,7 +110,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace
@@ -127,7 +125,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace
@@ -143,7 +140,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
   configSecret:
     name: test-secret-name
     namespace: test-secret-namespace

--- a/test/e2e/resources/feature-gates.yaml
+++ b/test/e2e/resources/feature-gates.yaml
@@ -95,7 +95,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
   configSecret:
     name: aws-variables
     namespace: default
@@ -131,7 +130,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
   configSecret:
     name: aws-variables
     namespace: default

--- a/test/e2e/resources/kubeadm-manager-defined.yaml
+++ b/test/e2e/resources/kubeadm-manager-defined.yaml
@@ -103,7 +103,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
 ---
 # Source: cluster-api-operator/templates/ipam.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -116,7 +115,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
 ---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -129,4 +127,3 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:

--- a/test/e2e/resources/manager-defined-missing-other-infra-spec.yaml
+++ b/test/e2e/resources/manager-defined-missing-other-infra-spec.yaml
@@ -115,7 +115,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:
 ---
 # Source: cluster-api-operator/templates/infra.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -128,4 +127,3 @@ metadata:
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
 spec:
-  manager:


### PR DESCRIPTION
Following https://github.com/kubernetes-sigs/cluster-api-operator/pull/681 

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Handle cases where manager values is present for default controlPlane provider.
This will make sure the manager field for the default control plane provider is added only if featureGates for this one are present when no controlPlane is provided (despite calling it out in the previous example).
The default controlPlane provider being `kubeadm`

The last part was the miss of https://github.com/kubernetes-sigs/cluster-api-operator/pull/681 

Example with current/v0.17.0 chart:
```
# Source: cluster-api-operator/charts/cluster-api-operator/templates/infra-conditions.yaml
apiVersion: operator.cluster.x-k8s.io/v1alpha2
kind: ControlPlaneProvider
metadata:
  name: kubeadm
  namespace: capi-kubeadm-control-plane-system
  annotations:
    "helm.sh/hook": "post-install,post-upgrade"
    "helm.sh/hook-weight": "2"
    "argocd.argoproj.io/sync-wave": "2"
spec:
  manager:
```

Similar error for InfrastructureProvider and there is no workaround for metal3. I tried to set a featuregates foo true to have a valid infrastructure provider but I get this error:
```
unknown flag: --feature-gates
Usage of /manager:
unknown flag: --feature-gates
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
