### PR TITLE
:sparkles: Make configSecret configurable per component

### DIFF
--- a/hack/charts/cluster-api-operator/templates/_helpers.tpl
+++ b/hack/charts/cluster-api-operator/templates/_helpers.tpl
@@ -22,3 +22,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "capi-operator.configSecret" -}}
+{{- $ := .ROOT -}}
+{{- $arg := .ARGUMENT -}}
+configSecret:
+  name: {{ default (($arg).configSecret).name (($.Values).configSecret).name }}
+  {{- if (default (($arg).configSecret).namespace (($.Values).configSecret).namespace) }}
+  namespace: {{ default (($arg).configSecret).namespace (($.Values).configSecret).namespace }}
+  {{- end }}
+{{- end -}}

--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $addonVersion $.Values.secretName }}
+{{- if or $addonVersion $.Values.secretName $.Values.configSecret.name (($addon).configSecret).name }}
 spec:
 {{- end}}
 {{- if $addonVersion }}
   version: {{ $addonVersion }}
+{{- end }}
+{{- if (default (($addon).configSecret).name (($.Values).configSecret).name) }}
+{{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $addon) | nindent 2 }}
 {{- end }}
 {{- if $.Values.secretName }}
   secretName: {{ $.Values.secretName }}

--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -46,6 +46,9 @@ spec:
 {{- if $addon.manifestPatches }}
   manifestPatches: {{ toYaml $addon.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $addon.fetchConfig }}
+  fetchConfig: {{ toYaml $addon.fetchConfig | nindent 4 }}
+{{- end }}
 {{- if $addon.additionalManifests }}
   additionalManifests:
     name: {{ $addon.additionalManifests.name }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -28,18 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $bootstrapVersion $.Values.configSecret.name }}
+{{- if or $bootstrapVersion $.Values.configSecret.name (($bootstrap).configSecret).name }}
 spec:
 {{- end}}
 {{- if $bootstrapVersion }}
   version: {{ $bootstrapVersion }}
 {{- end }}
-{{- if $.Values.configSecret.name }}
-  configSecret:
-    name: {{ $.Values.configSecret.name }}
-    {{- if $.Values.configSecret.namespace }}
-    namespace: {{ $.Values.configSecret.namespace }}
-    {{- end }}
+{{- if (default (($bootstrap).configSecret).name (($.Values).configSecret).name) }}
+{{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $bootstrap) | nindent 2 }}
 {{- end }}
 {{- if $bootstrap.manifestPatches }}
   manifestPatches: {{ toYaml $bootstrap.manifestPatches | nindent 4 }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -40,6 +40,9 @@ spec:
 {{- if $bootstrap.manifestPatches }}
   manifestPatches: {{ toYaml $bootstrap.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $bootstrap.fetchConfig }}
+  fetchConfig: {{ toYaml $bootstrap.fetchConfig | nindent 4 }}
+{{- end }}
 {{- if $bootstrap.additionalManifests }}
   additionalManifests:
     name: {{ $bootstrap.additionalManifests.name }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -28,7 +28,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $controlPlaneVersion $.Values.configSecret.name $.Values.manager }}
+{{- if or $controlPlaneVersion $.Values.configSecret.name $.Values.manager (($controlPlane).configSecret).name }}
 spec:
 {{- end}}
 {{- if $controlPlaneVersion }}
@@ -47,12 +47,8 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $.Values.configSecret.name }}
-  configSecret:
-    name: {{ $.Values.configSecret.name }}
-    {{- if $.Values.configSecret.namespace }}
-    namespace: {{ $.Values.configSecret.namespace }}
-    {{- end }}
+{{- if (default (($controlPlane).configSecret).name (($.Values).configSecret).name) }}
+{{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $controlPlane) | nindent 2 }}
 {{- end }}
 {{- if $controlPlane.manifestPatches }}
   manifestPatches: {{ toYaml $controlPlane.manifestPatches | nindent 4 }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -53,6 +53,9 @@ spec:
 {{- if $controlPlane.manifestPatches }}
   manifestPatches: {{ toYaml $controlPlane.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $controlPlane.fetchConfig }}
+  fetchConfig: {{ toYaml $controlPlane.fetchConfig | nindent 4 }}
+{{- end }}
 {{- if $controlPlane.additionalManifests }}
   additionalManifests:
     name: {{ $controlPlane.additionalManifests.name }}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -28,7 +28,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $coreVersion $.Values.configSecret.name $.Values.manager }}
+{{- if or $coreVersion $.Values.configSecret.name $.Values.manager (($core).configSecret).name }}
 spec:
 {{- end}}
 {{- if $coreVersion }}
@@ -43,12 +43,8 @@ spec:
     {{- end }}
 {{- end }}
 {{- end }}
-{{- if $.Values.configSecret.name }}
-  configSecret:
-    name: {{ $.Values.configSecret.name }}
-    {{- if $.Values.configSecret.namespace }}
-    namespace: {{ $.Values.configSecret.namespace }}
-    {{- end }}
+{{- if (default (($core).configSecret).name (($.Values).configSecret).name) }}
+{{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $core) | nindent 2 }}
 {{- end }}
 {{- if $core.manifestPatches }}
   manifestPatches: {{ toYaml $core.manifestPatches | nindent 4 }}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -49,6 +49,9 @@ spec:
 {{- if $core.manifestPatches }}
   manifestPatches: {{ toYaml $core.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $core.fetchConfig }}
