### PR TITLE
🐛 Fix preflight check for generic provider overlap with core

### DIFF
--- a/internal/controller/preflight_checks.go
+++ b/internal/controller/preflight_checks.go
@@ -154,7 +154,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 		)
 
 		// CoreProvider is a singleton resource, more than one instances should not exist
-		if mapper(p) == clusterctlv1.CoreProviderType {
+		if mapper(provider) == clusterctlv1.CoreProviderType && mapper(p) == clusterctlv1.CoreProviderType {
 			log.Info(moreThanOneCoreProviderInstanceExistsMessage)
 			preflightFalseCondition.Message = moreThanOneCoreProviderInstanceExistsMessage
 			conditions.Set(provider, preflightFalseCondition)
@@ -163,7 +163,7 @@ func preflightChecks(ctx context.Context, c client.Client, provider genericprovi
 		}
 
 		// For any other provider we should check that instances with similar name exist in any namespace
-		if mapper(p) != clusterctlv1.CoreProviderType && p.GetName() == provider.GetName() {
+		if mapper(p) != clusterctlv1.CoreProviderType && p.GetName() == provider.GetName() && mapper(p) == mapper(provider) {
 			preflightFalseCondition.Message = fmt.Sprintf(moreThanOneProviderInstanceExistsMessage, p.GetName(), p.GetNamespace())
 			log.Info(preflightFalseCondition.Message)
 			conditions.Set(provider, preflightFalseCondition)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

In a scenario when a homogeneous provider type is used, core provider preflight check reports a false negative failure, due to encountering more than one core provider in the list.

To fix this, we need to compare provider type for both current and found at all times.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
