### PR TITLE
✨ feat: make feature gates additive instead of replacing defaults

### DIFF
--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -280,9 +280,16 @@ func customizeManagerContainer(mSpec *operatorv1.ManagerSpec, c *corev1.Containe
 	}
 
 	if len(mSpec.FeatureGates) > 0 {
-		fgValue := []string{}
+		// Start with existing feature gates from the manifest (defaults from upstream)
+		mergedGates := parseFeatureGates(c.Args)
 
+		// Merge user-specified feature gates (user values override defaults)
 		for fg, val := range mSpec.FeatureGates {
+			mergedGates[fg] = val
+		}
+
+		fgValue := []string{}
+		for fg, val := range mergedGates {
 			fgValue = append(fgValue, fg+"="+bool2Str[val])
 		}
 
@@ -336,6 +343,31 @@ func customizeContainer(cSpec operatorv1.ContainerSpec, d *appsv1.Deployment) er
 	}
 
 	return fmt.Errorf("cannot find container %q in deployment %q", cSpec.Name, d.Name)
+}
+
+// parseFeatureGates parses existing --feature-gates argument and returns a map of feature gates.
+// This allows user-specified feature gates to be merged with defaults instead of replacing them entirely.
+func parseFeatureGates(args []string) map[string]bool {
+	gates := make(map[string]bool)
+
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "--feature-gates=") {
+			continue
+		}
+
+		value := strings.TrimPrefix(arg, "--feature-gates=")
+
+		for _, gate := range strings.Split(value, ",") {
+			parts := strings.SplitN(gate, "=", 2)
+			if len(parts) == 2 {
+				gates[parts[0]] = parts[1] == operatorv1.TrueValue
+			}
+		}
+
+		break
+	}
+
+	return gates
 }
 
 // setArg set container arguments.

--- a/internal/controller/component_customizer_test.go
+++ b/internal/controller/component_customizer_test.go
@@ -780,3 +780,110 @@ func TestCustomizeMultipleDeployment(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFeatureGates(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected map[string]bool
+	}{
+		{
+			name:     "no feature gates",
+			args:     []string{"--webhook-port=2345"},
+			expected: map[string]bool{},
+		},
+		{
+			name:     "single feature gate",
+			args:     []string{"--feature-gates=MachinePool=true"},
+			expected: map[string]bool{"MachinePool": true},
+		},
+		{
+			name:     "multiple feature gates",
+			args:     []string{"--feature-gates=MachinePool=true,ClusterTopology=false,RuntimeSDK=true"},
+			expected: map[string]bool{"MachinePool": true, "ClusterTopology": false, "RuntimeSDK": true},
+		},
+		{
+			name:     "feature gates among other args",
+			args:     []string{"--webhook-port=2345", "--feature-gates=MachinePool=true,ClusterTopology=false", "--v=5"},
+			expected: map[string]bool{"MachinePool": true, "ClusterTopology": false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseFeatureGates(tt.args)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseFeatureGates() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAdditiveFeatureGates(t *testing.T) {
+	deplWithExistingGates := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manager",
+			Namespace: metav1.NamespaceSystem,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "manager",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "manager",
+							Image: "registry.k8s.io/a-manager:1.6.2",
+							Args: []string{
+								"--webhook-port=2345",
+								"--feature-gates=MachinePool=true,MachineSetPreflightChecks=true,PriorityQueue=false",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	managerSpec := &operatorv1.ManagerSpec{
+		FeatureGates: map[string]bool{
+			"ClusterTopology":           true,
+			"MachineSetPreflightChecks": false,
+		},
+	}
+
+	container := findManagerContainer(&deplWithExistingGates.Spec)
+	if container == nil {
+		t.Fatal("expected container to be found")
+	}
+
+	if err := customizeManagerContainer(managerSpec, container); err != nil {
+		t.Fatalf("customizeManagerContainer failed: %v", err)
+	}
+
+	featureGatesArg := ""
+
+	for _, arg := range container.Args {
+		if len(arg) > 16 && arg[:16] == "--feature-gates=" {
+			featureGatesArg = arg[16:]
+			break
+		}
+	}
+
+	if featureGatesArg == "" {
+		t.Fatal("expected --feature-gates arg to be present")
+	}
+
+	actualGates := parseFeatureGates([]string{"--feature-gates=" + featureGatesArg})
+	expectedGates := map[string]bool{
+		"MachinePool":               true,
+		"ClusterTopology":           true,
+		"MachineSetPreflightChecks": false,
+		"PriorityQueue":             false,
+	}
+
+	if !reflect.DeepEqual(actualGates, expectedGates) {
+		t.Errorf("Feature gates not merged correctly.\nGot: %v\nWant: %v", actualGates, expectedGates)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This change makes user specified feature gates merge with existing defaults from the manifest instead of replacing them entirely.

Previously, specifying featureGates would remove all default feature gates from the upstream manifest. Now it preserves existing gates and only overrides the ones explicitly specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
