### PR TITLE
🌱 Update helm chart index.yaml to v0.19.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,16 @@ apiVersion: v1
 entries:
   cluster-api-operator:
   - apiVersion: v2
+    appVersion: 0.19.0
+    created: "2025-04-23T17:41:16.290068+03:00"
+    description: Cluster API Operator
+    digest: fa7f955239d7a4ed2d71844d4af9b3faffd801c8a4686b793eabee61f0a9cd3a
+    name: cluster-api-operator
+    type: application
+    urls:
+    - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.19.0/cluster-api-operator-0.19.0.tgz
+    version: 0.19.0
+  - apiVersion: v2
     appVersion: 0.18.1
     created: "2025-04-02T11:43:16.092682+03:00"
     description: Cluster API Operator
@@ -306,4 +316,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.2.0/cluster-api-operator-0.2.0.tgz
     version: 0.2.0
-generated: "2025-04-02T11:43:16.092789+03:00"
+generated: "2025-04-23T17:41:16.290161+03:00"

--- a/plugins/clusterctl-operator.yaml
+++ b/plugins/clusterctl-operator.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: operator
 spec:
-  version: v0.18.1
+  version: v0.19.0
   homepage: https://github.com/kubernetes-sigs/cluster-api-operator
   shortDescription: Use this clusterctl plugin to bootstrap a management cluster for Cluster API with the Cluster API Operator.
   description: |
@@ -13,36 +13,36 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.18.1/clusterctl-operator_v0.18.1_darwin_amd64.tar.gz
-    sha256: 49ff47935465deb8446b957ffa551008e603102d568d12dfaf00ef76a3bdda53
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.19.0/clusterctl-operator_v0.19.0_darwin_amd64.tar.gz
+    sha256: 007ed897f96a46288f0e48d155cfa339c01e97920f6f30fa0b303aab5d0a2912
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.18.1/clusterctl-operator_v0.18.1_darwin_arm64.tar.gz
-    sha256: e966756f41a1f0b4328902d15e7972d06999a959f758247e5e6a2e4a5e5d8a7b
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.19.0/clusterctl-operator_v0.19.0_darwin_arm64.tar.gz
+    sha256: 584611ba02f639631f8b6d6160b465482d0412344ad086255b70e1aee14077b6
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.18.1/clusterctl-operator_v0.18.1_linux_amd64.tar.gz
-    sha256: 9ccd83943dc83240d313842e2f4bedf5c8f412c0462f7acfdff8852411c78210
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.19.0/clusterctl-operator_v0.19.0_linux_amd64.tar.gz
+    sha256: 95166c4d245b1ed618ae95d5c9d5edacd59f1067273e38a2776bfcd674f8a7ac
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.18.1/clusterctl-operator_v0.18.1_linux_arm64.tar.gz
-    sha256: 011c0eeb4663613f9ffa3379a19d0c21ff36f868a846149131800f11aefa219d
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.19.0/clusterctl-operator_v0.19.0_linux_arm64.tar.gz
+    sha256: df40ddb0f61a7c7d306df7ec097e9f082a484d77f1d5532920763dfdb3aa83d9
     bin: bin/clusterctl-operator
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.18.1/clusterctl-operator_v0.18.1_windows_amd64.tar.gz
-    sha256: f7655dde21786dc50605d66de88db155af06beb67c600719dde3b3667189c707
+    uri: https://github.com/kubernetes-sigs/cluster-api-operator/releases/download/v0.19.0/clusterctl-operator_v0.19.0_windows_amd64.tar.gz
+    sha256: 20fd5720ac89e23e3f9a79b4d5de970bc654b1f23f2b4efe113e0806a06ba388
     bin: bin/clusterctl-operator.exe
 
 


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR updates index.yaml for v0.19.0.

Automatically generated by `make update-helm-repo`.