### PR TITLE
:sparkles: feat: adds support for custom ca.crt

### DIFF
--- a/cmd/plugin/cmd/preload.go
+++ b/cmd/plugin/cmd/preload.go
@@ -282,7 +282,7 @@ func fetchProviders(ctx context.Context, cl client.Client, providerList genericP
 
 	for _, provider := range providerList.GetItems() {
 		if provider.GetSpec().FetchConfig != nil && provider.GetSpec().FetchConfig.OCI != "" {
-			cm, err := providercontroller.OCIConfigMap(ctx, provider, ociAuthentication())
+			cm, err := providercontroller.OCIConfigMap(ctx, provider, ociAuthentication(), []byte(""))
 			if err != nil {
 				return configMaps, err
 			}
@@ -337,7 +337,7 @@ func templateConfigMap(ctx context.Context, providerType clusterctlv1.ProviderTy
 	provider.SetSpec(spec)
 
 	if spec.Version != "" {
-		return providercontroller.OCIConfigMap(ctx, provider, ociAuthentication())
+		return providercontroller.OCIConfigMap(ctx, provider, ociAuthentication(), []byte(""))
 	}
 
 	// User didn't set the version, try to get repository default.
@@ -362,7 +362,7 @@ func templateConfigMap(ctx context.Context, providerType clusterctlv1.ProviderTy
 
 	provider.SetSpec(spec)
 
-	return providercontroller.OCIConfigMap(ctx, provider, ociAuthentication())
+	return providercontroller.OCIConfigMap(ctx, provider, ociAuthentication(), []byte(""))
 }
 
 func providerConfigMap(ctx context.Context, provider operatorv1.GenericProvider) (*corev1.ConfigMap, error) {

--- a/internal/controller/manifests_downloader.go
+++ b/internal/controller/manifests_downloader.go
@@ -101,8 +101,10 @@ func (p *PhaseReconciler) DownloadManifests(ctx context.Context) (*Result, error
 	// Fetch the provider metadata and components yaml files from the provided repository GitHub/GitLab or OCI source
 	if p.provider.GetSpec().FetchConfig != nil && p.provider.GetSpec().FetchConfig.OCI != "" {
 		log.Info("Downloading manifests from OCI source", "oci", p.provider.GetSpec().FetchConfig.OCI)
+		caCertString, _ := p.configClient.Variables().Get(OCICACert)
+		caCert := []byte(caCertString)
 
-		configMap, err = OCIConfigMap(ctx, p.provider, OCIAuthentication(p.configClient.Variables()))
+		configMap, err = OCIConfigMap(ctx, p.provider, OCIAuthentication(p.configClient.Variables()), caCert)
 		if err != nil {
 			return &Result{}, wrapPhaseError(err, operatorv1.ComponentsFetchErrorReason, operatorv1.ProviderInstalledCondition)
 		}
@@ -266,8 +268,8 @@ func decompressData(compressedData []byte) (data []byte, err error) {
 }
 
 // OCIConfigMap templates config from the OCI source.
-func OCIConfigMap(ctx context.Context, provider operatorv1.GenericProvider, auth *auth.Credential) (*corev1.ConfigMap, error) {
-	store, err := FetchOCI(ctx, provider, auth)
+func OCIConfigMap(ctx context.Context, provider operatorv1.GenericProvider, auth *auth.Credential, caCert []byte) (*corev1.ConfigMap, error) {
+	store, err := FetchOCI(ctx, provider, auth, caCert)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/oci_source.go
+++ b/internal/controller/oci_source.go
@@ -18,9 +18,14 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
+	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
@@ -38,6 +43,8 @@ const (
 	OCIPasswordKey     = "OCI_PASSWORD"
 	OCIAccessTokenKey  = "OCI_ACCESS_TOKEN"
 	OCIRefreshTokenKey = "OCI_REFRESH_TOKEN" // #nosec G101
+
+	OCICACert = "ca.crt"
 
 	metadataFile     = "metadata.yaml"
 	fullMetadataFile = "%s-%s-%s-metadata.yaml"
@@ -195,6 +202,9 @@ func (m mapStore) Tag(ctx context.Context, desc ocispec.Descriptor, reference st
 }
 
 var _ oras.Target = &mapStore{}
+var transportPoolCache = &transportPool{
+	cache: map[string]*http.Transport{},
+}
 
 // parseOCISource accepts an OCI URL and the provider version. It returns the image name,
 // the image version (if not set on the OCI URL, the provider version is used) and whether
@@ -213,8 +223,57 @@ func parseOCISource(url string, version string) (string, string, bool) {
 	return url, version, plainHTTP
 }
 
+// newRetryClient creates a new HTTP client with retry policy, optionally wrapping a custom transport.
+func newRetryClient(base http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: retry.NewTransport(base),
+	}
+}
+
+type transportPool struct {
+	cache map[string]*http.Transport
+	lock  sync.Mutex
+}
+
+func (t *transportPool) GetTransportForCACert(caCert []byte) (*http.Transport, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.cache == nil {
+		t.cache = map[string]*http.Transport{}
+	}
+	sum := fmt.Sprintf("%x", sha256.Sum256(caCert))
+	if transport, ok := t.cache[sum]; ok {
+		return transport, nil
+	}
+	transport, err := t.createNewTransport(caCert)
+	if err != nil {
+		return nil, err
+	}
+	t.cache[sum] = transport
+	return transport, nil
+}
+
+func (t *transportPool) createNewTransport(caCert []byte) (*http.Transport, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to append custom CA certificate")
+	}
+
+	transport := http.DefaultTransport.(*http.Transport)
+	transport = transport.Clone()
+	transport.TLSClientConfig = &tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}
+	return transport, nil
+}
+
 // CopyOCIStore collects artifacts from the provider OCI url and creates a map of file contents.
-func CopyOCIStore(ctx context.Context, url string, version string, store *mapStore, credential *auth.Credential) error {
+func CopyOCIStore(ctx context.Context, url string, version string, store *mapStore, credential *auth.Credential, caCert []byte) error {
 	url, version, plainHTTP := parseOCISource(url, version)
 
 	repo, err := remote.NewRepository(url)
@@ -222,9 +281,21 @@ func CopyOCIStore(ctx context.Context, url string, version string, store *mapSto
 		return fmt.Errorf("invalid registry URL specified: %w", err)
 	}
 
+	baseClient := retry.DefaultClient
+
+	if len(caCert) > 0 {
+		transport, transportErr := transportPoolCache.GetTransportForCACert(caCert)
+		if transportErr != nil {
+			return fmt.Errorf("failed to create HTTP client with custom CA: %w", transportErr)
+		}
+		baseClient = newRetryClient(transport)
+	}
+
+	repo.Client = baseClient
+
 	if credential != nil {
 		repo.Client = &auth.Client{
-			Client:     retry.DefaultClient,
+			Client:     baseClient,
 			Cache:      auth.NewCache(),
 			Credential: auth.StaticCredential(repo.Reference.Registry, *credential),
 		}
@@ -267,7 +338,7 @@ func OCIAuthentication(c configclient.VariablesClient) *auth.Credential {
 }
 
 // FetchOCI copies the content of OCI.
-func FetchOCI(ctx context.Context, provider operatorv1.GenericProvider, cred *auth.Credential) (*mapStore, error) {
+func FetchOCI(ctx context.Context, provider operatorv1.GenericProvider, cred *auth.Credential, caCert []byte) (*mapStore, error) {
 	log := log.FromContext(ctx)
 
 	log.V(2).Info("Custom fetch configuration OCI url was provided")
@@ -275,7 +346,7 @@ func FetchOCI(ctx context.Context, provider operatorv1.GenericProvider, cred *au
 	// Prepare components store for the provider type.
 	store := NewMapStore(provider)
 
-	err := CopyOCIStore(ctx, provider.GetSpec().FetchConfig.OCI, provider.GetSpec().Version, &store, cred)
+	err := CopyOCIStore(ctx, provider.GetSpec().FetchConfig.OCI, provider.GetSpec().Version, &store, cred, caCert)
 	if err != nil {
 		return nil, fmt.Errorf("unable to copy OCI content: %w", err)
 	}

--- a/internal/controller/oci_source_test.go
+++ b/internal/controller/oci_source_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
+
+// generateTestCA creates a self-signed CA certificate and returns the PEM-encoded cert bytes.
+func generateTestCA(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create CA certificate: %v", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func Test_transportPool_createNewTransport(t *testing.T) {
+	caPEM := generateTestCA(t)
+	pool := &transportPool{}
+
+	t.Run("valid CA cert", func(t *testing.T) {
+		g := NewWithT(t)
+
+		transport, err := pool.createNewTransport(caPEM)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(transport).ToNot(BeNil())
+
+		g.Expect(transport.TLSClientConfig).ToNot(BeNil())
+		g.Expect(transport.TLSClientConfig.RootCAs).ToNot(BeNil())
+		g.Expect(transport.TLSClientConfig.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+	})
+
+	t.Run("invalid PEM data", func(t *testing.T) {
+		g := NewWithT(t)
+
+		transport, err := pool.createNewTransport([]byte("not-a-valid-pem"))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to append custom CA certificate"))
+		g.Expect(transport).To(BeNil())
+	})
+}
+
+func Test_transportPool_GetTransportForCACert(t *testing.T) {
+	caPEM := generateTestCA(t)
+
+	t.Run("returns cached transport for same CA", func(t *testing.T) {
+		g := NewWithT(t)
+		pool := &transportPool{
+			cache: map[string]*http.Transport{},
+		}
+
+		first, err := pool.GetTransportForCACert(caPEM)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(first).ToNot(BeNil())
+
+		second, err := pool.GetTransportForCACert(caPEM)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(second).To(BeIdenticalTo(first))
+	})
+
+	t.Run("invalid pem returns error", func(t *testing.T) {
+		g := NewWithT(t)
+		pool := &transportPool{
+			cache: map[string]*http.Transport{},
+		}
+
+		transport, err := pool.GetTransportForCACert([]byte("not-a-valid-pem"))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to append custom CA certificate"))
+		g.Expect(transport).To(BeNil())
+	})
+}
+
+func Test_newRetryClient(t *testing.T) {
+	t.Run("nil base transport uses retry default", func(t *testing.T) {
+		g := NewWithT(t)
+
+		client := newRetryClient(nil)
+		g.Expect(client).ToNot(BeNil())
+		g.Expect(client.Transport).ToNot(BeNil())
+
+		retryTransport, ok := client.Transport.(*retry.Transport)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(retryTransport.Base).To(BeNil())
+	})
+
+	t.Run("custom base transport is wrapped in retry", func(t *testing.T) {
+		g := NewWithT(t)
+
+		caPEM := generateTestCA(t)
+		base, err := (&transportPool{}).createNewTransport(caPEM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		client := newRetryClient(base)
+		g.Expect(client).ToNot(BeNil())
+
+		retryTransport, ok := client.Transport.(*retry.Transport)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(retryTransport.Base).To(Equal(base))
+	})
+
+	t.Run("does not mutate retry.DefaultClient", func(t *testing.T) {
+		g := NewWithT(t)
+
+		originalTransport := retry.DefaultClient.Transport
+
+		caPEM := generateTestCA(t)
+		base, err := (&transportPool{}).createNewTransport(caPEM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_ = newRetryClient(base)
+
+		g.Expect(retry.DefaultClient.Transport).To(BeIdenticalTo(originalTransport))
+	})
+}
+
+func Test_CopyOCIStore_clientSetup(t *testing.T) {
+	caPEM := generateTestCA(t)
+
+	t.Run("with caCert and credentials, auth client wraps custom transport", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// We can't fully test CopyOCIStore without a real registry, but we can
+		// verify the client setup by checking the repo's client after construction.
+		// Use the helper functions directly to verify the composition.
+		base, err := (&transportPool{}).createNewTransport(caPEM)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		baseClient := newRetryClient(base)
+
+		cred := &auth.Credential{Username: "user", Password: "pass"}
+		authClient := &auth.Client{
+			Client:     baseClient,
+			Cache:      auth.NewCache(),
+			Credential: auth.StaticCredential("registry.example.com", *cred),
+		}
+
+		// The auth client's inner client should be our custom baseClient
+		g.Expect(authClient.Client).To(BeIdenticalTo(baseClient))
+
+		// The baseClient's transport should wrap our custom CA transport
+		retryTransport, ok := baseClient.Transport.(*retry.Transport)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(retryTransport.Base).To(Equal(base))
+	})
+
+	t.Run("without caCert, default transport is used", func(t *testing.T) {
+		g := NewWithT(t)
+
+		baseClient := newRetryClient(nil)
+
+		retryTransport, ok := baseClient.Transport.(*retry.Transport)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(retryTransport.Base).To(BeNil())
+	})
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds a field to the configuration secret called `ca.crt` this can be helpful if users are storing provider manifests in internal OCI registries.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
