### PR TITLE
:bug: CAPI operator incorrectly finds the manager container if the number of containers is greater than one

### DIFF
--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -179,7 +179,14 @@ func customizeDeploymentSpec(dSpec operatorv1.DeploymentSpec, d *appsv1.Deployme
 // findManagerContainer finds manager container in the provider deployment.
 func findManagerContainer(dSpec *appsv1.DeploymentSpec) *corev1.Container {
 	for ic := range dSpec.Template.Spec.Containers {
-		return &dSpec.Template.Spec.Containers[ic]
+		if dSpec.Template.Spec.Containers[ic].Name == managerContainerName {
+			return &dSpec.Template.Spec.Containers[ic]
+		}
+	}
+
+	// This is for backward compatibility before fixing the issue https://github.com/kubernetes-sigs/cluster-api-operator/issues/787
+	if len(dSpec.Template.Spec.Containers) > 0 {
+		return &dSpec.Template.Spec.Containers[0]
 	}
 
 	return nil

--- a/internal/controller/component_customizer_test.go
+++ b/internal/controller/component_customizer_test.go
@@ -49,33 +49,39 @@ func TestCustomizeDeployment(t *testing.T) {
 					Name: "manager",
 				},
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "manager",
-						Image: "registry.k8s.io/a-manager:1.6.2",
-						Env: []corev1.EnvVar{
-							{
-								Name:  "test1",
-								Value: "value1",
-							},
+					Containers: []corev1.Container{
+						{
+							Name:  "kube-rbac-proxy",
+							Image: "registry.k8s.io/a-kube-rbac-proxy:v0.13.1",
 						},
-						Args: []string{"--webhook-port=2345"},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/healthz",
-									Port: intstr.FromString("healthz"),
+						{
+							Name:  "manager",
+							Image: "registry.k8s.io/a-manager:1.6.2",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "test1",
+									Value: "value1",
+								},
+							},
+							Args: []string{"--webhook-port=2345"},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromString("healthz"),
+									},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/readyz",
+										Port: intstr.FromString("healthz"),
+									},
 								},
 							},
 						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/readyz",
-									Port: intstr.FromString("healthz"),
-								},
-							},
-						},
-					}},
+					},
 				},
 			},
 		},
@@ -279,6 +285,10 @@ func TestCustomizeDeployment(t *testing.T) {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
+									Name:  "kube-rbac-proxy",
+									Image: "registry.k8s.io/a-kube-rbac-proxy:v0.13.1",
+								},
+								{
 									Name:  "manager",
 									Image: "quay.io/dev/mydns:v3.4.2",
 									Env: []corev1.EnvVar{
@@ -404,6 +414,10 @@ func TestCustomizeDeployment(t *testing.T) {
 							},
 							Containers: []corev1.Container{
 								{
+									Name:  "kube-rbac-proxy",
+									Image: "registry.k8s.io/a-kube-rbac-proxy:v0.13.1",
+								},
+								{
 									Name:  "manager",
 									Image: "quay.io/dev/mydns:v3.4.2",
 									Env: []corev1.EnvVar{
@@ -506,6 +520,10 @@ func TestCustomizeDeployment(t *testing.T) {
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
+								{
+									Name:  "kube-rbac-proxy",
+									Image: "registry.k8s.io/a-kube-rbac-proxy:v0.13.1",
+								},
 								{
 									Name:  "manager",
 									Image: "registry.k8s.io/a-manager:1.6.2",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #787 
