### PR TITLE
🐛 Set insecure-diagnostics Arg only when true

### DIFF
--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -248,7 +248,9 @@ func customizeManagerContainer(mSpec *operatorv1.ManagerSpec, c *corev1.Containe
 		c.Args = setArgs(c.Args, "--diagnostics-address", mSpec.Metrics.DiagnosticsAddress)
 	}
 
-	c.Args = setArgs(c.Args, "--insecure-diagnostics", strconv.FormatBool(mSpec.Metrics.InsecureDiagnostics))
+	if mSpec.Metrics.InsecureDiagnostics {
+		c.Args = setArgs(c.Args, "--insecure-diagnostics", strconv.FormatBool(mSpec.Metrics.InsecureDiagnostics))
+	}
 
 	// webhooks
 	if mSpec.Webhook.Host != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

The manager flag `insecure-diagnostics` defaults to `false` but CAPO (https://github.com/oracle/cluster-api-provider-oci) does not use `AddManagerOptions` from cluster-api/util/flags to configure the manager causing a failure to start when `--insecure-diagnostics` is unexpectedly passed. Omitting this Arg when false will allow CAPO (and any other providers that skip this step) to boot while retaining the ability to enable this on other providers that configure the manager with `AddManagerOptions`

**Which issue(s) this PR fixes**:
Fixes #