### PR TITLE
✨ Helm: Expose deployment spec for all provider types

### DIFF
--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -28,9 +28,12 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $addonVersion $.Values.secretName $.Values.configSecret.name $addon.manager (($addon).configSecret).name }}
+{{- if or $addonVersion $.Values.secretName $.Values.configSecret.name $addon.manager $addon.deployment (($addon).configSecret).name }}
 spec:
 {{- end}}
+{{- if $addon.deployment }}
+  deployment: {{ toYaml $addon.deployment | nindent 4 }}
+{{- end }}
 {{- if $addon.manager }}
   manager:
   {{- if $addon.manager.metrics }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -28,9 +28,12 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $bootstrapVersion $.Values.configSecret.name $bootstrap.manager (($bootstrap).configSecret).name }}
+{{- if or $bootstrapVersion $.Values.configSecret.name $bootstrap.manager $bootstrap.deployment (($bootstrap).configSecret).name }}
 spec:
 {{- end}}
+{{- if $bootstrap.deployment }}
+  deployment: {{ toYaml $bootstrap.deployment | nindent 4 }}
+{{- end }}
 {{- if $bootstrap.manager }}
   manager:
   {{- if $bootstrap.manager.featureGates }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $controlPlaneVersion $.Values.configSecret.name $controlPlane.manager (($controlPlane).configSecret).name }}
+{{- if or $controlPlaneVersion $.Values.configSecret.name $controlPlane.manager $controlPlane.deployment (($controlPlane).configSecret).name }}
 spec:
 {{- end}}
 {{- if $controlPlaneVersion }}
   version: {{ $controlPlaneVersion }}
+{{- end }}
+{{- if $controlPlane.deployment }}
+  deployment: {{ toYaml $controlPlane.deployment | nindent 4 }}
 {{- end }}
 {{- if $controlPlane.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $coreVersion $.Values.configSecret.name $core.manager (($core).configSecret).name }}
+{{- if or $coreVersion $.Values.configSecret.name $core.manager $core.deployment (($core).configSecret).name }}
 spec:
 {{- end}}
 {{- if $coreVersion }}
   version: {{ $coreVersion }}
+{{- end }}
+{{- if $core.deployment }}
+  deployment: {{ toYaml $core.deployment | nindent 4 }}
 {{- end }}
 {{- if $core.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $infrastructureVersion $.Values.configSecret.name $infra.manager $.Values.additionalDeployments (($infra).configSecret).name }}
+{{- if or $infrastructureVersion $.Values.configSecret.name $infra.manager $infra.deployment $.Values.additionalDeployments (($infra).configSecret).name }}
 spec:
 {{- end }}
 {{- if $infrastructureVersion }}
   version: {{ $infrastructureVersion }}
+{{- end }}
+{{- if $infra.deployment }}
+  deployment: {{ toYaml $infra.deployment | nindent 4 }}
 {{- end }}
 {{- if $infra.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -28,11 +28,14 @@ metadata:
     "helm.sh/hook-weight": "2"
     {{- end }}
     "argocd.argoproj.io/sync-wave": "2"
-{{- if or $ipamVersion $.Values.configSecret.name $ipam.manager $.Values.additionalDeployments (($ipam).configSecret).name }}
+{{- if or $ipamVersion $.Values.configSecret.name $ipam.manager $ipam.deployment $.Values.additionalDeployments (($ipam).configSecret).name }}
 spec:
 {{- end }}
 {{- if $ipamVersion }}
   version: {{ $ipamVersion }}
+{{- end }}
+{{- if $ipam.deployment }}
+  deployment: {{ toYaml $ipam.deployment | nindent 4 }}
 {{- end }}
 {{- if $ipam.manager }}
   manager:

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -6,6 +6,14 @@ core: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -17,6 +25,14 @@ bootstrap: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -29,6 +45,14 @@ controlPlane: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -40,6 +64,14 @@ infrastructure: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true
@@ -51,6 +83,14 @@ addon: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     metrics:
 #       insecureDiagnostics: true
@@ -60,6 +100,14 @@ ipam: {}
 #   namespace: ""         # Optional
 #   version: ""           # Optional
 #   createNamespace: true # Optional
+#   deployment:           # Optional
+#     replicas: 1
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     containers: []
+#     serviceAccountName: ""
+#     imagePullSecrets: []
 #   manager:              # Optional
 #     featureGates:
 #       ClusterTopology: true

--- a/test/e2e/helm_test.go
+++ b/test/e2e/helm_test.go
@@ -422,6 +422,39 @@ var _ = Describe("Create a proper set of manifests when using helm charts", func
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manifests).To(Equal(string(expectedManifests)))
 	})
