### PR TITLE
🌱 Add examples for feature-gates in helm chart values.yaml

### DIFF
--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -26,7 +26,7 @@ ipam: {}
 #   namespace: ""  # Optional
 #   version: ""    # Optional
 manager.featureGates: {}
-# Configuration for enabling feature gates in diffrent providers
+# Configuration for enabling feature gates in different providers
 # manager: 
 #   featureGates:
 #     proxmox: # Name of the provider

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -27,9 +27,9 @@ ipam: {}
 #   version: ""    # Optional
 manager.featureGates: {}
 # Configuration for enabling feature gates in diffrent providers
-# manager: # example
+# manager: 
 #   featureGates:
-#     proxmox:
+#     proxmox: # Name of the provider
 #       ClusterTopology: true
 #     core:
 #       ClusterTopology: true

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -26,6 +26,15 @@ ipam: {}
 #   namespace: ""  # Optional
 #   version: ""    # Optional
 manager.featureGates: {}
+# Configuration for enabling feature gates in diffrent providers
+# manager: # example
+#   featureGates:
+#     proxmox:
+#       ClusterTopology: true
+#     core:
+#       ClusterTopology: true
+#     kubeadm:
+#       ClusterTopology: true
 fetchConfig: {}
 # ---
 # Common configuration secret options


### PR DESCRIPTION
**What this PR does / why we need it**:
I had a hard time while figuring out how to configure the feature-gates for providers in the helm-chart. I thought it would work like for core - so i tried `manager.featureGates.infrastructure`.
This PR adds a little example on how to get feature-gates working. 
