### PR TITLE
✨ Expose internal controllers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -244,6 +244,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchConfigSecretCh
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InfrastructureProvider")
 		os.Exit(1)
@@ -255,6 +256,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchConfigSecretCh
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BootstrapProvider")
 		os.Exit(1)
@@ -266,6 +268,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchConfigSecretCh
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ControlPlaneProvider")
 		os.Exit(1)
@@ -277,6 +280,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchConfigSecretCh
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AddonProvider")
 		os.Exit(1)
@@ -288,6 +292,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchConfigSecretCh
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IPAMProvider")
 		os.Exit(1)
@@ -299,6 +304,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchConfigSecretCh
 		Client:                   mgr.GetClient(),
 		Config:                   mgr.GetConfig(),
 		WatchConfigSecretChanges: watchConfigSecretChanges,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, mgr, concurrency(concurrencyNumber)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RuntimeExtensionProvider")
 		os.Exit(1)

--- a/controller/alias.go
+++ b/controller/alias.go
@@ -14,8 +14,52 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Package controller provides aliases for internal controller types and functions
+to allow external users to interact with the core controller logic.
+*/
 package controller
 
-import providercontroller "sigs.k8s.io/cluster-api-operator/internal/controller"
+import (
+	"context"
 
-type GenericProviderReconciler = providercontroller.GenericProviderReconciler
+	"k8s.io/client-go/rest"
+	internalcontroller "sigs.k8s.io/cluster-api-operator/internal/controller"
+	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
+	internalhealthcheck "sigs.k8s.io/cluster-api-operator/internal/controller/healthcheck"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// GenericProviderReconciler wraps the internal GenericProviderReconciler.
+type GenericProviderReconciler struct {
+	Provider                 genericprovider.GenericProvider
+	ProviderList             genericprovider.GenericProviderList
+	Client                   client.Client
+	Config                   *rest.Config
+	WatchConfigSecretChanges bool
+}
+
+// SetupWithManager sets up the GenericProviderReconciler with the Manager.
+func (r *GenericProviderReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return (&internalcontroller.GenericProviderReconciler{
+		Provider:                 r.Provider,
+		ProviderList:             r.ProviderList,
+		Client:                   r.Client,
+		Config:                   r.Config,
+		WatchConfigSecretChanges: r.WatchConfigSecretChanges,
+	}).SetupWithManager(ctx, mgr, options)
+}
+
+// ProviderHealthCheckReconciler wraps the internal ProviderHealthCheckReconciler.
+type ProviderHealthCheckReconciler struct {
+	Client client.Client
+}
+
+// SetupWithManager sets up the health check controllers with the Manager.
+func (r *ProviderHealthCheckReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return (&internalhealthcheck.ProviderHealthCheckReconciler{
+		Client: r.Client,
+	}).SetupWithManager(mgr, options)
+}

--- a/controller/alias.go
+++ b/controller/alias.go
@@ -21,45 +21,21 @@ to allow external users to interact with the core controller logic.
 package controller
 
 import (
-	"context"
-
-	"k8s.io/client-go/rest"
-	internalcontroller "sigs.k8s.io/cluster-api-operator/internal/controller"
-	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
+	providercontroller "sigs.k8s.io/cluster-api-operator/internal/controller"
 	internalhealthcheck "sigs.k8s.io/cluster-api-operator/internal/controller/healthcheck"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // GenericProviderReconciler wraps the internal GenericProviderReconciler.
-type GenericProviderReconciler struct {
-	Provider                 genericprovider.GenericProvider
-	ProviderList             genericprovider.GenericProviderList
-	Client                   client.Client
-	Config                   *rest.Config
-	WatchConfigSecretChanges bool
-}
+type GenericProviderReconciler = providercontroller.GenericProviderReconciler
 
-// SetupWithManager sets up the GenericProviderReconciler with the Manager.
-func (r *GenericProviderReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	return (&internalcontroller.GenericProviderReconciler{
-		Provider:                 r.Provider,
-		ProviderList:             r.ProviderList,
-		Client:                   r.Client,
-		Config:                   r.Config,
-		WatchConfigSecretChanges: r.WatchConfigSecretChanges,
-	}).SetupWithManager(ctx, mgr, options)
-}
+// GenericProviderHealthCheckReconciler wraps the internal GenericProviderHealthCheckReconciler.
+type GenericProviderHealthCheckReconciler = internalhealthcheck.GenericProviderHealthCheckReconciler
 
-// ProviderHealthCheckReconciler wraps the internal ProviderHealthCheckReconciler.
-type ProviderHealthCheckReconciler struct {
-	Client client.Client
-}
+// PhaseFn is an alias for the internal PhaseFn type.
+type PhaseFn = providercontroller.PhaseFn
 
-// SetupWithManager sets up the health check controllers with the Manager.
-func (r *ProviderHealthCheckReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	return (&internalhealthcheck.ProviderHealthCheckReconciler{
-		Client: r.Client,
-	}).SetupWithManager(mgr, options)
-}
+// Result is an alias for the internal Result type.
+type Result = providercontroller.Result
+
+// NewPhaseReconciler is an alias for the internal NewPhaseReconciler function.
+var NewPhaseReconciler = providercontroller.NewPhaseReconciler

--- a/internal/controller/manifests_downloader.go
+++ b/internal/controller/manifests_downloader.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	"sigs.k8s.io/cluster-api-operator/util"
@@ -47,14 +46,14 @@ const (
 )
 
 // downloadManifests downloads CAPI manifests from a url.
-func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) downloadManifests(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Return immediately if a custom config map is used instead of a url.
 	if p.provider.GetSpec().FetchConfig != nil && p.provider.GetSpec().FetchConfig.Selector != nil {
 		log.V(5).Info("Custom config map is used, skip downloading provider manifests")
 
-		return reconcile.Result{}, nil
+		return &Result{}, nil
 	}
 
 	// Check if manifests are already downloaded and stored in a configmap
@@ -64,13 +63,13 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 
 	exists, err := p.checkConfigMapExists(ctx, labelSelector, p.provider.GetNamespace())
 	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, "failed to check that config map with manifests exists", operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, "failed to check that config map with manifests exists", operatorv1.ProviderInstalledCondition)
 	}
 
 	if exists {
 		log.V(5).Info("Config map with downloaded manifests already exists, skip downloading provider manifests")
 
-		return reconcile.Result{}, nil
+		return &Result{}, nil
 	}
 
 	log.Info("Downloading provider manifests")
