### PR TITLE
🐛 Allow non canonical image paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/goutils v1.1.1
+	github.com/distribution/reference v0.6.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-errors/errors v1.5.1
 	github.com/go-logr/logr v1.4.3
@@ -40,7 +41,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/internal/controller/image_overrides.go
+++ b/internal/controller/image_overrides.go
@@ -17,9 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 
+	"github.com/distribution/reference"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -63,16 +64,9 @@ func alterImage(component, imageString string, imageMeta configclient.ImageMetaC
 	return result, nil
 }
 
-// isCanonicalError checks if error is about non nanonical image format.
+// isCanonicalError checks if error is about non canonical image format.
 func isCanonicalError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	msg := err.Error()
-
-	return strings.Contains(msg, "repository name must be canonical") ||
-		strings.Contains(msg, "couldn't parse image name")
+	return errors.Is(err, reference.ErrNameNotCanonical)
 }
 
 // fixImages alters images using the give alter func

--- a/internal/controller/image_overrides_test.go
+++ b/internal/controller/image_overrides_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/distribution/reference"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -203,7 +204,7 @@ func TestAlterImage(t *testing.T) {
 			component: "cluster-api",
 			image:     "example.com/controller:v1.0.0",
 			mockFunc: func(component, image string) (string, error) {
-				return "", fmt.Errorf("couldn't parse image name: repository name must be canonical")
+				return "", reference.ErrNameNotCanonical
 			},
 			want:    "example.com/controller:v1.0.0",
 			wantErr: false,
@@ -250,18 +251,23 @@ func TestIsCanonicalError(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "canonical error with 'repository name must be canonical'",
-			err:  fmt.Errorf("repository name must be canonical"),
+			name: "ErrNameNotCanonical returns true",
+			err:  reference.ErrNameNotCanonical,
 			want: true,
 		},
 		{
-			name: "canonical error with 'couldn't parse image name'",
-			err:  fmt.Errorf("couldn't parse image name: invalid format"),
+			name: "wrapped ErrNameNotCanonical returns true",
+			err:  fmt.Errorf("parse error: %w", reference.ErrNameNotCanonical),
 			want: true,
 		},
 		{
 			name: "other error returns false",
 			err:  fmt.Errorf("test"),
+			want: false,
+		},
+		{
+			name: "couldn't parse image name error returns false",
+			err:  fmt.Errorf("couldn't parse image name: invalid format"),
 			want: false,
 		},
 		{

--- a/scripts/ci-install-mdbook.sh
+++ b/scripts/ci-install-mdbook.sh
@@ -30,5 +30,5 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 # Install mdbook and dependencies
 cargo install mdbook --version "$VERSION" --root "$OUTPUT_PATH"
-cargo install mdbook-fs-summary --root "$OUTPUT_PATH"
-cargo install mdbook-toc --root "$OUTPUT_PATH"
+cargo install mdbook-fs-summary --version "=0.2.0" --root "$OUTPUT_PATH"
+cargo install mdbook-toc --version "=0.14.2" --root "$OUTPUT_PATH"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
We have a use-case where CAPI operator doesn't work in air-gapped environments because it doesn't allow non-canonical images references like `example/image:v0.0.1` only `example.com/image:v0.0.1` is allowed and this done on the `clusterctl` level. This PR fixes the issue by skipping all image processing in case of non-canonical image assuming that this is for advanced users and they know what they are doing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
