### PR TITLE
🐛  Allow setting empty tolerations on provider deployments

### DIFF
--- a/api/v1alpha2/provider_types.go
+++ b/api/v1alpha2/provider_types.go
@@ -216,7 +216,7 @@ type DeploymentSpec struct {
 
 	// If specified, the pod's tolerations.
 	// +optional
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	Tolerations *[]corev1.Toleration `json:"tolerations,omitempty"`
 
 	// If specified, the pod's scheduling constraints
 	// +optional

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -613,9 +613,13 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
-		*out = make([]corev1.Toleration, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = new([]corev1.Toleration)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]corev1.Toleration, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
 		}
 	}
 	if in.Affinity != nil {

--- a/internal/controller/cache_roundtrip_test.go
+++ b/internal/controller/cache_roundtrip_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -400,4 +401,48 @@ func TestProviderHash_ChangesWithSpec(t *testing.T) {
 	sum2 := fmt.Sprintf("%x", hash2.Sum(nil))
 
 	g.Expect(sum1).ToNot(Equal(sum2), "hashes must differ when spec changes")
+}
+
+func TestProviderHash_ChangesWhenEmptyTolerationsAreExplicitlySet(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := fake.NewClientBuilder().WithScheme(cacheTestScheme()).Build()
+	providerWithoutTolerations := &operatorv1.CoreProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-api",
+			Namespace: "default",
+		},
+		Spec: operatorv1.CoreProviderSpec{
+			ProviderSpec: operatorv1.ProviderSpec{
+				Deployment: &operatorv1.DeploymentSpec{
+					Replicas: ptr.To(1),
+				},
+			},
+		},
+	}
+
+	providerWithEmptyTolerations := &operatorv1.CoreProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-api",
+			Namespace: "default",
+		},
+		Spec: operatorv1.CoreProviderSpec{
+			ProviderSpec: operatorv1.ProviderSpec{
+				Deployment: &operatorv1.DeploymentSpec{
+					Replicas:    ptr.To(1),
+					Tolerations: ptr.To([]corev1.Toleration{}),
+				},
+			},
+		},
+	}
+
+	hash1 := sha256.New()
+	g.Expect(providerHash(context.Background(), cl, hash1, providerWithoutTolerations)).To(Succeed())
+	sum1 := fmt.Sprintf("%x", hash1.Sum(nil))
+
+	hash2 := sha256.New()
+	g.Expect(providerHash(context.Background(), cl, hash2, providerWithEmptyTolerations)).To(Succeed())
+	sum2 := fmt.Sprintf("%x", hash2.Sum(nil))
+
+	g.Expect(sum1).ToNot(Equal(sum2), "explicit empty tolerations should change the provider hash")
 }

--- a/internal/controller/component_customizer.go
+++ b/internal/controller/component_customizer.go
@@ -159,7 +159,7 @@ func customizeDeploymentSpec(dSpec operatorv1.DeploymentSpec, d *appsv1.Deployme
 	}
 
 	if dSpec.Tolerations != nil {
-		d.Spec.Template.Spec.Tolerations = dSpec.Tolerations
+		d.Spec.Template.Spec.Tolerations = *dSpec.Tolerations
 	}
 
 	if dSpec.ServiceAccountName != "" {

--- a/internal/controller/component_customizer_test.go
+++ b/internal/controller/component_customizer_test.go
@@ -153,12 +153,12 @@ func TestCustomizeDeployment(t *testing.T) {
 		{
 			name: "only tolerations modified",
 			inputDeploymentSpec: &operatorv1.DeploymentSpec{
-				Tolerations: []corev1.Toleration{
+				Tolerations: ptr.To([]corev1.Toleration{
 					{
 						Key:    "node-role.kubernetes.io/master",
 						Effect: corev1.TaintEffectNoSchedule,
 					},
-				},
+				}),
 			},
 			expectedDeploymentSpec: func(inputDS *appsv1.DeploymentSpec) (*appsv1.DeploymentSpec, bool) {
 				expectedDS := &appsv1.DeploymentSpec{
@@ -345,12 +345,12 @@ func TestCustomizeDeployment(t *testing.T) {
 			inputDeploymentSpec: &operatorv1.DeploymentSpec{
 				Replicas:     ptr.To(3),
 				NodeSelector: map[string]string{"a": "b"},
-				Tolerations: []corev1.Toleration{
+				Tolerations: ptr.To([]corev1.Toleration{
 					{
 						Key:    "node-role.kubernetes.io/master",
 						Effect: corev1.TaintEffectNoSchedule,
 					},
-				},
+				}),
 				Affinity: &corev1.Affinity{
 					NodeAffinity: &corev1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -657,6 +657,31 @@ func TestCustomizeDeployment(t *testing.T) {
 				t.Error(cmp.Diff(ds, deployment.Spec))
 			}
 		})
+	}
+}
+
+func TestCustomizeDeployment_ClearsTolerationsWhenExplicitlyEmpty(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Tolerations: []corev1.Toleration{{
+						Key:    "node-role.kubernetes.io/control-plane",
+						Effect: corev1.TaintEffectNoSchedule,
+					}},
+				},
+			},
+		},
+	}
+
+	if err := customizeDeploymentSpec(operatorv1.DeploymentSpec{
+		Tolerations: ptr.To([]corev1.Toleration{}),
+	}, deployment); err != nil {
+		t.Fatalf("customizeDeploymentSpec() error = %v", err)
+	}
+
+	if len(deployment.Spec.Template.Spec.Tolerations) != 0 {
+		t.Fatalf("expected tolerations to be cleared, got %#v", deployment.Spec.Template.Spec.Tolerations)
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Changes `DeploymentSpec.Tolerations` from `[]corev1.Toleration` to `*[]corev1.Toleration` so the three states — unset (nil), explicitly empty (&[]), and non-empty — are distinguishable.

Previously, setting `spec.deployment.tolerations: []` produced the same json.Marshal output as not setting tolerations at all (null vs [] both marshal identically for a bare slice). This meant the provider cache hash did not change, stale cached manifests were reused, and upstream tolerations (e.g. `node-role.kubernetes.io/control-plane`) remained on the provider Deployment.

With the pointer, json.Marshal emits `"tolerations":null` vs `"tolerations":[]`, producing different hashes and triggering a proper re-reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1018