+	It("should deploy all providers with deployment spec", func() {
+		manifests, err := helmChart.Run(map[string]string{
+			"configSecret.name":                                         "test-secret-name",
+			"configSecret.namespace":                                    "test-secret-namespace",
+			"core.cluster-api.version":                                  "v1.7.7",
+			"core.cluster-api.deployment.replicas":                      "2",
+			"core.cluster-api.deployment.nodeSelector.tier":             "control-plane",
+			"bootstrap.kubeadm.version":                                 "v1.7.7",
+			"bootstrap.kubeadm.deployment.replicas":                     "2",
+			"bootstrap.kubeadm.deployment.tolerations[0].key":           "node-role",
+			"bootstrap.kubeadm.deployment.tolerations[0].operator":      "Exists",
+			"bootstrap.kubeadm.deployment.tolerations[0].effect":        "NoSchedule",
+			"controlPlane.kubeadm.version":                              "v1.7.7",
+			"controlPlane.kubeadm.deployment.replicas":                  "2",
+			"controlPlane.kubeadm.deployment.serviceAccountName":        "custom-cp-sa",
+			"infrastructure.docker.version":                             "v1.7.7",
+			"infrastructure.docker.deployment.replicas":                 "3",
+			"infrastructure.docker.deployment.imagePullSecrets[0].name": "my-registry-secret",
+			"ipam.in-cluster.version":                                   "v1.0.0",
+			"ipam.in-cluster.deployment.replicas":                       "1",
+			"ipam.in-cluster.deployment.nodeSelector.disktype":          "ssd",
+			"addon.helm.version":                                        "v0.2.6",
+			"addon.helm.deployment.replicas":                            "1",
+			"addon.helm.deployment.serviceAccountName":                  "addon-sa",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).ToNot(BeEmpty())
+
+		expectedManifests, err := os.ReadFile(filepath.Join(customManifestsFolder, "all-providers-deployment-spec.yaml"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifests).To(Equal(string(expectedManifests)))
+	})
+
 	It("should deploy kubeadm control plane with manager specified", func() {
 		manifests, err := helmChart.Run(map[string]string{
 			"core.cluster-api.enabled":                                  "true",

--- a/test/e2e/resources/all-providers-deployment-spec.yaml
+++ b/test/e2e/resources/all-providers-deployment-spec.yaml
@@ -1,0 +1,180 @@
+---
+# Source: cluster-api-operator/templates/addon.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: helm-addon-system
+---
+# Source: cluster-api-operator/templates/bootstrap.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: kubeadm-bootstrap-system
+---
+# Source: cluster-api-operator/templates/control-plane.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: kubeadm-control-plane-system
+---
+# Source: cluster-api-operator/templates/core.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: capi-system
+---
+# Source: cluster-api-operator/templates/infra.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: docker-infrastructure-system
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "1"
+    "argocd.argoproj.io/sync-wave": "1"
+  name: in-cluster-ipam-system
+---
+# Source: cluster-api-operator/templates/addon.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: AddonProvider
+metadata:
+  name: helm
+  namespace: helm-addon-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  deployment: 
+    replicas: 1
+    serviceAccountName: addon-sa
+  version: v0.2.6
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/bootstrap.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: kubeadm-bootstrap-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  deployment: 
+    replicas: 2
+    tolerations:
+    - effect: NoSchedule
+      key: node-role
+      operator: Exists
+  version: v1.7.7
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/control-plane.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: kubeadm-control-plane-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  version: v1.7.7
+  deployment: 
+    replicas: 2
+    serviceAccountName: custom-cp-sa
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/core.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  version: v1.7.7
+  deployment: 
+    nodeSelector:
+      tier: control-plane
+    replicas: 2
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/ipam.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: in-cluster
+  namespace: in-cluster-ipam-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  version: v1.0.0
+  deployment: 
+    nodeSelector:
+      disktype: ssd
+    replicas: 1
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace
+---
+# Source: cluster-api-operator/templates/infra.yaml
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: docker
+  namespace: docker-infrastructure-system
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "2"
+    "argocd.argoproj.io/sync-wave": "2"
+spec:
+  version: v1.7.7
+  deployment: 
+    imagePullSecrets:
+    - name: my-registry-secret
+    replicas: 3
+  configSecret:
+    name: test-secret-name
+    namespace: test-secret-namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
This change exposes the deployment spec configuration in the Helm chart for all provider types (Core, Bootstrap, ControlPlane, Infrastructure, Addon, IPAM).

The provider CRDs already support these fields - this exposes them through the chart values.

Supported fields: replicas, nodeSelector, tolerations, affinity, containers, serviceAccountName, imagePullSecrets

**Which issue(s) this PR fixes** :
Fixes #916 
Fixes #955 
