### PR TITLE
🌱 Fix spelling in controller metrics config description

### DIFF
--- a/api/v1alpha2/controllermanagerconfig_types.go
+++ b/api/v1alpha2/controllermanagerconfig_types.go
@@ -59,7 +59,7 @@ type ControllerManagerConfiguration struct {
 	// +optional
 	Controller *ControllerConfigurationSpec `json:"controller,omitempty"`
 
-	// Metrics contains thw controller metrics configuration
+	// Metrics contains the controller metrics configuration
 	// +optional
 	Metrics ControllerMetrics `json:"metrics,omitempty"`
 

--- a/config/crd/bases/operator.cluster.x-k8s.io_addonproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_addonproviders.yaml
@@ -1433,7 +1433,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2970,7 +2970,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
@@ -1433,7 +1433,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2970,7 +2970,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
@@ -1434,7 +1434,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2971,7 +2971,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
@@ -1433,7 +1433,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2970,7 +2970,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
@@ -1434,7 +1434,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2971,7 +2971,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_ipamproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_ipamproviders.yaml
@@ -1433,7 +1433,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2970,7 +2970,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_runtimeextensionproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_runtimeextensionproviders.yaml
@@ -1435,7 +1435,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2972,7 +2972,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -1458,7 +1458,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -2995,7 +2995,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-
@@ -4588,7 +4588,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -6125,7 +6125,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-
@@ -7719,7 +7719,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -9256,7 +9256,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-
@@ -10850,7 +10850,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -12387,7 +12387,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-
@@ -13981,7 +13981,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -15518,7 +15518,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-
@@ -17112,7 +17112,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -18649,7 +18649,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-
@@ -20244,7 +20244,7 @@ spec:
                           minimum: 1
                           type: integer
                         metrics:
-                          description: Metrics contains thw controller metrics configuration
+                          description: Metrics contains the controller metrics configuration
                           properties:
                             bindAddress:
                               description: |-
@@ -21781,7 +21781,7 @@ spec:
                     minimum: 1
                     type: integer
                   metrics:
-                    description: Metrics contains thw controller metrics configuration
+                    description: Metrics contains the controller metrics configuration
                     properties:
                       bindAddress:
                         description: |-


### PR DESCRIPTION
**What this PR does / why we need it**:

Mini spelling fix for the description of the controller metrics configuration.

