### PR TITLE
✨ Expose clusterctl provider dependent logic for custom provider building

### DIFF
--- a/api/v1alpha2/addonprovider_wrapper.go
+++ b/api/v1alpha2/addonprovider_wrapper.go
@@ -50,6 +50,10 @@ func (b *AddonProvider) GetType() string {
 	return "addon"
 }
 
+func (b *AddonProvider) ProviderName() string {
+	return b.GetName()
+}
+
 func (b *AddonProviderList) GetItems() []GenericProvider {
 	providers := []GenericProvider{}
 

--- a/api/v1alpha2/bootstrapprovider_wrapper.go
+++ b/api/v1alpha2/bootstrapprovider_wrapper.go
@@ -50,6 +50,10 @@ func (b *BootstrapProvider) GetType() string {
 	return "bootstrap"
 }
 
+func (b *BootstrapProvider) ProviderName() string {
+	return b.GetName()
+}
+
 func (b *BootstrapProviderList) GetItems() []GenericProvider {
 	providers := []GenericProvider{}
 

--- a/api/v1alpha2/controlplaneprovider_wrapper.go
+++ b/api/v1alpha2/controlplaneprovider_wrapper.go
@@ -50,6 +50,10 @@ func (c *ControlPlaneProvider) GetType() string {
 	return "controlplane"
 }
 
+func (c *ControlPlaneProvider) ProviderName() string {
+	return c.GetName()
+}
+
 func (c *ControlPlaneProviderList) GetItems() []GenericProvider {
 	providers := make([]GenericProvider, len(c.Items))
 

--- a/api/v1alpha2/coreprovider_wrapper.go
+++ b/api/v1alpha2/coreprovider_wrapper.go
@@ -50,6 +50,10 @@ func (c *CoreProvider) GetType() string {
 	return "core"
 }
 
+func (c *CoreProvider) ProviderName() string {
+	return c.GetName()
+}
+
 func (c *CoreProviderList) GetItems() []GenericProvider {
 	providers := make([]GenericProvider, len(c.Items))
 

--- a/api/v1alpha2/genericprovider_interfaces.go
+++ b/api/v1alpha2/genericprovider_interfaces.go
@@ -30,6 +30,7 @@ type GenericProvider interface {
 	GetStatus() ProviderStatus
 	SetStatus(in ProviderStatus)
 	GetType() string
+	ProviderName() string
 }
 
 // GenericProviderList interface describes operations applicable to the provider list type.

--- a/api/v1alpha2/infrastructureprovider_wrapper.go
+++ b/api/v1alpha2/infrastructureprovider_wrapper.go
@@ -50,6 +50,10 @@ func (c *InfrastructureProvider) GetType() string {
 	return "infrastructure"
 }
 
+func (c *InfrastructureProvider) ProviderName() string {
+	return c.GetName()
+}
+
 func (c *InfrastructureProviderList) GetItems() []GenericProvider {
 	providers := make([]GenericProvider, len(c.Items))
 

--- a/api/v1alpha2/ipamprovider_wrapper.go
+++ b/api/v1alpha2/ipamprovider_wrapper.go
@@ -50,6 +50,10 @@ func (p *IPAMProvider) GetType() string {
 	return "ipam"
 }
 
+func (p *IPAMProvider) ProviderName() string {
+	return p.GetName()
+}
+
 func (p *IPAMProviderList) GetItems() []GenericProvider {
 	providers := []GenericProvider{}
 

--- a/api/v1alpha2/runtimeextensionprovider_wrapper.go
+++ b/api/v1alpha2/runtimeextensionprovider_wrapper.go
@@ -50,6 +50,10 @@ func (p *RuntimeExtensionProvider) GetType() string {
 	return "runtimeextension"
 }
 
+func (p *RuntimeExtensionProvider) ProviderName() string {
+	return p.GetName()
+}
+
 func (p *RuntimeExtensionProviderList) GetItems() []GenericProvider {
 	providers := []GenericProvider{}
 

--- a/cmd/plugin/cmd/init_test.go
+++ b/cmd/plugin/cmd/init_test.go
@@ -324,7 +324,7 @@ func TestInitProviders(t *testing.T) {
 
 			for _, genericProvider := range tt.wantedProviders {
 				g.Eventually(func() (bool, error) {
-					provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.GetName(), genericProvider.GetNamespace())
+					provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.ProviderName(), genericProvider.GetNamespace())
 					if err != nil {
 						return false, err
 					}

--- a/cmd/plugin/cmd/preload.go
+++ b/cmd/plugin/cmd/preload.go
@@ -313,7 +313,7 @@ func templateConfigMap(ctx context.Context, providerType clusterctlv1.ProviderTy
 		return nil, fmt.Errorf("cannot create config client: %w", err)
 	}
 
-	providerConfig, err := configClient.Providers().Get(provider.GetName(), util.ClusterctlProviderType(provider))
+	providerConfig, err := configClient.Providers().Get(provider.ProviderName(), util.ClusterctlProviderType(provider))
 	if err != nil {
 		if !strings.Contains(err.Error(), "failed to get configuration") {
 			return nil, err
@@ -340,7 +340,7 @@ func providerConfigMap(ctx context.Context, provider operatorv1.GenericProvider)
 
 	// If provided store fetch config url in memory reader.
 	if provider.GetSpec().FetchConfig != nil && provider.GetSpec().FetchConfig.URL != "" {
-		_, err := mr.AddProvider(provider.GetName(), util.ClusterctlProviderType(provider), provider.GetSpec().FetchConfig.URL)
+		_, err := mr.AddProvider(provider.ProviderName(), util.ClusterctlProviderType(provider), provider.GetSpec().FetchConfig.URL)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add custom url provider: %w", err)
 		}
@@ -351,7 +351,7 @@ func providerConfigMap(ctx context.Context, provider operatorv1.GenericProvider)
 		return nil, fmt.Errorf("cannot create config client: %w", err)
 	}
 
-	providerConfig, err := configClient.Providers().Get(provider.GetName(), util.ClusterctlProviderType(provider))
+	providerConfig, err := configClient.Providers().Get(provider.ProviderName(), util.ClusterctlProviderType(provider))
 	if err != nil {
 		if !strings.Contains(err.Error(), "failed to get configuration") {
 			return nil, err

--- a/cmd/plugin/cmd/upgrade_plan.go
+++ b/cmd/plugin/cmd/upgrade_plan.go
@@ -331,7 +331,7 @@ func planUpgrade(ctx context.Context, client ctrlclient.Client) (upgradePlan, er
 		}
 
 		upgradeItems = append(upgradeItems, upgradeItem{
-			Name:           genericProvider.GetName(),
+			Name:           genericProvider.ProviderName(),
 			Namespace:      genericProvider.GetNamespace(),
 			Type:           genericProvider.GetType(),
 			CurrentVersion: genericProvider.GetSpec().Version,
@@ -448,7 +448,7 @@ func getProviderFetchConfig(ctx context.Context, genericProvider operatorv1.Gene
 		return "", "", err
 	}
 
-	providerConfig, err := configClient.Providers().Get(genericProvider.GetName(), util.ClusterctlProviderType(genericProvider))
+	providerConfig, err := configClient.Providers().Get(genericProvider.ProviderName(), util.ClusterctlProviderType(genericProvider))
 	if err != nil {
 		// TODO: implement support of fetching data from config maps
 		// This is a temporary fix for providers installed from config maps

--- a/cmd/plugin/cmd/upgrade_plan_test.go
+++ b/cmd/plugin/cmd/upgrade_plan_test.go
@@ -117,7 +117,7 @@ func TestUpgradePlan(t *testing.T) {
 
 			for _, genericProvider := range tt.wantedProviders {
 				g.Eventually(func() (bool, error) {
-					provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.GetName(), genericProvider.GetNamespace())
+					provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.ProviderName(), genericProvider.GetNamespace())
 					if err != nil {
 						return false, err
 					}
@@ -133,7 +133,7 @@ func TestUpgradePlan(t *testing.T) {
 			// Init doesn't support custom URLs yet, so we have to update providers here
 			if tt.customURL != "" {
 				for _, genericProvider := range tt.wantedProviders {
-					provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.GetName(), genericProvider.GetNamespace())
+					provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.ProviderName(), genericProvider.GetNamespace())
 					g.Expect(err).NotTo(HaveOccurred())
 
 					spec := provider.GetSpec()
@@ -146,7 +146,7 @@ func TestUpgradePlan(t *testing.T) {
 					g.Expect(env.Update(ctx, provider)).NotTo(HaveOccurred())
 
 					g.Eventually(func() (bool, error) {
-						provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.GetName(), genericProvider.GetNamespace())
+						provider, err := getGenericProvider(ctx, env, string(util.ClusterctlProviderType(genericProvider)), genericProvider.ProviderName(), genericProvider.GetNamespace())
 						if err != nil {
 							return false, err
 						}

--- a/controller/alias.go
+++ b/controller/alias.go
@@ -39,3 +39,30 @@ type Result = providercontroller.Result
 
 // NewPhaseReconciler is an alias for the internal NewPhaseReconciler function.
 var NewPhaseReconciler = providercontroller.NewPhaseReconciler
+
+// ProviderTypeMapper is an alias for the internal ProviderTypeMapper type.
+type ProviderTypeMapper = providercontroller.ProviderTypeMapper
+
+// WithProviderTypeMapper is an alias for the internal WithProviderTypeMapper function.
+var WithProviderTypeMapper = providercontroller.WithProviderTypeMapper
+
+// ProviderConverter is an alias for the internal ProviderConverter type.
+type ProviderConverter = providercontroller.ProviderConverter
+
+// WithProviderConverter is an alias for the internal WithProviderConverter function.
+var WithProviderConverter = providercontroller.WithProviderConverter
+
+// ProviderLister is an alias for the internal ProviderLister type.
+type ProviderLister = providercontroller.ProviderLister
+
+// ProviderOperation is an alias for the internal ProviderOperation type.
+type ProviderOperation = providercontroller.ProviderOperation
+
+// WithProviderLister is an alias for the internal WithProviderLister function.
+var WithProviderLister = providercontroller.WithProviderLister
+
+// ProviderMapper is an alias for the internal ProviderMapper type.
+type ProviderMapper = providercontroller.ProviderMapper
+
+// WithProviderMapper is an alias for the internal WithProviderMapper function.
+var WithProviderMapper = providercontroller.WithProviderMapper

--- a/internal/controller/client_proxy.go
+++ b/internal/controller/client_proxy.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
@@ -40,12 +39,13 @@ import (
 // interact with the management cluster.
 type clientProxy struct {
 	client.Client
+	lister ProviderLister
 }
 
 func (c clientProxy) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	switch l := list.(type) {
 	case *clusterctlv1.ProviderList:
-		return listProviders(ctx, c.Client, l)
+		return c.lister(ctx, l)
 	default:
 		return c.Client.List(ctx, l, opts...)
 	}
@@ -67,34 +67,6 @@ func (c clientProxy) Patch(ctx context.Context, obj client.Object, patch client.
 	default:
 		return c.Client.Patch(ctx, o, patch, opts...)
 	}
-}
-
-func listProviders(ctx context.Context, cl client.Client, list *clusterctlv1.ProviderList) error {
-	providers := []operatorv1.GenericProviderList{
-		&operatorv1.CoreProviderList{},
-		&operatorv1.InfrastructureProviderList{},
-		&operatorv1.BootstrapProviderList{},
-		&operatorv1.ControlPlaneProviderList{},
-		&operatorv1.AddonProviderList{},
-		&operatorv1.IPAMProviderList{},
-	}
-
-	for _, group := range providers {
-		g, ok := group.(client.ObjectList)
-		if !ok {
-			continue
-		}
-
-		if err := cl.List(ctx, g); err != nil {
-			return err
-		}
-
-		for _, p := range group.GetItems() {
-			list.Items = append(list.Items, getProvider(p, ""))
-		}
-	}
-
-	return nil
 }
 
 // controllerProxy implements the Proxy interface from the clusterctl. It is used to

--- a/internal/controller/manifests_downloader_test.go
+++ b/internal/controller/manifests_downloader_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
+	"sigs.k8s.io/cluster-api-operator/util"
 )
 
 func TestManifestsDownloader(t *testing.T) {
@@ -35,6 +36,10 @@ func TestManifestsDownloader(t *testing.T) {
 	ctx := context.Background()
 
 	fakeclient := fake.NewClientBuilder().WithObjects().Build()
+
+	r := &GenericProviderReconciler{
+		Client: fakeclient,
+	}
 
 	p := &PhaseReconciler{
 		ctrlClient: fakeclient,
@@ -49,6 +54,10 @@ func TestManifestsDownloader(t *testing.T) {
 				},
 			},
 		},
+		providerTypeMapper: util.ClusterctlProviderType,
+		providerLister:     r.listProviders,
+		providerConverter:  convertProvider,
+		providerMapper:     r.providerMapper,
 	}
 
 	_, err := p.InitializePhaseReconciler(ctx)
@@ -82,6 +91,10 @@ func TestProviderDownloadWithOverrides(t *testing.T) {
 	overridesClient, err := configclient.New(ctx, "", configclient.InjectReader(reader))
 	g.Expect(err).ToNot(HaveOccurred())
 
+	r := &GenericProviderReconciler{
+		Client: fakeclient,
+	}
+
 	p := &PhaseReconciler{
 		ctrlClient: fakeclient,
 		provider: &operatorv1.CoreProvider{
@@ -91,7 +104,11 @@ func TestProviderDownloadWithOverrides(t *testing.T) {
 			},
 			Spec: operatorv1.CoreProviderSpec{},
 		},
-		overridesClient: overridesClient,
+		overridesClient:    overridesClient,
+		providerTypeMapper: util.ClusterctlProviderType,
+		providerLister:     r.listProviders,
+		providerConverter:  convertProvider,
+		providerMapper:     r.providerMapper,
 	}
 
 	_, err = p.InitializePhaseReconciler(ctx)

--- a/internal/controller/oci_source.go
+++ b/internal/controller/oci_source.go
@@ -59,16 +59,16 @@ func NewMapStore(p operatorv1.GenericProvider) mapStore {
 		data: map[string][]byte{
 			metadataFile:   nil,
 			componentsFile: nil,
-			fmt.Sprintf(typedComponentsFile, p.GetType()):                                  nil,
-			fmt.Sprintf(fullMetadataFile, p.GetType(), p.GetName(), p.GetSpec().Version):   nil,
-			fmt.Sprintf(fullComponentsFile, p.GetType(), p.GetName(), p.GetSpec().Version): nil,
+			fmt.Sprintf(typedComponentsFile, p.GetType()):                                       nil,
+			fmt.Sprintf(fullMetadataFile, p.GetType(), p.ProviderName(), p.GetSpec().Version):   nil,
+			fmt.Sprintf(fullComponentsFile, p.GetType(), p.ProviderName(), p.GetSpec().Version): nil,
 		},
 	}
 }
 
 // GetMetadata returns metadata file for the provider.
 func (m mapStore) GetMetadata(p operatorv1.GenericProvider) ([]byte, error) {
-	fullMetadataKey := fmt.Sprintf(fullMetadataFile, p.GetType(), p.GetName(), p.GetSpec().Version)
+	fullMetadataKey := fmt.Sprintf(fullMetadataFile, p.GetType(), p.ProviderName(), p.GetSpec().Version)
 
 	data := m.data[fullMetadataKey]
 	if len(data) != 0 {
@@ -85,7 +85,7 @@ func (m mapStore) GetMetadata(p operatorv1.GenericProvider) ([]byte, error) {
 
 // GetComponents returns componenents file for the provider.
 func (m mapStore) GetComponents(p operatorv1.GenericProvider) ([]byte, error) {
-	fullComponentsKey := fmt.Sprintf(fullComponentsFile, p.GetType(), p.GetName(), p.GetSpec().Version)
+	fullComponentsKey := fmt.Sprintf(fullComponentsFile, p.GetType(), p.ProviderName(), p.GetSpec().Version)
 
 	data := m.data[fullComponentsKey]
 	if len(data) != 0 {

--- a/internal/controller/phases_test.go
+++ b/internal/controller/phases_test.go
@@ -42,6 +42,10 @@ func TestSecretReader(t *testing.T) {
 	secretName := "test-secret"
 	secretNamespace := "test-secret-namespace"
 
+	r := &GenericProviderReconciler{
+		Client: fakeclient,
+	}
+
 	p := &PhaseReconciler{
 		ctrlClient: fakeclient,
 		provider: &operatorv1.CoreProvider{
@@ -65,6 +69,10 @@ func TestSecretReader(t *testing.T) {
 				},
 			},
 		},
+		providerTypeMapper: util.ClusterctlProviderType,
+		providerLister:     r.listProviders,
+		providerConverter:  convertProvider,
+		providerMapper:     r.providerMapper,
 	}
 
 	testKey1 := "test-key1"
@@ -380,9 +388,18 @@ metadata:
 			g := NewWithT(t)
 
 			fakeclient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(provider).Build()
+
+			r := &GenericProviderReconciler{
+				Client: fakeclient,
+			}
+
 			p := &PhaseReconciler{
-				ctrlClient: fakeclient,
-				provider:   provider,
+				ctrlClient:         fakeclient,
+				provider:           provider,
+				providerTypeMapper: util.ClusterctlProviderType,
+				providerLister:     r.listProviders,
+				providerConverter:  convertProvider,
+				providerMapper:     r.providerMapper,
 			}
 
 			for i := range tt.configMaps {
@@ -579,11 +596,19 @@ releaseSeries:
 			g := NewWithT(t)
 
 			fakeclient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(tt.genericProviders...).Build()
+			r := &GenericProviderReconciler{
+				Client: fakeclient,
+			}
+
 			p := &PhaseReconciler{
-				ctrlClient:     fakeclient,
-				providerConfig: coreProvider,
-				repo:           repository.NewMemoryRepository(),
-				provider:       core,
+				ctrlClient:         fakeclient,
+				providerConfig:     coreProvider,
+				repo:               repository.NewMemoryRepository(),
+				provider:           core,
+				providerTypeMapper: util.ClusterctlProviderType,
+				providerLister:     r.listProviders,
+				providerConverter:  convertProvider,
+				providerMapper:     r.providerMapper,
 			}
 
 			for i := range tt.configMaps {

--- a/internal/controller/preflight_checks_test.go
+++ b/internal/controller/preflight_checks_test.go
@@ -29,6 +29,7 @@ import (
 
 	operatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	"sigs.k8s.io/cluster-api-operator/internal/controller/genericprovider"
+	"sigs.k8s.io/cluster-api-operator/util"
 )
 
 func TestPreflightChecks(t *testing.T) {
@@ -662,7 +663,11 @@ func TestPreflightChecks(t *testing.T) {
 				gs.Expect(fakeClient.Create(ctx, c)).To(Succeed())
 			}
 
-			err := preflightChecks(context.Background(), fakeClient, tc.providers[0], tc.providerList)
+			r := GenericProviderReconciler{
+				Client: fakeClient,
+			}
+
+			err := preflightChecks(context.Background(), fakeClient, tc.providers[0], tc.providerList, util.ClusterctlProviderType, r.listProviders)
 			if tc.expectedError {
 				gs.Expect(err).To(HaveOccurred())
 			} else {
@@ -759,7 +764,11 @@ func TestPreflightChecksUpgradesDowngrades(t *testing.T) {
 
 			gs.Expect(fakeClient.Create(ctx, provider)).To(Succeed())
 
-			err := preflightChecks(context.Background(), fakeClient, provider, &operatorv1.CoreProviderList{})
+			r := GenericProviderReconciler{
+				Client: fakeClient,
+			}
+
+			err := preflightChecks(context.Background(), fakeClient, provider, &operatorv1.CoreProviderList{}, util.ClusterctlProviderType, r.listProviders)
 			if tc.expectedError {
 				gs.Expect(err).To(HaveOccurred())
 			} else {

--- a/util/util.go
+++ b/util/util.go
@@ -127,7 +127,7 @@ func GetGenericProvider(ctx context.Context, cl ctrlclient.Client, provider conf
 	}
 
 	for _, p := range list.GetItems() {
-		if p.GetName() == provider.Name() {
+		if p.ProviderName() == provider.Name() {
 			return p, nil
 		}
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

CAPI Operator reconciles essentially 2 provider types: Core and non-Core providers. There are differences in `GetType()` method and how each provider translates to the path to the component files in the release payload, but these details are abstracted away behind `GenericProvider` interface.

This change exposes inner methods used to determine provider type and provide a `clusterctl` equivalent for it via a set of injection points, available as a public API through `alias.go`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
