### PR TITLE
🐛  helm: preserve whitespace in metrics template values

### DIFF
--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -39,10 +39,10 @@ spec:
   {{- if $addon.manager.metrics }}
     metrics:
     {{- if $addon.manager.metrics.insecureDiagnostics }}
-      insecureDiagnostics: {{- $addon.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{ $addon.manager.metrics.insecureDiagnostics }}
     {{- end }}
     {{- if $addon.manager.metrics.diagnosticsAddress }}
-      diagnosticsAddress: {{- $addon.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{ $addon.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -45,10 +45,10 @@ spec:
   {{- if $bootstrap.manager.metrics }}
     metrics:
     {{- if $bootstrap.manager.metrics.insecureDiagnostics }}
-      insecureDiagnostics: {{- $bootstrap.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{ $bootstrap.manager.metrics.insecureDiagnostics }}
     {{- end }}
     {{- if $bootstrap.manager.metrics.diagnosticsAddress }}
-      diagnosticsAddress: {{- $bootstrap.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{ $bootstrap.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -48,10 +48,10 @@ spec:
   {{- if $controlPlane.manager.metrics }}
     metrics:
     {{- if $controlPlane.manager.metrics.insecureDiagnostics }}
-      insecureDiagnostics: {{- $controlPlane.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{ $controlPlane.manager.metrics.insecureDiagnostics }}
     {{- end }}
     {{- if $controlPlane.manager.metrics.diagnosticsAddress }}
-      diagnosticsAddress: {{- $controlPlane.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{ $controlPlane.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -48,10 +48,10 @@ spec:
   {{- if $core.manager.metrics }}
     metrics:
     {{- if $core.manager.metrics.insecureDiagnostics }}
-      insecureDiagnostics: {{- $core.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{ $core.manager.metrics.insecureDiagnostics }}
     {{- end }}
     {{- if $core.manager.metrics.diagnosticsAddress }}
-      diagnosticsAddress: {{- $core.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{ $core.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -48,10 +48,10 @@ spec:
   {{- if $infra.manager.metrics }}
     metrics:
     {{- if $infra.manager.metrics.insecureDiagnostics }}
-      insecureDiagnostics: {{- $infra.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{ $infra.manager.metrics.insecureDiagnostics }}
     {{- end }}
     {{- if $infra.manager.metrics.diagnosticsAddress }}
-      diagnosticsAddress: {{- $infra.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{ $infra.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -74,6 +74,9 @@ spec:
 {{- if $infra.manifestPatches }}
   manifestPatches: {{- toYaml $infra.manifestPatches | nindent 4 }}
 {{- end }} {{/* if $infra.manifestPatches */}}
+{{- if $infra.patches }}
+  patches: {{ toYaml $infra.patches | nindent 4 }}
+{{- end }} {{/* if $infra.patches */}}
 {{- if $infra.fetchConfig }}
   fetchConfig: {{ toYaml $infra.fetchConfig | nindent 4 }}
 {{- end }}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -48,10 +48,10 @@ spec:
   {{- if $ipam.manager.metrics }}
     metrics:
     {{- if $ipam.manager.metrics.insecureDiagnostics }}
-      insecureDiagnostics: {{- $ipam.manager.metrics.insecureDiagnostics }}
+      insecureDiagnostics: {{ $ipam.manager.metrics.insecureDiagnostics }}
     {{- end }}
     {{- if $ipam.manager.metrics.diagnosticsAddress }}
-      diagnosticsAddress: {{- $ipam.manager.metrics.diagnosticsAddress }}
+      diagnosticsAddress: {{ $ipam.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The metrics field templates used {{- which strips leading whitespace, causing invalid YAML output like 'diagnosticsAddress:localhost:8443' instead of 'diagnosticsAddress: localhost:8443'.

This resulted in admission webhook rejections with error: 'cannot unmarshal string into Go struct field ManagerSpec.spec.manager.metrics of type v1alpha2.ControllerMetrics'

Remove the dash from {{- to {{ for insecureDiagnostics and diagnosticsAddress fields across all provider templates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1038 
