### PR TITLE
🐛 [OCI] Normalize provider type name when control plane

### DIFF
--- a/api/v1alpha2/controlplaneprovider_wrapper.go
+++ b/api/v1alpha2/controlplaneprovider_wrapper.go
@@ -47,7 +47,7 @@ func (c *ControlPlaneProvider) SetStatus(in ProviderStatus) {
 }
 
 func (c *ControlPlaneProvider) GetType() string {
-	return "controlplane"
+	return "control-plane"
 }
 
 func (c *ControlPlaneProvider) ProviderName() string {


### PR DESCRIPTION
Normalize provider type name for controlPlane, both kubeadm and rke2 contolPlane components have name control-plane-components.yaml

Issue: https://github.com/kubernetes-sigs/cluster-api-operator/issues/858

<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