@@ -80,7 +79,7 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 		if err != nil {
 			err = fmt.Errorf("failed to create repo from provider url for provider %q: %w", p.provider.GetName(), err)
 
-			return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
+			return &Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 		}
 	}
 
@@ -100,26 +99,26 @@ func (p *phaseReconciler) downloadManifests(ctx context.Context) (reconcile.Resu
 	if p.provider.GetSpec().FetchConfig != nil && p.provider.GetSpec().FetchConfig.OCI != "" {
 		configMap, err = OCIConfigMap(ctx, p.provider, OCIAuthentication(p.configClient.Variables()))
 		if err != nil {
-			return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
+			return &Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 		}
 	} else {
 		configMap, err = RepositoryConfigMap(ctx, p.provider, p.repo)
 		if err != nil {
 			err = fmt.Errorf("failed to create config map for provider %q: %w", p.provider.GetName(), err)
 
-			return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
+			return &Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 		}
 	}
 
 	if err := p.ctrlClient.Create(ctx, configMap); client.IgnoreAlreadyExists(err) != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
-	return reconcile.Result{}, nil
+	return &Result{}, nil
 }
 
 // checkConfigMapExists checks if a config map exists in Kubernetes with the given LabelSelector.
-func (p *phaseReconciler) checkConfigMapExists(ctx context.Context, labelSelector metav1.LabelSelector, namespace string) (bool, error) {
+func (p *PhaseReconciler) checkConfigMapExists(ctx context.Context, labelSelector metav1.LabelSelector, namespace string) (bool, error) {
 	labelSet := labels.Set(labelSelector.MatchLabels)
 	listOpts := []client.ListOption{
 		client.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labelSet)},
@@ -140,7 +139,7 @@ func (p *phaseReconciler) checkConfigMapExists(ctx context.Context, labelSelecto
 }
 
 // prepareConfigMapLabels returns labels that identify a config map with downloaded manifests.
-func (p *phaseReconciler) prepareConfigMapLabels() map[string]string {
+func (p *PhaseReconciler) prepareConfigMapLabels() map[string]string {
 	return ProviderLabels(p.provider)
 }
 

--- a/internal/controller/manifests_downloader.go
+++ b/internal/controller/manifests_downloader.go
@@ -45,8 +45,8 @@ const (
 	ociSource        = "oci"
 )
 
-// downloadManifests downloads CAPI manifests from a url.
-func (p *PhaseReconciler) downloadManifests(ctx context.Context) (*Result, error) {
+// DownloadManifests downloads CAPI manifests from a url.
+func (p *PhaseReconciler) DownloadManifests(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Return immediately if a custom config map is used instead of a url.

--- a/internal/controller/manifests_downloader_test.go
+++ b/internal/controller/manifests_downloader_test.go
@@ -51,10 +51,10 @@ func TestManifestsDownloader(t *testing.T) {
 		},
 	}
 
-	_, err := p.initializePhaseReconciler(ctx)
+	_, err := p.InitializePhaseReconciler(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = p.downloadManifests(ctx)
+	_, err = p.DownloadManifests(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Ensure that config map was created
@@ -94,16 +94,16 @@ func TestProviderDownloadWithOverrides(t *testing.T) {
 		overridesClient: overridesClient,
 	}
 
-	_, err = p.initializePhaseReconciler(ctx)
+	_, err = p.InitializePhaseReconciler(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = p.downloadManifests(ctx)
+	_, err = p.DownloadManifests(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = p.load(ctx)
+	_, err = p.Load(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = p.fetch(ctx)
+	_, err = p.Fetch(ctx)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	g.Expect(p.components.Images()).To(HaveExactElements([]string{"registry.k8s.io/cluster-api/cluster-api-controller:v1.4.3"}))

--- a/internal/controller/manifests_downloader_test.go
+++ b/internal/controller/manifests_downloader_test.go
@@ -36,7 +36,7 @@ func TestManifestsDownloader(t *testing.T) {
 
 	fakeclient := fake.NewClientBuilder().WithObjects().Build()
 
-	p := &phaseReconciler{
+	p := &PhaseReconciler{
 		ctrlClient: fakeclient,
 		provider: &operatorv1.CoreProvider{
 			ObjectMeta: metav1.ObjectMeta{
@@ -82,7 +82,7 @@ func TestProviderDownloadWithOverrides(t *testing.T) {
 	overridesClient, err := configclient.New(ctx, "", configclient.InjectReader(reader))
 	g.Expect(err).ToNot(HaveOccurred())
 
-	p := &phaseReconciler{
+	p := &PhaseReconciler{
 		ctrlClient: fakeclient,
 		provider: &operatorv1.CoreProvider{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,15 +46,14 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // fakeURL is the stub url for custom providers, missing from clusterctl repository.
 const fakeURL = "https://example.com/my-provider"
 
-// phaseReconciler holds all required information for interacting with clusterctl code and
+// PhaseReconciler holds all required information for interacting with clusterctl code and
 // helps to iterate through provider reconciliation phases.
-type phaseReconciler struct {
+type PhaseReconciler struct {
 	provider     genericprovider.GenericProvider
 	providerList genericprovider.GenericProviderList
 
@@ -69,8 +69,31 @@ type phaseReconciler struct {
 	clusterctlProvider *clusterctlv1.Provider
 }
 
-// reconcilePhaseFn is a function that represent a phase of the reconciliation.
-type reconcilePhaseFn func(context.Context) (reconcile.Result, error)
+// PhaseFn is a function that represent a phase of the reconciliation.
+type PhaseFn func(context.Context) (*Result, error)
+
+// Result holds the result and error from a reconciliation phase.
+type Result struct {
+	// Requeue tells the Controller to requeue the reconcile key.  Defaults to false.
+	Requeue bool
+
+	// RequeueAfter if greater than 0, tells the Controller to requeue the reconcile key after the Duration.
+	// Implies that Requeue is true, there is no need to set Requeue to true at the same time as RequeueAfter.
+	RequeueAfter time.Duration
+
+	// Completed indicates if this phase finalized the reconcile process.
+	Completed bool
+}
+
+// // PhaseReconciler defines the interface for a provider phase reconciler.
+// type PhaseReconciler interface {
+// 	// GetPhases returns the list of reconciliation phases.
+// 	GetPhases() []PhaseFn
+// }
+
+func (r *Result) IsZero() bool {
+	return r == nil || *r == Result{}
+}
 
 // PhaseError custom error type for phases.
 type PhaseError struct {
@@ -97,9 +120,9 @@ func wrapPhaseError(err error, reason string, condition clusterv1.ConditionType)
 	}
 }
 
-// newPhaseReconciler returns phase reconciler for the given provider.
-func newPhaseReconciler(r GenericProviderReconciler, provider genericprovider.GenericProvider, providerList genericprovider.GenericProviderList) *phaseReconciler {
-	return &phaseReconciler{
+// NewPhaseReconciler returns phase reconciler for the given provider.
+func NewPhaseReconciler(r GenericProviderReconciler, provider genericprovider.GenericProvider, providerList genericprovider.GenericProviderList) *PhaseReconciler {
+	return &PhaseReconciler{
 		ctrlClient:         r.Client,
 		ctrlConfig:         r.Config,
 		clusterctlProvider: &clusterctlv1.Provider{},
@@ -138,23 +161,23 @@ func (i InNamespace) ApplyToConfigMapRepository(settings *ConfigMapRepositorySet
 }
 
 // preflightChecks a wrapper around the preflight checks.
-func (p *phaseReconciler) preflightChecks(ctx context.Context) (reconcile.Result, error) {
-	return reconcile.Result{}, preflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
+func (p *PhaseReconciler) preflightChecks(ctx context.Context) (*Result, error) {
+	return &Result{}, preflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
 }
 
 // initializePhaseReconciler initializes phase reconciler.
-func (p *phaseReconciler) initializePhaseReconciler(ctx context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) initializePhaseReconciler(ctx context.Context) (*Result, error) {
 	path := configPath
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		path = ""
 	} else if err != nil {
-		return reconcile.Result{}, err
+		return &Result{}, err
 	}
 
 	// Initialize a client for interacting with the clusterctl configuration.
 	initConfig, err := configclient.New(ctx, path)
 	if err != nil {
-		return reconcile.Result{}, err
+		return &Result{}, err
 	} else if path != "" {
 		// Set the image and providers override client
 		p.overridesClient = initConfig
@@ -165,7 +188,7 @@ func (p *phaseReconciler) initializePhaseReconciler(ctx context.Context) (reconc
 	if p.overridesClient != nil {
 		providers, err := p.overridesClient.Providers().List()
 		if err != nil {
-			return reconcile.Result{}, err
+			return &Result{}, err
 		}
 
 		overrideProviders = providers
@@ -173,39 +196,39 @@ func (p *phaseReconciler) initializePhaseReconciler(ctx context.Context) (reconc
 
 	reader, err := p.secretReader(ctx, overrideProviders...)
 	if err != nil {
-		return reconcile.Result{}, err
+		return &Result{}, err
 	}
 
 	// Get all custom providers using fetchConfig that aren't the current provider.
 	customProviders, err := util.GetCustomProviders(ctx, p.ctrlClient, p.provider)
 	if err != nil {
-		return reconcile.Result{}, err
+		return &Result{}, err
 	}
 
 	// Load all custom providers into MemoryReader.
 	reader, err = loadCustomProviders(customProviders, reader)
 	if err != nil {
-		return reconcile.Result{}, err
+		return &Result{}, err
 	}
 
 	// Load provider's secret and config url.
 	p.configClient, err = configclient.New(ctx, "", configclient.InjectReader(reader))
 	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, "failed to load the secret reader", operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, "failed to load the secret reader", operatorv1.ProviderInstalledCondition)
 	}
 
 	// Get returns the configuration for the provider with a given name/type.
 	// This is done using clusterctl internal API types.
 	p.providerConfig, err = p.configClient.Providers().Get(p.provider.GetName(), util.ClusterctlProviderType(p.provider))
 	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.UnknownProviderReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.UnknownProviderReason, operatorv1.ProviderInstalledCondition)
 	}
 
-	return reconcile.Result{}, nil
+	return &Result{}, nil
 }
 
 // load provider specific configuration into phaseReconciler object.
-func (p *phaseReconciler) load(ctx context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) load(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	log.Info("Loading provider")
@@ -225,24 +248,24 @@ func (p *phaseReconciler) load(ctx context.Context) (reconcile.Result, error) {
 
 	additionalManifests, err := p.fetchAdditionalManifests(ctx)
 	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, "failed to load additional manifests", operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, "failed to load additional manifests", operatorv1.ProviderInstalledCondition)
 	}
 
 	p.repo, err = p.configmapRepository(ctx, labelSelector, InNamespace(p.provider.GetNamespace()), WithAdditionalManifests(additionalManifests))
 	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, "failed to load the repository", operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, "failed to load the repository", operatorv1.ProviderInstalledCondition)
 	}
 
 	if spec.Version == "" {
 		// User didn't set the version, so we need to find the latest one from the matching config maps.
 		repoVersions, err := p.repo.GetVersions(ctx)
 		if err != nil {
-			return reconcile.Result{}, wrapPhaseError(err, fmt.Sprintf("failed to get a list of available versions for provider %q", p.provider.GetName()), operatorv1.ProviderInstalledCondition)
+			return &Result{}, wrapPhaseError(err, fmt.Sprintf("failed to get a list of available versions for provider %q", p.provider.GetName()), operatorv1.ProviderInstalledCondition)
 		}
 
 		spec.Version, err = getLatestVersion(repoVersions)
 		if err != nil {
-			return reconcile.Result{}, wrapPhaseError(err, fmt.Sprintf("failed to get the latest version for provider %q", p.provider.GetName()), operatorv1.ProviderInstalledCondition)
+			return &Result{}, wrapPhaseError(err, fmt.Sprintf("failed to get the latest version for provider %q", p.provider.GetName()), operatorv1.ProviderInstalledCondition)
 		}
 
 		// Add latest version to the provider spec.
@@ -257,15 +280,15 @@ func (p *phaseReconciler) load(ctx context.Context) (reconcile.Result, error) {
 	}
 
 	if err := p.validateRepoCAPIVersion(ctx); err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.CAPIVersionIncompatibilityReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.CAPIVersionIncompatibilityReason, operatorv1.ProviderInstalledCondition)
 	}
 
-	return reconcile.Result{}, nil
+	return &Result{}, nil
 }
 
 // secretReader use clusterctl MemoryReader structure to store the configuration variables
 // that are obtained from a secret and try to set fetch url config.
-func (p *phaseReconciler) secretReader(ctx context.Context, providers ...configclient.Provider) (configclient.Reader, error) {
+func (p *PhaseReconciler) secretReader(ctx context.Context, providers ...configclient.Provider) (configclient.Reader, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	mr := configclient.NewMemoryReader()
@@ -328,7 +351,7 @@ func (p *phaseReconciler) secretReader(ctx context.Context, providers ...configc
 
 // configmapRepository use clusterctl NewMemoryRepository structure to store the manifests
 // and metadata from a given configmap.
-func (p *phaseReconciler) configmapRepository(ctx context.Context, labelSelector *metav1.LabelSelector, options ...ConfigMapRepositoryOption) (repository.Repository, error) {
+func (p *PhaseReconciler) configmapRepository(ctx context.Context, labelSelector *metav1.LabelSelector, options ...ConfigMapRepositoryOption) (repository.Repository, error) {
 	mr := repository.NewMemoryRepository()
 	mr.WithPaths("", "components.yaml")
 
@@ -402,7 +425,7 @@ func (p *phaseReconciler) configmapRepository(ctx context.Context, labelSelector
 	return mr, nil
 }
 
-func (p *phaseReconciler) fetchAdditionalManifests(ctx context.Context) (string, error) {
+func (p *PhaseReconciler) fetchAdditionalManifests(ctx context.Context) (string, error) {
 	cm := &corev1.ConfigMap{}
 
 	if p.provider.GetSpec().AdditionalManifestsRef != nil {
@@ -452,7 +475,7 @@ func getComponentsData(cm corev1.ConfigMap) (string, error) {
 }
 
 // validateRepoCAPIVersion checks that the repo is using the correct version.
-func (p *phaseReconciler) validateRepoCAPIVersion(ctx context.Context) error {
+func (p *PhaseReconciler) validateRepoCAPIVersion(ctx context.Context) error {
 	name := p.provider.GetName()
 
 	file, err := p.repo.GetFile(ctx, p.options.Version, metadataFile)
@@ -489,7 +512,7 @@ func (p *phaseReconciler) validateRepoCAPIVersion(ctx context.Context) error {
 }
 
 // fetch fetches the provider components from the repository and processes all yaml manifests.
-func (p *phaseReconciler) fetch(ctx context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) fetch(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Fetching provider")
 
@@ -498,7 +521,7 @@ func (p *phaseReconciler) fetch(ctx context.Context) (reconcile.Result, error) {
 	if err != nil {
 		err = fmt.Errorf("failed to read %q from provider's repository %q: %w", p.repo.ComponentsPath(), p.providerConfig.ManifestLabel(), err)
 
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	// Generate a set of new objects using the clusterctl library. NewComponents() will do the yaml processing,
@@ -512,43 +535,43 @@ func (p *phaseReconciler) fetch(ctx context.Context) (reconcile.Result, error) {
 		Options:      p.options,
 	})
 	if err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	// ProviderSpec provides fields for customizing the provider deployment options.
 	// We can use clusterctl library to apply this customizations.
 	if err := repository.AlterComponents(p.components, customizeObjectsFn(p.provider)); err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsCustomizationErrorReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.ComponentsCustomizationErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	// Apply patches to the provider components if specified.
 	if err := repository.AlterComponents(p.components, applyPatches(ctx, p.provider)); err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsPatchErrorReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.ComponentsPatchErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	// Apply image overrides to the provider manifests.
 	if err := repository.AlterComponents(p.components, imageOverrides(p.components.ManifestLabel(), p.overridesClient)); err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsImageOverrideErrorReason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.ComponentsImageOverrideErrorReason, operatorv1.ProviderInstalledCondition)
 	}
 
 	conditions.Set(p.provider, conditions.TrueCondition(operatorv1.ProviderInstalledCondition))
 
-	return reconcile.Result{}, nil
+	return &Result{}, nil
 }
 
 // upgrade ensure all the clusterctl CRDs are available before installing the provider,
 // and update existing components if required.
-func (p *phaseReconciler) upgrade(ctx context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) upgrade(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Nothing to do if it's a fresh installation.
 	if p.provider.GetStatus().InstalledVersion == nil {
-		return reconcile.Result{}, nil
+		return &Result{}, nil
 	}
 
 	// Provider needs to be re-installed
 	if *p.provider.GetStatus().InstalledVersion == p.provider.GetSpec().Version {
-		return reconcile.Result{}, nil
+		return &Result{}, nil
 	}
 
 	log.Info("Version changes detected, updating existing components")
@@ -557,22 +580,22 @@ func (p *phaseReconciler) upgrade(ctx context.Context) (reconcile.Result, error)
 		NextVersion: p.provider.GetSpec().Version,
 		Provider:    getProvider(p.provider, p.options.Version),
 	}); err != nil {
-		return reconcile.Result{}, wrapPhaseError(err, operatorv1.ComponentsUpgradeErrorReason, operatorv1.ProviderUpgradedCondition)
+		return &Result{}, wrapPhaseError(err, operatorv1.ComponentsUpgradeErrorReason, operatorv1.ProviderUpgradedCondition)
 	}
 
 	log.Info("Provider successfully upgraded")
 	conditions.Set(p.provider, conditions.TrueCondition(operatorv1.ProviderUpgradedCondition))
 
-	return reconcile.Result{}, nil
+	return &Result{}, nil
 }
 
 // install installs the provider components using clusterctl library.
-func (p *phaseReconciler) install(ctx context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) install(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Provider was upgraded, nothing to do
 	if p.provider.GetStatus().InstalledVersion != nil && *p.provider.GetStatus().InstalledVersion != p.provider.GetSpec().Version {
-		return reconcile.Result{}, nil
+		return &Result{}, nil
 	}
 
 	clusterClient := p.newClusterClient()
@@ -585,23 +608,23 @@ func (p *phaseReconciler) install(ctx context.Context) (reconcile.Result, error)
 			reason = "Timed out waiting for deployment to become ready"
 		}
 
-		return reconcile.Result{}, wrapPhaseError(err, reason, operatorv1.ProviderInstalledCondition)
+		return &Result{}, wrapPhaseError(err, reason, operatorv1.ProviderInstalledCondition)
 	}
 
 	log.Info("Provider successfully installed")
 	conditions.Set(p.provider, conditions.TrueCondition(operatorv1.ProviderInstalledCondition))
 
-	return reconcile.Result{}, nil
+	return &Result{}, nil
 }
 
-func (p *phaseReconciler) reportStatus(_ context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) reportStatus(_ context.Context) (*Result, error) {
 	status := p.provider.GetStatus()
 	status.Contract = &p.contract
 	installedVersion := p.components.Version()
 	status.InstalledVersion = &installedVersion
 	p.provider.SetStatus(status)
 
-	return reconcile.Result{}, nil
+	return &Result{}, nil
 }
 
 func getProvider(provider operatorv1.GenericProvider, defaultVersion string) clusterctlv1.Provider {
@@ -643,7 +666,7 @@ func loadCustomProviders(providers []operatorv1.GenericProvider, reader configcl
 }
 
 // delete deletes the provider components using clusterctl library.
-func (p *phaseReconciler) delete(ctx context.Context) (reconcile.Result, error) {
+func (p *PhaseReconciler) delete(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Deleting provider")
 
@@ -655,7 +678,7 @@ func (p *phaseReconciler) delete(ctx context.Context) (reconcile.Result, error) 
 		IncludeCRDs:      false,
 	})
 
-	return reconcile.Result{}, wrapPhaseError(err, operatorv1.OldComponentsDeletionErrorReason, operatorv1.ProviderInstalledCondition)
+	return &Result{}, wrapPhaseError(err, operatorv1.OldComponentsDeletionErrorReason, operatorv1.ProviderInstalledCondition)
 }
 
 func clusterctlProviderName(provider operatorv1.GenericProvider) client.ObjectKey {
@@ -678,7 +701,7 @@ func clusterctlProviderName(provider operatorv1.GenericProvider) client.ObjectKe
 	return client.ObjectKey{Name: prefix + provider.GetName(), Namespace: provider.GetNamespace()}
 }
 
-func (p *phaseReconciler) repositoryProxy(ctx context.Context, provider configclient.Provider, configClient configclient.Client, options ...repository.Option) (repository.Client, error) {
+func (p *PhaseReconciler) repositoryProxy(ctx context.Context, provider configclient.Provider, configClient configclient.Client, options ...repository.Option) (repository.Client, error) {
 	injectRepo := p.repo
 
 	if !provider.SameAs(p.providerConfig) {
@@ -713,7 +736,7 @@ func (p *phaseReconciler) repositoryProxy(ctx context.Context, provider configcl
 }
 
 // newClusterClient returns a clusterctl client for interacting with management cluster.
-func (p *phaseReconciler) newClusterClient() cluster.Client {
+func (p *PhaseReconciler) newClusterClient() cluster.Client {
 	return cluster.New(cluster.Kubeconfig{}, p.configClient, cluster.InjectProxy(&controllerProxy{
 		ctrlClient: clientProxy{p.ctrlClient},
 		ctrlConfig: p.ctrlConfig,

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -85,12 +85,6 @@ type Result struct {
 	Completed bool
 }
 
-// // PhaseReconciler defines the interface for a provider phase reconciler.
-// type PhaseReconciler interface {
-// 	// GetPhases returns the list of reconciliation phases.
-// 	GetPhases() []PhaseFn
-// }
-
 func (r *Result) IsZero() bool {
 	return r == nil || *r == Result{}
 }

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -160,13 +160,13 @@ func (i InNamespace) ApplyToConfigMapRepository(settings *ConfigMapRepositorySet
 	settings.namespace = string(i)
 }
 
-// preflightChecks a wrapper around the preflight checks.
-func (p *PhaseReconciler) preflightChecks(ctx context.Context) (*Result, error) {
+// PreflightChecks a wrapper around the preflight checks.
+func (p *PhaseReconciler) PreflightChecks(ctx context.Context) (*Result, error) {
 	return &Result{}, preflightChecks(ctx, p.ctrlClient, p.provider, p.providerList)
 }
 
-// initializePhaseReconciler initializes phase reconciler.
-func (p *PhaseReconciler) initializePhaseReconciler(ctx context.Context) (*Result, error) {
+// InitializePhaseReconciler initializes phase reconciler.
+func (p *PhaseReconciler) InitializePhaseReconciler(ctx context.Context) (*Result, error) {
 	path := configPath
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		path = ""
@@ -227,8 +227,8 @@ func (p *PhaseReconciler) initializePhaseReconciler(ctx context.Context) (*Resul
 	return &Result{}, nil
 }
 
-// load provider specific configuration into phaseReconciler object.
-func (p *PhaseReconciler) load(ctx context.Context) (*Result, error) {
+// Load provider specific configuration into phaseReconciler object.
+func (p *PhaseReconciler) Load(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	log.Info("Loading provider")
@@ -511,8 +511,8 @@ func (p *PhaseReconciler) validateRepoCAPIVersion(ctx context.Context) error {
 	return nil
 }
 
-// fetch fetches the provider components from the repository and processes all yaml manifests.
-func (p *PhaseReconciler) fetch(ctx context.Context) (*Result, error) {
+// Fetch fetches the provider components from the repository and processes all yaml manifests.
+func (p *PhaseReconciler) Fetch(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Fetching provider")
 
@@ -559,9 +559,9 @@ func (p *PhaseReconciler) fetch(ctx context.Context) (*Result, error) {
 	return &Result{}, nil
 }
 
-// upgrade ensure all the clusterctl CRDs are available before installing the provider,
+// Upgrade ensure all the clusterctl CRDs are available before installing the provider,
 // and update existing components if required.
-func (p *PhaseReconciler) upgrade(ctx context.Context) (*Result, error) {
+func (p *PhaseReconciler) Upgrade(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Nothing to do if it's a fresh installation.
@@ -589,8 +589,8 @@ func (p *PhaseReconciler) upgrade(ctx context.Context) (*Result, error) {
 	return &Result{}, nil
 }
 
-// install installs the provider components using clusterctl library.
-func (p *PhaseReconciler) install(ctx context.Context) (*Result, error) {
+// Install installs the provider components using clusterctl library.
+func (p *PhaseReconciler) Install(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Provider was upgraded, nothing to do
@@ -617,7 +617,7 @@ func (p *PhaseReconciler) install(ctx context.Context) (*Result, error) {
 	return &Result{}, nil
 }
 
-func (p *PhaseReconciler) reportStatus(_ context.Context) (*Result, error) {
+func (p *PhaseReconciler) ReportStatus(_ context.Context) (*Result, error) {
 	status := p.provider.GetStatus()
 	status.Contract = &p.contract
 	installedVersion := p.components.Version()
@@ -665,8 +665,8 @@ func loadCustomProviders(providers []operatorv1.GenericProvider, reader configcl
 	return mr, nil
 }
 
-// delete deletes the provider components using clusterctl library.
-func (p *PhaseReconciler) delete(ctx context.Context) (*Result, error) {
+// Delete deletes the provider components using clusterctl library.
+func (p *PhaseReconciler) Delete(ctx context.Context) (*Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Deleting provider")
 

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -42,7 +42,7 @@ func TestSecretReader(t *testing.T) {
 	secretName := "test-secret"
 	secretNamespace := "test-secret-namespace"
 
-	p := &phaseReconciler{
+	p := &PhaseReconciler{
 		ctrlClient: fakeclient,
 		provider: &operatorv1.CoreProvider{
 			ObjectMeta: metav1.ObjectMeta{
@@ -380,7 +380,7 @@ metadata:
 			g := NewWithT(t)
 
 			fakeclient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(provider).Build()
-			p := &phaseReconciler{
+			p := &PhaseReconciler{
 				ctrlClient: fakeclient,
 				provider:   provider,
 			}
@@ -579,7 +579,7 @@ releaseSeries:
 			g := NewWithT(t)
 
 			fakeclient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tt.genericProviders...).Build()
-			p := &phaseReconciler{
+			p := &PhaseReconciler{
 				ctrlClient:     fakeclient,
 				providerConfig: coreProvider,
 				repo:           repository.NewMemoryRepository(),

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -58,6 +58,7 @@ func TestMain(m *testing.M) {
 		ProviderList:             &operatorv1.InfrastructureProviderList{},
 		Client:                   env,
 		WatchConfigSecretChanges: true,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start InfrastructureProviderReconciler: %v", err))
 	}
@@ -67,6 +68,7 @@ func TestMain(m *testing.M) {
 		ProviderList:             &operatorv1.BootstrapProviderList{},
 		Client:                   env,
 		WatchConfigSecretChanges: true,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start BootstrapProviderReconciler: %v", err))
 	}
@@ -76,6 +78,7 @@ func TestMain(m *testing.M) {
 		ProviderList:             &operatorv1.ControlPlaneProviderList{},
 		Client:                   env,
 		WatchConfigSecretChanges: true,
+		WatchCoreProviderChanges: true,
 	}).SetupWithManager(ctx, env.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		panic(fmt.Sprintf("Failed to start ControlPlaneProviderReconciler: %v", err))
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR refactors the generic provider reconciliation logic to expose internal controllers and phases through the `controller/alias.go` file. This change allows external users to construct and interact with the core controller logic outside the operator pod.

- Introduce and expose a phase-based framework for generic provider reconciliation.
- Define and expose a custom `Result` type to avoid controller-runtime dependency on import.
- Enable selectable watching of CoreProvider changes for non-core provider types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #798 
