### PR TITLE
🌱 Pass global concurrency number to manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 150Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -54,7 +54,7 @@ resources:
   manager:
     limits:
       cpu: 100m
-      memory: 150Mi
+      memory: 300Mi
     requests:
       cpu: 100m
       memory: 100Mi

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -389,7 +389,7 @@ metadata:
 				g.Expect(fakeclient.Create(ctx, &tt.configMaps[i])).To(Succeed())
 			}
 
-			got, err := p.configmapRepository(context.TODO(), p.provider.GetSpec().FetchConfig.Selector, "ns1", tt.additionalManifests)
+			got, err := p.configmapRepository(context.TODO(), p.provider.GetSpec().FetchConfig.Selector, InNamespace("ns1"), WithAdditionalManifests(tt.additionalManifests))
 
 			if len(tt.wantErr) > 0 {
 				g.Expect(err).Should(MatchError(tt.wantErr))
@@ -596,7 +596,7 @@ releaseSeries:
 					MatchLabels: map[string]string{
 						operatorManagedLabel: "true",
 					},
-				}, "default", "")
+				}, InNamespace("default"))
 				g.Expect(err).To(Succeed())
 			}
 

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -22096,7 +22096,7 @@ spec:
         resources:
             limits:
               cpu: 100m
-              memory: 150Mi
+              memory: 300Mi
             requests:
               cpu: 100m
               memory: 100Mi


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR slightly improves memory footprint of the operator by implementing minor adjustments to the code:
- Skip components.yaml caching in upgrade scenario for all other providers except upgraded. Only metadata.yaml is important there.
- Pass concurrency number to the manager instance, allowing max X concurrent reconciles across different providers.
- Increases memory limits to 300Mi from 150Mi, since in current setup azure provider alone is able to bump memory usage to median of ~130Mi.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
