### PR TITLE
✨ helm: Expose manager verbosity parameter for all provider types

### DIFF
--- a/hack/charts/cluster-api-operator/templates/addon.yaml
+++ b/hack/charts/cluster-api-operator/templates/addon.yaml
@@ -45,6 +45,7 @@ spec:
       diagnosticsAddress: {{- $addon.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
+    verbosity: {{ default 1 $addon.manager.verbosity }}
 {{- end }}
 {{- if $addonVersion }}
   version: {{ $addonVersion }}

--- a/hack/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/hack/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -51,6 +51,7 @@ spec:
       diagnosticsAddress: {{- $bootstrap.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
+    verbosity: {{ default 1 $bootstrap.manager.verbosity }}
 {{- end }}
 {{- if $bootstrapVersion }}
   version: {{ $bootstrapVersion }}

--- a/hack/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/hack/charts/cluster-api-operator/templates/control-plane.yaml
@@ -54,6 +54,7 @@ spec:
       diagnosticsAddress: {{- $controlPlane.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
+    verbosity: {{ default 1 $controlPlane.manager.verbosity }}
 {{- end }}
 {{- if (default (($controlPlane).configSecret).name (($.Values).configSecret).name) }}
 {{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $controlPlane) | nindent 2 }}

--- a/hack/charts/cluster-api-operator/templates/core.yaml
+++ b/hack/charts/cluster-api-operator/templates/core.yaml
@@ -54,6 +54,7 @@ spec:
       diagnosticsAddress: {{- $core.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
+    verbosity: {{ default 1 $core.manager.verbosity }}
 {{- end }}
 {{- if (default (($core).configSecret).name (($.Values).configSecret).name) }}
 {{- include "capi-operator.configSecret" (dict "ROOT" $ "ARGUMENT" $core) | nindent 2 }}

--- a/hack/charts/cluster-api-operator/templates/infra.yaml
+++ b/hack/charts/cluster-api-operator/templates/infra.yaml
@@ -54,6 +54,7 @@ spec:
       diagnosticsAddress: {{- $infra.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
+    verbosity: {{ default 1 $infra.manager.verbosity }}
 {{- end }}
 {{- if and (kindIs "map" $.Values.fetchConfig) (hasKey $.Values.fetchConfig $infrastructureName) }}
 {{- range $key, $value := $.Values.fetchConfig }}

--- a/hack/charts/cluster-api-operator/templates/ipam.yaml
+++ b/hack/charts/cluster-api-operator/templates/ipam.yaml
@@ -54,6 +54,7 @@ spec:
       diagnosticsAddress: {{- $ipam.manager.metrics.diagnosticsAddress }}
     {{- end }}
   {{- end }}
+    verbosity: {{ default 1 $ipam.manager.verbosity }}
 {{- end }}
 {{- if and (kindIs "map" $.Values.fetchConfig) (hasKey $.Values.fetchConfig $ipamName) }}
 {{- range $key, $value := $.Values.fetchConfig }}

--- a/hack/charts/cluster-api-operator/values.yaml
+++ b/hack/charts/cluster-api-operator/values.yaml
@@ -20,6 +20,7 @@ core: {}
 #     metrics:
 #       insecureDiagnostics: true
 #       diagnosticsAddress: localhost:8080
+#     verbosity: 1
 bootstrap: {}
 # kubeadm: {}             # Name, required
 #   namespace: ""         # Optional
@@ -40,6 +41,7 @@ bootstrap: {}
 #     metrics:
 #       insecureDiagnostics: true
 #       diagnosticsAddress: localhost:8080
+#     verbosity: 1
 controlPlane: {}
 # kubeadm: {}             # Name, required
 #   namespace: ""         # Optional
@@ -59,6 +61,7 @@ controlPlane: {}
 #     metrics:
 #       insecureDiagnostics: true
 #       diagnosticsAddress: localhost:8080
+#     verbosity: 1
 infrastructure: {}
 # docker: {}              # Name, required
 #   namespace: ""         # Optional
@@ -78,6 +81,7 @@ infrastructure: {}
 #     metrics:
 #       insecureDiagnostics: true
 #       diagnosticsAddress: localhost:8080
+#     verbosity: 1
 addon: {}
 # helm: {}                # Name, required
 #   namespace: ""         # Optional
@@ -95,6 +99,7 @@ addon: {}
 #     metrics:
 #       insecureDiagnostics: true
 #       diagnosticsAddress: localhost:8080
+#     verbosity: 1
 ipam: {}
 # in-cluster: {}          # Name, required
 #   namespace: ""         # Optional
@@ -114,6 +119,7 @@ ipam: {}
 #     metrics:
 #       insecureDiagnostics: true
 #       diagnosticsAddress: localhost:8080
+#     verbosity: 1
 fetchConfig: {}
 # ---
 # Common configuration secret options


### PR DESCRIPTION
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The provider CRDs support a `manager.verbosity` field but it is not exposed in the Helm chart. The PR adds `verbosity` to the `manager` spec block in all the provider templates, defaulting to `1` when not set (existing behavior).