### PR TITLE
🌱 Added example for feature gate config within the helm-chart

### DIFF
--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -32,6 +32,15 @@ spec:
 {{- if $addonVersion }}
   version: {{ $addonVersion }}
 {{- end }}
+{{- if $.Values.manager }}
+{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.addon }}
+  manager:
+    featureGates:
+    {{- range $key, $value := $.Values.manager.featureGates.addon }}
+      {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+{{- end }}
 {{- if $.Values.secretName }}
   secretName: {{ $.Values.secretName }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -32,6 +32,15 @@ spec:
 {{- if $bootstrapVersion }}
   version: {{ $bootstrapVersion }}
 {{- end }}
+{{- if $.Values.manager }}
+{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.bootstrap }}
+  manager:
+    featureGates:
+    {{- range $key, $value := $.Values.manager.featureGates.bootstrap }}
+      {{ $key }}: {{ $value }}
+    {{- end }}
+{{- end }}
+{{- end }}
 {{- if $.Values.configSecret.name }}
   configSecret:
     name: {{ $.Values.configSecret.name }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -33,16 +33,12 @@ spec:
   version: {{ $controlPlaneVersion }}
 {{- end }}
 {{- if $.Values.manager }}
-{{- if hasKey $.Values.manager.featureGates $controlPlaneName }}
+{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.controlPlane }}
   manager:
-{{- range $key, $value := $.Values.manager.featureGates }}
-  {{- if eq $key $controlPlaneName }}
     featureGates:
-    {{- range $k, $v := $value }}
-      {{ $k }}: {{ $v }}
+    {{- range $key, $value := $.Values.manager.featureGates.controlPlane }}
+      {{ $key }}: {{ $value }}
     {{- end }}
-  {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if $.Values.configSecret.name }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -33,16 +33,12 @@ spec:
   version: {{ $infrastructureVersion }}
 {{- end }}
 {{- if $.Values.manager }}
-{{- if and (kindIs "map" $.Values.manager.featureGates) (hasKey $.Values.manager.featureGates $infrastructureName) }}
+{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.infrastructure }}
   manager:
-{{- range $key, $value := $.Values.manager.featureGates }}
-  {{- if eq $key $infrastructureName }}
     featureGates:
-    {{- range $k, $v := $value }}
-      {{ $k }}: {{ $v }}
+    {{- range $key, $value := $.Values.manager.featureGates.infrastructure }}
+      {{ $key }}: {{ $value }}
     {{- end }}
-  {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if and (kindIs "map" $.Values.fetchConfig) (hasKey $.Values.fetchConfig $infrastructureName) }}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -33,16 +33,12 @@ spec:
   version: {{ $ipamVersion }}
 {{- end }}
 {{- if $.Values.manager }}
-{{- if and (kindIs "map" $.Values.manager.featureGates) (hasKey $.Values.manager.featureGates $ipamName) }}
+{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.ipam }}
   manager:
-{{- range $key, $value := $.Values.manager.featureGates }}
-  {{- if eq $key $ipamName }}
     featureGates:
-    {{- range $k, $v := $value }}
-      {{ $k }}: {{ $v }}
+    {{- range $key, $value := $.Values.manager.featureGates.ipam }}
+      {{ $key }}: {{ $value }}
     {{- end }}
-  {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if $.Values.configSecret.name }}

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -25,7 +25,14 @@ ipam: {}
 # in-cluster: {}   # Name, required
 #   namespace: ""  # Optional
 #   version: ""    # Optional
-manager.featureGates: {}
+manager:
+  featureGates:
+    addon: {}
+    bootstrap: {}
+    core: {}
+    controlPlane: {}
+    infrastructure: {}
+    ipam: {}
 fetchConfig: {}
 # ---
 # Common configuration secret options


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently its not possible to enable feature-gates only for specific providers which were installed with the helm chart except for core. This PR uses the same approach for core but extended to all Providers. 

