### PR TITLE
✨ Implement diagnostics fields in Providers CRD

### DIFF
--- a/api/v1alpha2/controllermanagerconfig_types.go
+++ b/api/v1alpha2/controllermanagerconfig_types.go
@@ -104,8 +104,20 @@ type ControllerMetrics struct {
 	// BindAddress is the TCP address that the controller should bind to
 	// for serving prometheus metrics.
 	// It can be set to "0" to disable the metrics serving.
+	// NOTE: This field is deprecated, please use DiagnosticsAddress field
 	// +optional
 	BindAddress string `json:"bindAddress,omitempty"`
+
+	// DiagnosticsAddress is the TCP address that the controller should bind to
+	// for serving prometheus metric.
+	// It can be set to "0" to disable the metrics serving.
+	// +optional
+	DiagnosticsAddress string `json:"diagnosticsAddress,omitempty"`
+
+	// InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+	// If false, or not set, the diagnostics address will expose pprof endpoints too.
+	// +optional
+	InsecureDiagnostics bool `json:"insecureDiagnostics,omitempty"`
 }
 
 // ControllerHealth defines the health configs.

--- a/config/crd/bases/operator.cluster.x-k8s.io_addonproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_addonproviders.yaml
@@ -1432,7 +1432,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2961,7 +2973,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_bootstrapproviders.yaml
@@ -1432,7 +1432,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2961,7 +2973,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_controlplaneproviders.yaml
@@ -1433,7 +1433,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2962,7 +2974,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_coreproviders.yaml
@@ -1432,7 +1432,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2961,7 +2973,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_infrastructureproviders.yaml
@@ -1433,7 +1433,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2962,7 +2974,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_ipamproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_ipamproviders.yaml
@@ -1432,7 +1432,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2961,7 +2973,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-

--- a/config/crd/bases/operator.cluster.x-k8s.io_runtimeextensionproviders.yaml
+++ b/config/crd/bases/operator.cluster.x-k8s.io_runtimeextensionproviders.yaml
@@ -1434,7 +1434,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2963,7 +2975,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-

--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -232,9 +233,16 @@ func customizeManagerContainer(mSpec *operatorv1.ManagerSpec, c *corev1.Containe
 		c.Args = leaderElectionArgs(mSpec.LeaderElection, c.Args)
 	}
 
+	// metrics
 	if mSpec.Metrics.BindAddress != "" {
 		c.Args = setArgs(c.Args, "--metrics-bind-addr", mSpec.Metrics.BindAddress)
 	}
+
+	if mSpec.Metrics.DiagnosticsAddress != "" {
+		c.Args = setArgs(c.Args, "--diagnostics-address", mSpec.Metrics.DiagnosticsAddress)
+	}
+
+	c.Args = setArgs(c.Args, "--insecure-diagnostics", strconv.FormatBool(mSpec.Metrics.InsecureDiagnostics))
 
 	// webhooks
 	if mSpec.Webhook.Host != "" {

--- a/test/e2e/resources/full-chart-install.yaml
+++ b/test/e2e/resources/full-chart-install.yaml
@@ -1457,7 +1457,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -2986,7 +2998,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-
@@ -4576,7 +4600,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -6105,7 +6141,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-
@@ -7696,7 +7744,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -9225,7 +9285,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-
@@ -10816,7 +10888,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -12345,7 +12429,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-
@@ -13936,7 +14032,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -15465,7 +15573,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-
@@ -17056,7 +17176,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -18585,7 +18717,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-
@@ -20177,7 +20321,19 @@ spec:
                                 BindAddress is the TCP address that the controller should bind to
                                 for serving prometheus metrics.
                                 It can be set to "0" to disable the metrics serving.
+                                NOTE: This field is deprecated, please use DiagnosticsAddress field
                               type: string
+                            diagnosticsAddress:
+                              description: |-
+                                DiagnosticsAddress is the TCP address that the controller should bind to
+                                for serving prometheus metric.
+                                It can be set to "0" to disable the metrics serving.
+                              type: string
+                            insecureDiagnostics:
+                              description: |-
+                                InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                                If false, or not set, the diagnostics address will expose pprof endpoints too.
+                              type: boolean
                           type: object
                         profilerAddress:
                           description: |-
@@ -21706,7 +21862,19 @@ spec:
                           BindAddress is the TCP address that the controller should bind to
                           for serving prometheus metrics.
                           It can be set to "0" to disable the metrics serving.
+                          NOTE: This field is deprecated, please use DiagnosticsAddress field
                         type: string
+                      diagnosticsAddress:
+                        description: |-
+                          DiagnosticsAddress is the TCP address that the controller should bind to
+                          for serving prometheus metric.
+                          It can be set to "0" to disable the metrics serving.
+                        type: string
+                      insecureDiagnostics:
+                        description: |-
+                          InsecureDiagnostics indicates if insecure metrics serving should be enabled.
+                          If false, or not set, the diagnostics address will expose pprof endpoints too.
+                        type: boolean
                     type: object
                   profilerAddress:
                     description: |-


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the fields `DiagnosticsAddress` and `InsecureDiagnostics` to `ControllerMetrics` struct. It also configures these fields as flags in the deployment.
As of CAPI v1.9, the flag `--metrics-bind-addr` was removed, so the flag `--diagnostics-address` must be used in place. 
