### PR TITLE
Fix Secret name inconsistency in quickstart AWS provider example

### DIFF
--- a/docs/book/src/01_user/02_quick-start.md
+++ b/docs/book/src/01_user/02_quick-start.md
@@ -85,5 +85,5 @@ metadata:
 spec:
  version: v2.1.4
  configSecret:
-   name: aws-variables
+   name: credentials-secret
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,5 +83,5 @@ metadata:
 spec:
  version: v2.1.4
  configSecret:
-   name: aws-variables
+   name: credentials-secret
 ```


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR fixes a documentation inconsistency in the quickstart guide where the AWS provider example referenced a Secret named `aws-variables`, but the setup instructions create a Secret named `credentials-secret`. This mismatch caused "Secret not found" errors when users followed the documentation.

**Changes made:**
- Updated `configSecret.name` from `aws-variables` to `credentials-secret` in AWS provider examples
- Applied fixes to both quickstart documentation files:
  - `/docs/quickstart.md`
  - `/docs/book/src/01_user/02_quick-start.md`

**Before:**
```yaml
configSecret:
  name: aws-variables
```

**After:**
```yaml
configSecret:
  name: credentials-secret
```

This ensures consistency between the Secret creation instructions and the AWS provider example, preventing setup failures for new users.

**Which issue(s) this PR fixes:**
Fixes #913