### PR TITLE
:book: Fix broken links in documentation

### DIFF
--- a/docs/book/src/00_introduction.md
+++ b/docs/book/src/00_introduction.md
@@ -14,8 +14,8 @@ This operator leverages a declarative API and extends the capabilities of the `c
 
 ## Getting started
 
-* [Quick Start](./01_user/02_quick-start.md)
-* [Concepts](./01_user/01_concepts.md)
-* [Developer guide](./04_developer/02_guide.md)
-* [Contributing](./05_reference/04_contributing.md)
+* [Quick Start](user/quick-start.md)
+* [Concepts](user/concepts.md)
+* [Developer guide](developer/guide.md)
+* [Contributing](reference/contributing.md)
 

--- a/docs/book/src/02_installation/02_plugin-installation.md
+++ b/docs/book/src/02_installation/02_plugin-installation.md
@@ -1,3 +1,3 @@
 # Plugin installation
 
-Please refer to [plugin installation](../03_topics/03_plugin/01_installation.md) section.
+Please refer to [plugin installation](../topics/plugin/installation.md) section.

--- a/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
+++ b/docs/book/src/03_topics/02_configuration/01_air-gapped-environtment.md
@@ -80,7 +80,7 @@ Example layout for a `kubeadm` provider may look like:
 - `control-plane-components.yaml`
 - `bootstrap-components.yaml`
 
-See the [plugin docs](../03_plugin/03_publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.
+See the [plugin docs](../plugin/publish_subcommand.md) for more information on how to properly build and publish the OCI artifacts to the air-gapped registry.
 
 To fetch provider components which are stored as an OCI artifact, you can configure `fetchConfig.oci` field to pull them directly from an OCI registry:
 

--- a/docs/book/src/03_topics/02_configuration/03_examples-of-api-usage.md
+++ b/docs/book/src/03_topics/02_configuration/03_examples-of-api-usage.md
@@ -106,7 +106,7 @@ spec:
 
 5. As an admin, I would like to use the default fetch configurations by simply specifying the expected Cluster API provider names such as `aws`, `vsphere`, `azure`, `kubeadm`, `talos`, or `cluster-api` instead of having to explicitly specify the fetch configuration. In the example below, since we are using 'vsphere' as the name of the InfrastructureProvider the operator will fetch it's configuration from `url: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases` by default.
 
-See more examples in the [air-gapped environment section](./01_air-gapped-environtment.md)
+See more examples in the [air-gapped environment section](air-gapped-environtment.md)
 
 ```yaml
 ---

--- a/docs/book/src/04_developer/01_version_migration/00.md
+++ b/docs/book/src/04_developer/01_version_migration/00.md
@@ -2,4 +2,4 @@
 
 This section provides an overview of relevant changes between versions of Cluster API Operator and their direct successors.
 
-- [v1alpha1 to v1alpha2](./01_v1alpha1-to-v1alpha2.md)
+- [v1alpha1 to v1alpha2](v1alpha1-to-v1alpha2.md)

--- a/docs/book/src/04_developer/03_profiling.md
+++ b/docs/book/src/04_developer/03_profiling.md
@@ -11,7 +11,7 @@ profilerAddress: ":6060"
 contentionProfiling: true
 ```
 
-Install with these custom values using [Helm chart installation methods](../02_installation/04_helm-chart-installation.md)
+Install with these custom values using [Helm chart installation methods](../installation/helm-chart-installation.md)
 
 ### Enabling Port-Forwarding
 

--- a/docs/book/src/05_reference/00.md
+++ b/docs/book/src/05_reference/00.md
@@ -1,8 +1,8 @@
 # Reference
 
-- [API reference](./01_api_reference.md)
-- [Glossary](./02_glossary.md)
-- [Code of Conduct](./03_code-of-conduct.md)
-- [Contributing](./04_contributing.md)
-- [CI Jobs](./05_ci-jobs.md)
-- [Providers](./06_providers.md)
+- [API reference](api_reference.md)
+- [Glossary](glossary.md)
+- [Code of Conduct](code-of-conduct.md)
+- [Contributing](contributing.md)
+- [CI Jobs](ci-jobs.md)
+- [Providers](providers.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
Some links in the documentation are broken due to including leading numbers that should be stripped.

**Which issue(s) this PR fixes** :
Fixes #982
