### PR TITLE
helm: Expose deployment spec for all provider types

### DIFF
--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -28,9 +28,12 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $addonVersion $.Values.secretName $.Values.configSecret.name $addon.manager (($addon).configSecret).name }}
+{{- if or $addonVersion $.Values.secretName $.Values.configSecret.name $addon.manager $addon.deployment (($addon).configSecret).name }}
 spec:
 {{- end}}
+{{- if $addon.deployment }}
+  deployment: {{ toYaml $addon.deployment | nindent 4 }}
+{{- end }}
 {{- if $addon.manager }}
   manager:
   {{- if $addon.manager.metrics }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -28,9 +28,12 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $bootstrapVersion $.Values.configSecret.name $bootstrap.manager (($bootstrap).configSecret).name }}
+{{- if or $bootstrapVersion $.Values.configSecret.name $bootstrap.manager $bootstrap.deployment (($bootstrap).configSecret).name }}
 spec:
 {{- end}}
+{{- if $bootstrap.deployment }}
+  deployment: {{ toYaml $bootstrap.deployment | nindent 4 }}
+{{- end }}
 {{- if $bootstrap.manager }}
   manager:
   {{- if $bootstrap.manager.featureGates }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $controlPlaneVersion $.Values.configSecret.name $controlPlane.manager (($controlPlane).configSecret).name }}
+{{- if or $controlPlaneVersion $.Values.configSecret.name $controlPlane.manager $controlPlane.deployment (($controlPlane).configSecret).name }}
 spec:
 {{- end}}
 {{- if $controlPlaneVersion }}
   version: {{ $controlPlaneVersion }}
+{{- end }}
+{{- if $controlPlane.deployment }}
+  deployment: {{ toYaml $controlPlane.deployment | nindent 4 }}
 {{- end }}
 {{- if $controlPlane.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $coreVersion $.Values.configSecret.name $core.manager (($core).configSecret).name }}
+{{- if or $coreVersion $.Values.configSecret.name $core.manager $core.deployment (($core).configSecret).name }}
 spec:
 {{- end}}
 {{- if $coreVersion }}
   version: {{ $coreVersion }}
+{{- end }}
+{{- if $core.deployment }}
+  deployment: {{ toYaml $core.deployment | nindent 4 }}
 {{- end }}
 {{- if $core.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $infrastructureVersion $.Values.configSecret.name $infra.manager $.Values.additionalDeployments (($infra).configSecret).name }}
+{{- if or $infrastructureVersion $.Values.configSecret.name $infra.manager $infra.deployment $.Values.additionalDeployments (($infra).configSecret).name }}
 spec:
 {{- end }}
 {{- if $infrastructureVersion }}
   version: {{ $infrastructureVersion }}
+{{- end }}
+{{- if $infra.deployment }}
+  deployment: {{ toYaml $infra.deployment | nindent 4 }}
 {{- end }}
 {{- if $infra.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $ipamVersion $.Values.configSecret.name $ipam.manager $.Values.additionalDeployments (($ipam).configSecret).name }}
+{{- if or $ipamVersion $.Values.configSecret.name $ipam.manager $ipam.deployment $.Values.additionalDeployments (($ipam).configSecret).name }}
 spec:
 {{- end }}
 {{- if $ipamVersion }}
   version: {{ $ipamVersion }}
+{{- end }}
+{{- if $ipam.deployment }}
+  deployment: {{ toYaml $ipam.deployment | nindent 4 }}
 {{- end }}
 {{- if $ipam.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -6,6 +6,14 @@ core: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -17,6 +25,14 @@ bootstrap: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -29,6 +45,14 @@ controlPlane: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -40,6 +64,14 @@ infrastructure: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -51,6 +83,14 @@ addon: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     metrics:
 #       insecureDiagnostics: true
@@ -60,6 +100,14 @@ ipam: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true


### PR DESCRIPTION
This change exposes the deployment spec configuration in the Helm chart for all provider types (Core, Bootstrap, ControlPlane, Infrastructure, Addon, IPAM).

The provider CRDs already support these fields - this exposes them through the chart values.

Supported fields: replicas, nodeSelector, tolerations, affinity, containers, serviceAccountName, imagePullSecrets