### PR TITLE
🌱 Remove deprecated cert-manager.enabled parameter references

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,13 +52,13 @@ The `--wait` flag is REQUIRED for the helm install command to work. If the --wai
 </aside>
 
 ```bash
-helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure.docker.enabled=true --set cert-manager.enabled=true --set configSecret.name=${CREDENTIALS_SECRET_NAME} --set configSecret.namespace=${CREDENTIALS_SECRET_NAMESPACE}  --wait --timeout 90s
+helm install capi-operator capi-operator/cluster-api-operator --create-namespace -n capi-operator-system --set infrastructure.docker.enabled=true --set configSecret.name=${CREDENTIALS_SECRET_NAME} --set configSecret.namespace=${CREDENTIALS_SECRET_NAMESPACE}  --wait --timeout 90s
 ```
 
 Docker provider can be replaced by any provider supported by [clusterctl](https://cluster-api.sigs.k8s.io/reference/providers.html#infrastructure).
 
 Other options for installing Cluster API Operator are described in [full documentation](https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/docs/README.md#installation).
- 
+
 # Example API Usage
 
 Deploy latest version of core Cluster API components:
@@ -69,7 +69,6 @@ kind: CoreProvider
 metadata:
   name: cluster-api
   namespace: capi-system
-
 ```
 
 Deploy Cluster API AWS provider with specific version, custom manager options and flags:

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -355,8 +355,6 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 			"ipam.in-cluster.enabled":                   "true",
 			"addon.helm.enabled":                        "true",
 			"image.manager.tag":                         "v0.9.1",
-			"cert-manager.enabled":                      "false",
-			"cert-manager.installCRDs":                  "false",
 			"core.cluster-api.version":                  "v1.6.2",
 			"manager.featureGates.core.ClusterTopology": "true",
 			"manager.featureGates.core.MachinePool":     "true",
@@ -373,14 +371,12 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 	})
 	It("should deploy all providers with manager defined but no feature gates enabled", func() {
 		manifests, err := helmChart.Run(map[string]string{
-			"configSecret.name":                "test-secret-name",
-			"configSecret.namespace":           "test-secret-namespace",
-			"core.cluster-api.enabled":         "true",
-			"infrastructure.azure.enabled":     "true",
-			"ipam.in-cluster.enabled":          "true",
-			"addon.helm.enabled":               "true",
-			"manager.cert-manager.enabled":     "false",
-			"manager.cert-manager.installCRDs": "false",
+			"configSecret.name":            "test-secret-name",
+			"configSecret.namespace":       "test-secret-namespace",
+			"core.cluster-api.enabled":     "true",
+			"infrastructure.azure.enabled": "true",
+			"ipam.in-cluster.enabled":      "true",
+			"addon.helm.enabled":           "true",
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).ToNot(BeEmpty())


### PR DESCRIPTION
## What this PR does / why we need it

This PR removes all references to the deprecated `cert-manager.enabled` parameter from the codebase. 

Starting with v0.11.0, the Helm chart no longer includes cert-manager as a dependency, making these parameters ineffective. This cleanup ensures our documentation and tests reflect the current state of the project.

## Which issue(s) this PR fixes

Fixes #(issue number if applicable)

## Special notes for your reviewer

The `cert-manager.enabled` parameter and related settings were removed from the Helm chart dependencies in v0.11.0 (released June 2024). These parameters have been non-functional since then, so their removal has no impact on functionality.
