### PR TITLE
🌱 fix: missing provider downgrade status message templating

### DIFF
--- a/internal/controller/preflight_checks.go
+++ b/internal/controller/preflight_checks.go
@@ -241,7 +241,7 @@ func checkProviderVersion(ctx context.Context, providerVersion string, provider 
 				Type:    operatorv1.PreflightCheckCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  operatorv1.UnsupportedProviderDowngradeReason,
-				Message: unsupportedProviderDowngradeMessage,
+				Message: fmt.Sprintf(unsupportedProviderDowngradeMessage, provider.GetName()),
 			})
 
 			return fmt.Errorf("downgrade is not supported for provider %q", provider.GetName())


### PR DESCRIPTION
**What this PR does / why we need it**: 
At the moment, during an attempt to downgrade a provider, `CoreProvider.status.conditions` will report an unexpanded string template:
```YAML
  - lastTransitionTime: "2025-11-07T19:09:27Z"
    message: Downgrade is not supported for provider %s
    observedGeneration: 21
    reason: UnsupportedProviderDowngradeReason
    status: "False"
    type: PreflightCheckPassed
```

This PR fixes the problem by expanding the string template with the provider name.
