### PR TITLE
 📖 Docs/notes on airgapped config

### DIFF
--- a/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
+++ b/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
@@ -80,6 +80,9 @@ Example layout for a `kubeadm` provider may look like:
 - `control-plane-components.yaml`
 - `bootstrap-components.yaml`
 
+See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.<br>
+Other tools, such as [oras](https://oras.land/docs/), behvae in a similar fashion and can also be used to build and publish the OCI artifacts.
+
 To fetch provider components which are stored as an OCI artifact, you can configure `fetchConfig.oci` field to pull them directly from an OCI registry:
 
 ```yaml
@@ -96,8 +99,21 @@ spec:
     oci: "my-oci-registry.example.com/my-provider:v1.9.3"
 ```
 
-See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.<br>
-Other tools, such as [oras](https://oras.land/docs/), behvae in a similar fashion and can also be used to build and publish the OCI artifacts.
+You can likewise configure `fetchConfig.oci` to use plain http rather than https if so desired. This should only be used for development purposes as it can be insecure:
+
+```yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: azure
+  namespace: capz-system
+spec:
+  version: v1.9.3
+  configSecret:
+    name: azure-variables
+  fetchConfig:
+    oci: "http://my-oci-registry.example.com/my-provider:v1.9.3"
+```
 
 ## OCI Authentication
 

--- a/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
+++ b/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
@@ -80,8 +80,7 @@ Example layout for a `kubeadm` provider may look like:
 - `control-plane-components.yaml`
 - `bootstrap-components.yaml`
 
-See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.<br>
-Other tools, such as [oras](https://oras.land/docs/), behvae in a similar fashion and can also be used to build and publish the OCI artifacts.
+See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.
 
 To fetch provider components which are stored as an OCI artifact, you can configure `fetchConfig.oci` field to pull them directly from an OCI registry:
 

--- a/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
+++ b/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
@@ -80,7 +80,12 @@ Example layout for a `kubeadm` provider may look like:
 - `control-plane-components.yaml`
 - `bootstrap-components.yaml`
 
+<<<<<<< HEAD
 See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.
+=======
+See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.<br>
+Other tools, such as [oras](https://oras.land/docs/), behvae in a similar fashion and can also be used to build and publish the OCI artifacts.
+>>>>>>> 11a4553 (add a note on how to enable fetching oci artifacts using plain http)
 
 To fetch provider components which are stored as an OCI artifact, you can configure `fetchConfig.oci` field to pull them directly from an OCI registry:
 

--- a/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
+++ b/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
@@ -96,6 +96,9 @@ spec:
     oci: "my-oci-registry.example.com/my-provider:v1.9.3"
 ```
 
+See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.<br>
+Other tools, such as [oras](https://oras.land/docs/), behvae in a similar fashion and can also be used to build and publish the OCI artifacts.
+
 ## OCI Authentication
 
 To securely authenticate with an OCI registry, environment variables are used for user credentials. The following environment variables are involved:

--- a/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
+++ b/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
@@ -81,11 +81,15 @@ Example layout for a `kubeadm` provider may look like:
 - `bootstrap-components.yaml`
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.
 =======
 See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.<br>
 Other tools, such as [oras](https://oras.land/docs/), behvae in a similar fashion and can also be used to build and publish the OCI artifacts.
 >>>>>>> 11a4553 (add a note on how to enable fetching oci artifacts using plain http)
+=======
+See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.
+>>>>>>> a58babb (remove note about using oras)
 
 To fetch provider components which are stored as an OCI artifact, you can configure `fetchConfig.oci` field to pull them directly from an OCI registry:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a few notes to the air-gapped-environment documentation that add clarity to properly configuring the oci artifacts to be fetched.
I was recently setting up an air-gapped installation of the operator and installing providers to my cluster following these docs and found that it was ambiguous on how to configure the artifacts. I was under the impression that the artifacts need only to be in an oci compliant registry rather than the oci layout. As such, I was building simple docker images that were not in oci layout and the operator could not find the metadata/components files for any given provider despite successfully fetching the artifact from the oci registry.

The added notes include a link to the local plugin docs describing how to properly build and publish provider artifacts such that the operator can successfully fetch the artifact and then also extract the metadata/components files. I also add a note on how to fetch artifacts using plain http. As I was in development, my oci registry was a local zarf registry and I was accessing it over http. Using a `fetchConfig.oci` without the `http://` prefix resulted in the operator erroring with a message stating that the server returned an http status to an https client. I had to dig through the controller source code to find out how to properly instruct the operator to pull the artifacts via http.
