### PR TITLE
:bug: fix components ownerReference for GenericProvider implementations

### DIFF
--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -67,7 +67,7 @@ func customizeObjectsFn(provider operatorv1.GenericProvider) func(objs []unstruc
 
 				o.SetOwnerReferences(util.EnsureOwnerRef(ownerReferences,
 					metav1.OwnerReference{
-						APIVersion: operatorv1.GroupVersion.String(),
+						APIVersion: provider.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 						Kind:       provider.GetObjectKind().GroupVersionKind().Kind,
 						Name:       provider.GetName(),
 						UID:        provider.GetUID(),


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This is a small change to use the `GenericProvider` implementation GroupVersion instead of the hardcoded `operator.cluster.x-k8s.io/v1alpha2`. This change has no effect on cluster-api-operator itself, but allows external wrappers to see their owner reference set correctly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/rancher/turtles/issues/2167
