### PR TITLE
✨ add fetchConfig support to IPAMProvider in chart

### DIFF
--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -45,6 +45,16 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if and (kindIs "map" $.Values.fetchConfig) (hasKey $.Values.fetchConfig $ipamName) }}
+{{- range $key, $value := $.Values.fetchConfig }}
+  {{- if eq $key $ipamName }}
+  fetchConfig:
+    {{- range $k, $v := $value }}
+      {{ $k }}: {{ $v }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
 {{- if $.Values.configSecret.name }}
   configSecret:
     name: {{ $.Values.configSecret.name }}


### PR DESCRIPTION
**What this PR does / why we need it**:
While attempting to perform an air-gapped installation of the cluster-api operator using in-cluster IPAM, the helm chart does not utilize fetchConfig for the IPAMProvider CR, so there isn't a way to point the IPAM container to anything other than registry.k8s.io/capi-ipam-ic/cluster-api-ipam-in-cluster-controller:v1.0.1. Since I am trying to point all containers towards a local registry, I need to have the IPAMProvider fetch a LAN-located config which will point towards the disconnected container registry instead of generating its own. The IPAMProvider CRD already supports this, it just needs an update to the Helm chart to allow it to work properly.

Basically extending these steps:

https://cluster-api-operator.sigs.k8s.io/03_topics/02_configuration/01_air-gapped-environtment.html?highlight=air-gap#air-gapped-environment

But for the IPAM provider as well as the Infrastructure provider.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
