### PR TITLE
🌱 Add insecureDiagnostics and diagnosticsAddress to chart

### DIFF
--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -31,6 +31,18 @@ metadata:
 {{- if or $addonVersion $.Values.secretName $.Values.configSecret.name (($addon).configSecret).name }}
 spec:
 {{- end}}
+{{- if $.addon.manager }}
+  manager:
+  {{- if $.addon.manager.metrics }}
+    metrics:
+    {{- if $.addon.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{- $.addon.manager.metrics.insecureDiagnostics }}
+    {{- end }}
+    {{- if $.addon.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{- $.addon.manager.metrics.diagnosticsAddress }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if $addonVersion }}
   version: {{ $addonVersion }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -31,6 +31,18 @@ metadata:
 {{- if or $bootstrapVersion $.Values.configSecret.name (($bootstrap).configSecret).name }}
 spec:
 {{- end}}
+{{- if $.bootstrap.manager }}
+  manager:
+  {{- if $.bootstrap.manager.metrics }}
+    metrics:
+    {{- if $.bootstrap.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{- $.bootstrap.manager.metrics.insecureDiagnostics }}
+    {{- end }}
+    {{- if $.bootstrap.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{- $.bootstrap.manager.metrics.diagnosticsAddress }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if $bootstrapVersion }}
   version: {{ $bootstrapVersion }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -34,18 +34,23 @@ spec:
 {{- if $controlPlaneVersion }}
   version: {{ $controlPlaneVersion }}
 {{- end }}
-{{- if $.Values.manager }}
-{{- if hasKey $.Values.manager.featureGates $controlPlaneName }}
+{{- if $.controlPlane.manager }}
   manager:
-{{- range $key, $value := $.Values.manager.featureGates }}
-  {{- if eq $key $controlPlaneName }}
+  {{- if $.controlPlane.manager.featureGates }}
     featureGates:
-    {{- range $k, $v := $value }}
-      {{ $k }}: {{ $v }}
+    {{- range $key, $value := $.controlPlane.manager.featureGates }}
+      {{ $key }}: {{ $value }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- end }}
+  {{- if $.controlPlane.manager.metrics }}
+    metrics:
+    {{- if $.controlPlane.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{- $.controlPlane.manager.metrics.insecureDiagnostics }}
+    {{- end }}
+    {{- if $.controlPlane.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{- $.controlPlane.manager.metrics.diagnosticsAddress }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if (default (($controlPlane).configSecret).name (($.Values).configSecret).name) }}
 {{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $controlPlane) | nindent 2 }}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -34,14 +34,23 @@ spec:
 {{- if $coreVersion }}
   version: {{ $coreVersion }}
 {{- end }}
-{{- if $.Values.manager }}
-{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.core }}
+{{- if $.core.manager }}
   manager:
+  {{- if $.core.manager.featureGates }}
     featureGates:
-    {{- range $key, $value := $.Values.manager.featureGates.core }}
+    {{- range $key, $value := $.core.manager.featureGates }}
       {{ $key }}: {{ $value }}
     {{- end }}
-{{- end }}
+  {{- end }}
+  {{- if $.core.manager.metrics }}
+    metrics:
+    {{- if $.core.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{- $.core.manager.metrics.insecureDiagnostics }}
+    {{- end }}
+    {{- if $.core.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{- $.core.manager.metrics.diagnosticsAddress }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if (default (($core).configSecret).name (($.Values).configSecret).name) }}
 {{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $core) | nindent 2 }}

--- a/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra-conditions.yaml
@@ -61,14 +61,23 @@ metadata:
     "argocd.argoproj.io/sync-wave": "2"
 {{- with .Values.configSecret }}
 spec:
-{{- if $.Values.manager }}
-{{- if and $.Values.manager.featureGates $.Values.manager.featureGates.kubeadm }}
+{{- if $.Values.controlPlane.kubeadm.manager }}
   manager:
+  {{- if $.Values.controlPlane.kubeadm.manager.featureGates }}
     featureGates:
-    {{- range $key, $value := $.Values.manager.featureGates.kubeadm }}
+    {{- range $key, $value := $.Values.controlPlane.kubeadm.manager.featureGates }}
       {{ $key }}: {{ $value }}
     {{- end }}
-{{- end }}
+  {{- end }}
+  {{- if $$.Values.controlPlane.kubeadm.manager.metrics }}
+    metrics:
+    {{- if $.Values.controlPlane.kubeadm.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{- $.Values.controlPlane.kubeadm.manager.metrics.insecureDiagnostics }}
+    {{- end }}
+    {{- if $.Values.controlPlane.kubeadm.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{- $.Values.controlPlane.kubeadm.manager.metrics.diagnosticsAddress }}
+    {{- end }}
+  {{- end }}
 {{- end }}
   configSecret:
     name: {{ .name }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -34,18 +34,23 @@ spec:
 {{- if $infrastructureVersion }}
   version: {{ $infrastructureVersion }}
 {{- end }}
-{{- if $.Values.manager }}
-{{- if and (kindIs "map" $.Values.manager.featureGates) (hasKey $.Values.manager.featureGates $infrastructureName) }}
+{{- if $.infra.manager }}
   manager:
-{{- range $key, $value := $.Values.manager.featureGates }}
-  {{- if eq $key $infrastructureName }}
+  {{- if $.infra.manager.featureGates }}
     featureGates:
-    {{- range $k, $v := $value }}
-      {{ $k }}: {{ $v }}
+    {{- range $key, $value := $.infra.manager.featureGates }}
+      {{ $key }}: {{ $value }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- end }}
+  {{- if $.infra.manager.metrics }}
+    metrics:
+    {{- if $.infra.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{- $.infra.manager.metrics.insecureDiagnostics }}
+    {{- end }}
+    {{- if $.infra.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{- $.infra.manager.metrics.diagnosticsAddress }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if and (kindIs "map" $.Values.fetchConfig) (hasKey $.Values.fetchConfig $infrastructureName) }}
 {{- range $key, $value := $.Values.fetchConfig }}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -34,18 +34,23 @@ spec:
 {{- if $ipamVersion }}
   version: {{ $ipamVersion }}
 {{- end }}
-{{- if $.Values.manager }}
-{{- if and (kindIs "map" $.Values.manager.featureGates) (hasKey $.Values.manager.featureGates $ipamName) }}
+{{- if $.ipam.manager }}
   manager:
-{{- range $key, $value := $.Values.manager.featureGates }}
-  {{- if eq $key $ipamName }}
+  {{- if $.ipam.manager.featureGates }}
     featureGates:
-    {{- range $k, $v := $value }}
-      {{ $k }}: {{ $v }}
+    {{- range $key, $value := $.ipam.manager.featureGates }}
+      {{ $key }}: {{ $value }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- end }}
+  {{- if $.ipam.manager.metrics }}
+    metrics:
+    {{- if $.ipam.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{- $.ipam.manager.metrics.insecureDiagnostics }}
+    {{- end }}
+    {{- if $.ipam.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{- $.ipam.manager.metrics.diagnosticsAddress }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if and (kindIs "map" $.Values.fetchConfig) (hasKey $.Values.fetchConfig $ipamName) }}
 {{- range $key, $value := $.Values.fetchConfig }}

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -6,41 +6,63 @@ core: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   manager:              # Optional
+#     featureGates:
+#       ClusterTopology: true
+#     metrics:
+#       insecureDiagnostics: true
+#       diagnosticsAddress: localhost:8080
 bootstrap: {}
 # kubeadm: {}             # Name, required
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   manager:              # Optional
+#     metrics:
+#       insecureDiagnostics: true
+#       diagnosticsAddress: localhost:8080
 controlPlane: {}
 # kubeadm: {}             # Name, required
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   manager:              # Optional
+#     featureGates:
+#       ClusterTopology: true
+#     metrics:
+#       insecureDiagnostics: true
+#       diagnosticsAddress: localhost:8080
 infrastructure: {}
 # docker: {}              # Name, required
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   manager:              # Optional
+#     featureGates:
+#       ClusterTopology: true
+#     metrics:
+#       insecureDiagnostics: true
+#       diagnosticsAddress: localhost:8080
 addon: {}
 # helm: {}                # Name, required
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   manager:              # Optional
+#     metrics:
+#       insecureDiagnostics: true
+#       diagnosticsAddress: localhost:8080
 ipam: {}
 # in-cluster: {}          # Name, required
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
-manager.featureGates: {}
-# Configuration for enabling feature gates in different providers
-# manager: 
-#   featureGates:
-#     proxmox: # Name of the provider
+#   manager:              # Optional
+#     featureGates:
 #       ClusterTopology: true
-#     core:
-#       ClusterTopology: true
-#     kubeadm:
-#       ClusterTopology: true
+#     metrics:
+#       insecureDiagnostics: true
+#       diagnosticsAddress: localhost:8080
 fetchConfig: {}
 # ---
 # Common configuration secret options


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds the fields `insecureDiagnostics` and `diagnosticsAddress` to the chart. It also refactors the manager field to be configurable per component.

These fields are necessary to configure the metrics exposure of the components. 
