### PR TITLE
:sparkles: Support alter components custom func

### DIFF
--- a/controller/alias.go
+++ b/controller/alias.go
@@ -66,3 +66,6 @@ type ProviderMapper = providercontroller.ProviderMapper
 
 // WithProviderMapper is an alias for the internal WithProviderMapper function.
 var WithProviderMapper = providercontroller.WithProviderMapper
+
+// WithCustomAlterComponentsFuncs is an alias for the internal WithCustomAlterComponentsFuncs function.
+var WithCustomAlterComponentsFuncs = providercontroller.WithCustomAlterComponentsFuncs

--- a/internal/controller/phases.go
+++ b/internal/controller/phases.go
@@ -92,32 +92,32 @@ type PhaseReconciler struct {
 	needsCompression   bool
 }
 
-// PhaseReconcielerOption is a function that configures the reconciler.
-type PhaseReconcielerOption func(*PhaseReconciler)
+// PhaseReconcilerOption is a function that configures the reconciler.
+type PhaseReconcilerOption func(*PhaseReconciler)
 
 // WithProviderTypeMapper configures the reconciler to use the given clustectlv1 provider type mapper.
-func WithProviderTypeMapper(providerTypeMapper ProviderTypeMapper) PhaseReconcielerOption {
+func WithProviderTypeMapper(providerTypeMapper ProviderTypeMapper) PhaseReconcilerOption {
 	return func(r *PhaseReconciler) {
 		r.providerTypeMapper = providerTypeMapper
 	}
 }
 
 // WithProviderLister configures the reconciler to use the given provider lister.
-func WithProviderLister(providerLister ProviderLister) PhaseReconcielerOption {
+func WithProviderLister(providerLister ProviderLister) PhaseReconcilerOption {
 	return func(r *PhaseReconciler) {
 		r.providerLister = providerLister
 	}
 }
 
 // WithProviderConverter configures the reconciler to use the given provider converter.
-func WithProviderConverter(providerConverter ProviderConverter) PhaseReconcielerOption {
+func WithProviderConverter(providerConverter ProviderConverter) PhaseReconcilerOption {
 	return func(r *PhaseReconciler) {
 		r.providerConverter = providerConverter
 	}
 }
 
 // WithProviderMapper configures the reconciler to use the given provider mapper.
-func WithProviderMapper(providerMapper ProviderMapper) PhaseReconcielerOption {
+func WithProviderMapper(providerMapper ProviderMapper) PhaseReconcilerOption {
 	return func(r *PhaseReconciler) {
 		r.providerMapper = providerMapper
 	}
@@ -169,7 +169,7 @@ func wrapPhaseError(err error, reason string, condition clusterv1.ConditionType)
 }
 
 // NewPhaseReconciler returns phase reconciler for the given provider.
-func NewPhaseReconciler(r GenericProviderReconciler, provider genericprovider.GenericProvider, providerList genericprovider.GenericProviderList, options ...PhaseReconcielerOption) *PhaseReconciler {
+func NewPhaseReconciler(r GenericProviderReconciler, provider genericprovider.GenericProvider, providerList genericprovider.GenericProviderList, options ...PhaseReconcilerOption) *PhaseReconciler {
 	rec := &PhaseReconciler{
 		ctrlClient:         r.Client,
 		ctrlConfig:         r.Config,


### PR DESCRIPTION
**What this PR does / why we need it**:

With the recent changes in CAPI Operator that expose phase reconciliation, it would be great if we can also make applying changes on provider manifest definition easier during one of these phases.

This change introduces a new field in `PhaseReconciler` to embed one/multiple [ComponentsAlterFn](https://github.com/kubernetes-sigs/cluster-api/blob/7782ab73d31d3e1ffe3c46966bd438efe592be72/cmd/clusterctl/client/repository/components.go#L149) that are applied on `Fetch`. With this solution, specific components on a provider's manifest definition can be patched based on the logic passed in this/these function/functions.

Additionally, this adds an extra commit to fix a typo in one of the struct names `PhaseReconcilerOption`. **Looks like this is the reason CI's triggerring api diff issues**, I can drop this change if it delays having the new feature added, and I can open a separate PR to fix the typo.

**Which issue(s) this PR fixes**:
Fixes #
