### PR TITLE
🐛 Return error when customizing non-existent containers

### DIFF
--- a/internal/controller/component_customizer_test.go
+++ b/internal/controller/component_customizer_test.go
@@ -611,6 +611,18 @@ func TestCustomizeDeployment(t *testing.T) {
 			},
 			expectedError: true,
 		},
+		{
+			name: "container customization for non-existent container",
+			inputDeploymentSpec: &operatorv1.DeploymentSpec{
+				Containers: []operatorv1.ContainerSpec{
+					{
+						Name:     "NON-EXISTENT",
+						ImageURL: ptr.To("quay.io/dev/mydns:v3.4.2"),
+					},
+				},
+			},
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Previously, when a user specified container customizations in the provider spec for a container that doesn't exist in the deployment, the operator would silently ignore the configuration. This made it difficult to debug misconfigured provider specs.

This change adds error handling to the `customizeContainer` function to return an error when no matching container is found in the deployment. The error message includes both the container name and deployment name to help users quickly identify and fix the issue.

This makes the error handling consistent with the existing pattern used for manager container validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