+  fetchConfig: {{ toYaml $core.fetchConfig | nindent 4 }}
+{{- end }}
 {{- if $core.additionalManifests }}
   additionalManifests:
     name: {{ $core.additionalManifests.name }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -28,7 +28,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $infrastructureVersion $.Values.configSecret.name $.Values.manager $.Values.additionalDeployments }}
+{{- if or $infrastructureVersion $.Values.configSecret.name $.Values.manager $.Values.additionalDeployments (($infra).configSecret).name }}
 spec:
 {{- end }}
 {{- if $infrastructureVersion }}
@@ -57,12 +57,8 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
-{{- if $.Values.configSecret.name }}
-  configSecret:
-    name: {{ $.Values.configSecret.name }}
-    {{- if $.Values.configSecret.namespace }}
-    namespace: {{ $.Values.configSecret.namespace }}
-    {{- end }}
+{{- if (default (($infra).configSecret).name (($.Values).configSecret).name) }}
+{{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $infra) | nindent 2 }}
 {{- end }}
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -66,6 +66,9 @@ spec:
 {{- if $infra.manifestPatches }}
   manifestPatches: {{- toYaml $infra.manifestPatches | nindent 4 }}
 {{- end }} {{/* if $infra.manifestPatches */}}
+{{- if $infra.fetchConfig }}
+  fetchConfig: {{ toYaml $infra.fetchConfig | nindent 4 }}
+{{- end }}
 {{- if $infra.additionalManifests }}
   additionalManifests:
     name: {{ $infra.additionalManifests.name }}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -63,6 +63,9 @@ spec:
 {{- if $ipam.manifestPatches }}
   manifestPatches: {{ toYaml $ipam.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $ipam.fetchConfig }}
+  fetchConfig: {{ toYaml $ipam.fetchConfig | nindent 4 }}
+{{- end }}
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -28,7 +28,7 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $ipamVersion $.Values.configSecret.name $.Values.manager $.Values.additionalDeployments }}
+{{- if or $ipamVersion $.Values.configSecret.name $.Values.manager $.Values.additionalDeployments (($ipam).configSecret).name }}
 spec:
 {{- end }}
 {{- if $ipamVersion }}
@@ -57,12 +57,8 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
-{{- if $.Values.configSecret.name }}
-  configSecret:
-    name: {{ $.Values.configSecret.name }}
-    {{- if $.Values.configSecret.namespace }}
-    namespace: {{ $.Values.configSecret.namespace }}
-    {{- end }}
+{{- if (default (($ipam).configSecret).name (($.Values).configSecret).name) }}
+{{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $ipam) | nindent 2 }}
 {{- end }}
 {{- if $ipam.manifestPatches }}
   manifestPatches: {{ toYaml $ipam.manifestPatches | nindent 4 }}

--- a/hack/charts/cluster-api-operator/values.schema.json
+++ b/hack/charts/cluster-api-operator/values.schema.json
@@ -1,7 +1,12 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
+    "fetchConfig": {
+      "type": "object",
+      "deprecated": true,
+      "description": "This field is deprecated and will be removed in future versions. Prefer declaring fetchConfig under the individual providers instead."
+    },
     "core": {
       "oneOf": [
         { "type": "object" },

--- a/test/e2e/resources/all-providers-custom-ns-versions.yaml
+++ b/test/e2e/resources/all-providers-custom-ns-versions.yaml
@@ -71,6 +71,9 @@ metadata:
     "argocd.argoproj.io/sync-wave": "2"
 spec:
   version: v0.2.6
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/all-providers-custom-versions.yaml
+++ b/test/e2e/resources/all-providers-custom-versions.yaml
@@ -71,6 +71,9 @@ metadata:
     "argocd.argoproj.io/sync-wave": "2"
 spec:
   version: v0.2.6
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/all-providers-latest-versions.yaml
+++ b/test/e2e/resources/all-providers-latest-versions.yaml
@@ -69,6 +69,10 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/bootstrap.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
+++ b/test/e2e/resources/all-providers-manager-defined-no-feature-gates.yaml
@@ -69,6 +69,10 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/feature-gates.yaml
+++ b/test/e2e/resources/feature-gates.yaml
@@ -69,6 +69,10 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: aws-variables
+    namespace: default
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/only-addon.yaml
+++ b/test/e2e/resources/only-addon.yaml
@@ -29,6 +29,10 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/core-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2

--- a/test/e2e/resources/only-infra-and-addon.yaml
+++ b/test/e2e/resources/only-infra-and-addon.yaml
@@ -59,6 +59,10 @@ metadata:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "2"
     "argocd.argoproj.io/sync-wave": "2"
+spec:
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
 ---
 # Source: cluster-api-operator/templates/infra-conditions.yaml
 apiVersion: operator.cluster.x-k8s.io/v1alpha2


### PR DESCRIPTION
**What this PR does / why we need it**:
This builds on the extensibility introduced in #638.

* This makes the connection between the `configSecret` and the component/provider using said config clearer.
* Reduces duplication of the `configSecret` logic across templates by moving it into a helper.
* Adds the ability to configure `fetchConfig`.

This has been implemented in such a way that it is backwards compatible and will default to the existing behaviour. If you want to use the new behaviour you would have to do something like this:

```yaml
core:
  cluster-api:
    version: v1.9.6
    configSecret:
      name: my-custom-core-config
      namespace: capi-system

infrastructure:
  azure:
    namespace: capz-system
    version: v1.19.1
    configSecret:
      name: azure-variables
      namespace: capz-system
```
while also removing the `configSecret` key at the root level of the `values.yaml` file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
